### PR TITLE
feat: resolve aliased types in complex types

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,5 @@
 profile = default
-version = 0.26.1
+version = 0.26.2
 
 # preserve begin/end where it appears (instead of converting to parenthesis, the default)
 exp-grouping = preserve

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "ocaml.sandbox": {
-    "kind": "esy",
-    "root": "${workspaceFolder:aws-reason2}"
+    "kind": "opam",
+    "switch": "${workspaceFolder:aws-smsdk}"
   },
   "ocaml.trace.server": "verbose",
   "ocaml.useOcamlEnv": false

--- a/awssdklib/Auth.ml
+++ b/awssdklib/Auth.ml
@@ -12,8 +12,7 @@ let fromEnvironment () =
     { accessKeyId; secretAccessKey; sessionToken }
   with _ ->
     raise
-      (AuthError "Could not resolve AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY from environment"
-      [@explicit_arity])
+      (AuthError "Could not resolve AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY from environment")
 
 let load_ini_file_res file_path =
   try Ok (Ini.load_ini file_path)

--- a/awssdklib/Json.ml
+++ b/awssdklib/Json.ml
@@ -14,8 +14,7 @@ module SerializeHelpers = struct
   let assoc_to_yojson (x : (string * t option) list) : t =
     `Assoc
       (List.filter_map
-         (fun (name, value) ->
-           match value with ((Some value) [@explicit_arity]) -> Some (name, value) | None -> None)
+         (fun (name, value) -> match value with Some value -> Some (name, value) | None -> None)
          x)
 
   let blob_to_yojson (x : Bytes.t) : t = `String (Base64.encode_exn (Bytes.to_string x))

--- a/bin/SmithyHelpers.ml
+++ b/bin/SmithyHelpers.ml
@@ -4,12 +4,12 @@ open Parselib.Ast
 let printProtocol (traits : Trait.t list option) =
   traits |> Option.value ~default:[]
   |> List.find_map ~f:(function
-       | Trait.AwsProtocolAwsJson1_0Trait -> Some "AWS JSON 1.0" [@explicit_arity]
-       | Trait.AwsProtocolAwsJson1_1Trait -> Some "AWS JSON 1.1" [@explicit_arity]
-       | Trait.AwsProtocolRestJson1Trait -> Some "AWS REST JSON 1" [@explicit_arity]
-       | Trait.AwsProtocolRestXmlTrait -> Some "AWS REST XML" [@explicit_arity]
-       | Trait.AwsProtocolAwsQueryTrait -> Some "AWS Query" [@explicit_arity]
-       | Trait.AwsProtocolEc2QueryTrait -> Some "EC2 Query" [@explicit_arity]
+       | Trait.AwsProtocolAwsJson1_0Trait -> Some "AWS JSON 1.0"
+       | Trait.AwsProtocolAwsJson1_1Trait -> Some "AWS JSON 1.1"
+       | Trait.AwsProtocolRestJson1Trait -> Some "AWS REST JSON 1"
+       | Trait.AwsProtocolRestXmlTrait -> Some "AWS REST XML"
+       | Trait.AwsProtocolAwsQueryTrait -> Some "AWS Query"
+       | Trait.AwsProtocolEc2QueryTrait -> Some "EC2 Query"
        | _ -> None)
   |> Option.value ~default:"<unknown>"
 
@@ -26,20 +26,18 @@ let printServiceTrait traits =
 let printOperations operations =
   operations
   |> List.filter_map ~f:(function
-       | Shape.
-           { name; descriptor = ((Shape.OperationShape { input; output; _ }) [@explicit_arity]) } ->
+       | Shape.{ name; descriptor = Shape.OperationShape { input; output; _ } } ->
            Some
              (Printf.sprintf "operation %s = %s => %s" name
                 (Option.value input ~default:"()")
                 (Option.value output ~default:"void"))
-           [@explicit_arity]
        | _ -> None)
   |> List.iter ~f:(fun str -> Stdio.print_endline str)
 
 let printServiceDetails shapes =
   List.iter shapes ~f:(fun Shape.{ descriptor; _ } ->
       match descriptor with
-      | ((Shape.ServiceShape details) [@explicit_arity]) ->
+      | Shape.ServiceShape details ->
           Stdio.printf "Service: version=%s\n, protocol=%s, %s" details.version
             (printProtocol details.traits)
             (printServiceTrait details.traits)

--- a/bin/gen_operations.ml
+++ b/bin/gen_operations.ml
@@ -1,19 +1,19 @@
 open Parselib
 open Ast
 
-let generate ~name ~(service : Shape.serviceShapeDetails) ~operation_shapes ~structure_shapes oc =
+let generate ~name ~(service : Shape.serviceShapeDetails) ~operation_shapes ~structure_shapes ~alias_context oc =
   if
     Trait.hasTrait service.traits (function
       | Trait.AwsProtocolAwsJson1_1Trait -> true
       | Trait.AwsProtocolAwsJson1_0Trait -> true
       | _ -> false)
-  then Codegen.AwsProtocolJson.Operations.generate ~name ~operation_shapes oc
+  then Codegen.AwsProtocolJson.Operations.generate ~name ~operation_shapes ~alias_context oc
 
-let generate_mli ~name ~(service : Shape.serviceShapeDetails) ~operation_shapes ~structure_shapes
+let generate_mli ~name ~(service : Shape.serviceShapeDetails) ~operation_shapes ~structure_shapes ~alias_context
     ?(no_open = false) oc =
   if
     Trait.hasTrait service.traits (function
       | Trait.AwsProtocolAwsJson1_1Trait -> true
       | Trait.AwsProtocolAwsJson1_0Trait -> true
       | _ -> false)
-  then Codegen.AwsProtocolJson.Operations.generate_mli ~name ~operation_shapes ~no_open oc
+  then Codegen.AwsProtocolJson.Operations.generate_mli ~name ~operation_shapes ~alias_context ~no_open oc

--- a/examples/dynamodb_createTableAndWriteData.ml
+++ b/examples/dynamodb_createTableAndWriteData.ml
@@ -15,7 +15,7 @@ let _ =
               }
           in
           let context = Aws.Context.make ~sw ~config env () in
-          let ( let+ ) res map = Result.map map res in
+          let ( let+ ) res map = Result.bind res map in
 
           match
             let open Aws_SmSdk_Client_DynamoDB in
@@ -60,7 +60,7 @@ let _ =
                    ~item:[ ("pk", S "item1"); ("sk", S "item1") ]
                    ())
             in
-            ()
+            Ok ()
           with
           | Ok _ -> ()
           | Error (`HttpError e) ->

--- a/examples/sqs_ListQueues.ml
+++ b/examples/sqs_ListQueues.ml
@@ -29,6 +29,7 @@ let _ =
             end
           with
           | Ok _ -> ()
+          
           | Error (`HttpError e) ->
               Logs.err (fun m -> m "HTTP Error %a" Aws_SmSdk_Lib.Http.pp_http_failure e)
           | Error (`JsonParseError e) ->

--- a/library/ast/Dependencies.ml
+++ b/library/ast/Dependencies.ml
@@ -9,6 +9,7 @@ type shapeWithTarget = {
 }
 [@@deriving show, equal]
 
+(** Builtin Smithy shapes which are implied to be present in every context *)
 let smithyImplicitShapes =
   [
     { name = "smithy.api#Unit"; descriptor = UnitShape; targets = []; recursWith = None };
@@ -44,28 +45,27 @@ let smithyImplicitShapes =
     };
   ]
 
+(** resolve the target shape names referenced by the specified shape descriptor *)
 let getTargets descriptor =
   match descriptor with
-  | ((ListShape listShapeDetails) [@explicit_arity]) -> [ listShapeDetails.target ]
-  | ((OperationShape details) [@explicit_arity]) ->
+  | ListShape listShapeDetails -> [ listShapeDetails.target ]
+  | OperationShape details ->
       List.concat
         [
           Option.value (Option.map details.input ~f:(fun extracted -> [ extracted ])) ~default:[];
           Option.value (Option.map details.output ~f:(fun extracted -> [ extracted ])) ~default:[];
           Option.value (Option.map details.errors ~f:(fun extracted -> extracted)) ~default:[];
         ]
-  | ((StructureShape { members; _ }) [@explicit_arity]) ->
-      List.map members ~f:(fun member -> member.target)
-  | ((ServiceShape { operations; _ }) [@explicit_arity]) -> Option.value operations ~default:[]
-  | ((MapShape { mapKey; mapValue; _ }) [@explicit_arity]) -> [ mapKey.target; mapValue.target ]
+  | StructureShape { members; _ } -> List.map members ~f:(fun member -> member.target)
+  | ServiceShape { operations; _ } -> Option.value operations ~default:[]
+  | MapShape { mapKey; mapValue; _ } -> [ mapKey.target; mapValue.target ]
   | BlobShape _ | BooleanShape _ | IntegerShape _ | StringShape _ | ResourceShape | TimestampShape _
   | BigIntegerShape _ | BigDecimalShape _ ->
       []
-  | ((UnionShape { members; _ }) [@explicit_arity]) ->
-      List.map members ~f:(fun member -> member.target)
+  | UnionShape { members; _ } -> List.map members ~f:(fun member -> member.target)
   | LongShape _ -> []
   | DoubleShape _ -> []
-  | ((SetShape { target; _ }) [@explicit_arity]) -> [ target ]
+  | SetShape { target; _ } -> [ target ]
   | EnumShape { members; _ } -> List.map members ~f:(fun member -> member.target)
   | FloatShape _ -> []
   | UnitShape -> []

--- a/library/ast/Shape.ml
+++ b/library/ast/Shape.ml
@@ -65,23 +65,23 @@ type shapeDescriptor =
 
 let getShapeTraits descriptor =
   match descriptor with
-  | ((ListShape { traits; _ }) [@explicit_arity])
-  | ((StructureShape { traits; _ }) [@explicit_arity])
-  | ((OperationShape { traits; _ }) [@explicit_arity])
-  | ((UnionShape { traits; _ }) [@explicit_arity])
-  | ((BlobShape { traits }) [@explicit_arity])
-  | ((ServiceShape { traits; _ }) [@explicit_arity])
-  | ((BooleanShape { traits }) [@explicit_arity])
-  | ((IntegerShape { traits }) [@explicit_arity])
-  | ((StringShape { traits }) [@explicit_arity])
-  | ((MapShape { traits; _ }) [@explicit_arity])
-  | ((TimestampShape { traits }) [@explicit_arity])
-  | ((LongShape { traits }) [@explicit_arity])
-  | ((FloatShape { traits }) [@explicit_arity])
-  | ((DoubleShape { traits }) [@explicit_arity])
-  | ((BigIntegerShape { traits }) [@explicit_arity])
-  | ((BigDecimalShape { traits }) [@explicit_arity])
-  | ((SetShape { traits; _ }) [@explicit_arity]) ->
+  | ListShape { traits; _ }
+  | StructureShape { traits; _ }
+  | OperationShape { traits; _ }
+  | UnionShape { traits; _ }
+  | BlobShape { traits }
+  | ServiceShape { traits; _ }
+  | BooleanShape { traits }
+  | IntegerShape { traits }
+  | StringShape { traits }
+  | MapShape { traits; _ }
+  | TimestampShape { traits }
+  | LongShape { traits }
+  | FloatShape { traits }
+  | DoubleShape { traits }
+  | BigIntegerShape { traits }
+  | BigDecimalShape { traits }
+  | SetShape { traits; _ } ->
       traits
   | EnumShape { traits; _ } -> traits
   | UnitShape -> None

--- a/library/codegen/SafeNames.ml
+++ b/library/codegen/SafeNames.ml
@@ -133,7 +133,6 @@ let safeVariantName name =
   |> String.substr_replace_all ~pattern:"*" ~with_:"Star"
   |> String.split ~on:'_'
   |> List.filter_map ~f:(fun x ->
-         (if String.length x > 0 then Some (camelCase x) [@explicit_arity] [@ns.braces] else None)
-         [@ns.ternary])
+         (if String.length x > 0 then Some (camelCase x) else None) [@ns.ternary])
   |> String.concat ~sep:"_")
   [@ns.braces]

--- a/library/codegen/Types.ml
+++ b/library/codegen/Types.ml
@@ -2,6 +2,12 @@ open Base
 open SafeNames
 open Ast
 
+type t = (string, string) Hashtbl.t
+
+let resolve ctx target =
+  Fmt.pr "Resolving %s\n" target;
+  Hashtbl.find ctx target |> Option.value_or_thunk ~default:(fun () -> safeTypeName target)
+
 let type_name ~is_exception_type name =
   Fmt.str "%s%s" (safeTypeName name) (if is_exception_type then "_exception_details" else "")
 
@@ -26,9 +32,7 @@ let generateDoc traits =
   (let docStrs =
      traits |> Option.value ~default:[]
      |> List.filter_map ~f:(fun trait ->
-            match trait with
-            | ((Trait.DocumentationTrait str) [@explicit_arity]) -> Some str [@explicit_arity]
-            | _ -> None)
+            match trait with Trait.DocumentationTrait str -> Some str | _ -> None)
    in
    let docs = String.concat docStrs ~sep:"" in
    if not (String.is_empty docs) then ("@ocaml.doc(\"" ^ escapeString docs) ^ "\")" else "")
@@ -49,7 +53,7 @@ let generateStringShape (details : Shape.primitiveShapeDetails) =
      details.traits >>= List.find ~f:Trait.isEnumTrait
    in
    match enumTrait with
-   | ((Some ((EnumTrait pairs) [@explicit_arity])) [@explicit_arity]) ->
+   | Some (EnumTrait pairs) ->
        "\n"
        ^ (List.map pairs ~f:(fun { name; value } ->
               "  | " ^ safeConstructorName (Option.value name ~default:value))
@@ -57,15 +61,14 @@ let generateStringShape (details : Shape.primitiveShapeDetails) =
    | _ -> "string")
   [@ns.braces]
 
-let generateMember (m : Shape.member) ?(genDoc = false) () =
+let generateMember ctx (m : Shape.member) ?(genDoc = false) () =
   (let safeName = safeMemberName m.name in
    let required = Trait.hasTrait m.traits Trait.isRequiredTrait in
+   let resolved_target = m.target |> resolve ctx in
    let valueType =
-     (if required then safeTypeName m.target else safeTypeName m.target ^ " option") [@ns.ternary]
+     (if required then resolved_target else resolved_target ^ " option") [@ns.ternary]
    in
-   let doc =
-     match genDoc with true -> Some (generateDoc m.traits) [@explicit_arity] | false -> None
-   in
+   let doc = match genDoc with true -> Some (generateDoc m.traits) | false -> None in
    generateField safeName valueType ?doc)
   [@ns.braces]
 
@@ -75,42 +78,46 @@ let indentString indent =
    String.concat_array is)
   [@ns.braces]
 
-let generateStructureShape (details : Shape.structureShapeDetails) ?(genDoc = false) () =
+let generateStructureShape ctx (details : Shape.structureShapeDetails) ?(genDoc = false) () =
   let is_error = Trait.hasTrait details.traits Trait.isErrorTrait in
   let record_type_definition =
     generateRecordTypeDefinition
-      (List.map details.members ~f:(fun member -> generateMember member ~genDoc ()))
+      (List.map details.members ~f:(fun member -> generateMember ctx member ~genDoc ()))
   in
   record_type_definition
 
-let generateUnionShape (details : Shape.structureShapeDetails) ?(genDoc = false) () =
+let generateUnionShape ctx (details : Shape.structureShapeDetails) ?(genDoc = false) () =
   let tConstructors =
     List.map details.members ~f:(fun member ->
-        (safeVariantName member.name ^ " of ") ^ safeTypeName member.target)
+        let resolved = member.target |> resolve ctx in
+
+        (safeVariantName member.name ^ " of ") ^ resolved)
   in
   let t = String.concat tConstructors ~sep:" | " in
   t
 
-let generateListShape target = safeTypeName target ^ " list"
+let generateListShape ctx target =
+  let resolved = target |> resolve ctx in
+  resolved ^ " list"
 
-let generateMapShape _ (mapValue : Shape.mapKeyValue) =
-  let valueType = safeTypeName mapValue.target in
+let generateMapShape ctx _ (mapValue : Shape.mapKeyValue) =
+  let valueType = mapValue.target |> resolve ctx in
   "(string * " ^ valueType ^ ") list"
 
 exception NoServiceTrait of string
 exception UnknownTimestampFormat of string
 
-let generateSetShape (details : Shape.setShapeDetails) = safeTypeName details.target ^ " list"
+let generateSetShape ctx (details : Shape.setShapeDetails) =
+  let valueType = details.target |> resolve ctx in
+  valueType ^ " list"
 
 let generateTimestampShape ({ traits } : Shape.timestampShapeDetails) =
   (let timestampFormat =
      Trait.findTrait (Option.value traits ~default:[]) Trait.isTimestampFormatTrait
    in
    match timestampFormat with
-   | ((Some ((TimestampFormatTrait "date-time") [@explicit_arity])) [@explicit_arity]) ->
-       {js|float|js}
-   | ((Some ((TimestampFormatTrait "epoch-seconds") [@explicit_arity])) [@explicit_arity]) ->
-       {js|float;|js}
+   | Some (TimestampFormatTrait "date-time") -> {js|float|js}
+   | Some (TimestampFormatTrait "epoch-seconds") -> {js|float;|js}
    | _ -> {js|float|js})
   [@ns.braces]
 
@@ -119,12 +126,13 @@ let generateEnumShape (details : Shape.enumShapeDetails) =
   |> List.map ~f:(fun ({ name; _ } : Shape.member) -> "| " ^ (name |> safeConstructorName))
   |> String.concat ~sep:"\n  "
 
-let generateTypeTarget descriptor ?(genDoc = false) () =
+(** Generate the type declaration for descriptor (minus the {%type =%}) *)
+let generateTypeTarget ctx descriptor ?(genDoc = false) () =
   let open Shape in
   match descriptor with
   | StringShape details -> generateStringShape details
-  | StructureShape details -> generateStructureShape details ~genDoc ()
-  | ListShape { target; _ } -> generateListShape target
+  | StructureShape details -> generateStructureShape ctx details ~genDoc ()
+  | ListShape { target; _ } -> generateListShape ctx target
   | IntegerShape _ -> generateIntegerShape ()
   | LongShape _ -> generateLongShape ()
   | DoubleShape _ -> generateDoubleShape ()
@@ -133,41 +141,67 @@ let generateTypeTarget descriptor ?(genDoc = false) () =
   | BlobShape _ -> generateBinaryShape ()
   | BigIntegerShape _ -> generateBigIntegerShape ()
   | BigDecimalShape _ -> generateBigDecimalShape ()
-  | MapShape details -> generateMapShape details.mapKey details.mapValue
+  | MapShape details -> generateMapShape ctx details.mapKey details.mapValue
   | ServiceShape _ -> ""
-  | UnionShape details -> generateUnionShape details ~genDoc ()
+  | UnionShape details -> generateUnionShape ctx details ~genDoc ()
   | TimestampShape details -> generateTimestampShape details
   | ResourceShape -> ""
   | OperationShape _ -> ""
   | UnitShape -> "unit"
-  | SetShape details -> generateSetShape details
+  | SetShape details -> generateSetShape ctx details
   | EnumShape details -> generateEnumShape details
 
 let getStructureShape =
   let open Shape in
   function StructureShape details -> Some details | _ -> None
 
-let generateTypeBlock ({ name; descriptor } : Shape.t) ?(genDoc = false) () =
-  let docs =
-    match genDoc with true -> generateDoc (Shape.getShapeTraits descriptor) | false -> ""
-  in
-  let result = generateTypeTarget descriptor ~genDoc:false () in
-  let is_exception_type =
-    match descriptor with
-    | StructureShape s when Trait.(hasTrait s.traits isErrorTrait) -> true
-    | _ -> false
-  in
-  let t = if String.equal result "" then "" else generateType name result ~is_exception_type in
-  docs ^ t
+let should_generate_type_block descriptor =
+  let open Shape in
+  match descriptor with
+  | UnitShape | ListShape _ | BlobShape _ | BooleanShape _ | IntegerShape _ | StringShape _
+  | BigIntegerShape _ | BigDecimalShape _ | MapShape _ | ResourceShape | TimestampShape _
+  | LongShape _ | FloatShape _ | DoubleShape _ | SetShape _ ->
+      false
+  | _ -> true
 
-let generateRecursiveTypeBlock (shapes : Shape.t list) ?(genDoc = false) () =
+let generate_type ctx ({ name; descriptor } : Shape.t) ?(genDoc = false) () =
+  if should_generate_type_block descriptor then begin
+    let docs =
+      match genDoc with true -> generateDoc (Shape.getShapeTraits descriptor) | false -> ""
+    in
+    let result = generateTypeTarget ctx descriptor ~genDoc:false () in
+    let is_exception_type =
+      match descriptor with
+      | StructureShape s when Trait.(hasTrait s.traits isErrorTrait) -> true
+      | _ -> false
+    in
+    let t = if String.equal result "" then "" else generateType name result ~is_exception_type in
+    Some (docs ^ t)
+  end
+  else None
+
+let generate_recursive_types ctx (shapes : Shape.t list) ?(genDoc = false) () =
   let shapeTypes =
-    List.map shapes ~f:(fun shape ->
-        (safeTypeName shape.name ^ " = ") ^ generateTypeTarget shape.descriptor ~genDoc ())
-  in
-  let shapeModules =
     shapes
-    |> List.filter_map ~f:(fun Shape.{ name; descriptor } -> match descriptor with _ -> None)
-    |> String.concat ~sep:"\n"
+    |> List.filter ~f:(fun shape -> should_generate_type_block Shape.(shape.descriptor))
+    |> List.map ~f:(fun (shape : Shape.t) ->
+           (safeTypeName shape.name ^ " = ") ^ generateTypeTarget ctx shape.descriptor ~genDoc ())
   in
-  "type " ^ String.concat shapeTypes ~sep:" and " ^ shapeModules
+
+  if List.length shapeTypes > 0 then Some ("type " ^ String.concat shapeTypes ~sep:" and ")
+  else None
+
+let create_alias_context shapes : t =
+  let tbl = Hashtbl.create ~growth_allowed:true ~size:(List.length shapes / 2) (module String) in
+  List.iter
+    ~f:(fun Ast.Shape.{ name; descriptor; _ } ->
+      match descriptor with
+      | UnitShape | ListShape _ | BlobShape _ | BooleanShape _ | IntegerShape _ | StringShape _
+      | BigIntegerShape _ | BigDecimalShape _ | MapShape _ | ResourceShape | TimestampShape _
+      | LongShape _ | FloatShape _ | DoubleShape _ | SetShape _ ->
+          let alias = generateTypeTarget tbl descriptor () in
+          Fmt.pr "Aliasing %s -> %s\n" name alias;
+          ignore (Hashtbl.add ~key:name ~data:alias tbl)
+      | _ -> ())
+    shapes;
+  tbl

--- a/library/parse/Json.ml
+++ b/library/parse/Json.ml
@@ -7,9 +7,7 @@ module Decode = struct
   let flatMap_result = Base.Result.bind
 
   let optionToResult opt errorString =
-    match opt with
-    | ((Some result) [@explicit_arity]) -> Ok result [@explicit_arity]
-    | None -> Error errorString [@explicit_arity]
+    match opt with Some result -> Ok result | None -> Error errorString
 
   type nonrec jsonTreeRef = { tree : t; path : string }
   type jsonObject = (string, t) List.Assoc.t
@@ -26,33 +24,31 @@ module Decode = struct
 
   let jsonParseErrorToString error =
     match error with
-    | ((SyntaxError error) [@explicit_arity]) -> {js|Syntax Error: |js} ^ error
-    | ((WrongType (path, expected)) [@explicit_arity]) ->
+    | SyntaxError error -> {js|Syntax Error: |js} ^ error
+    | WrongType (path, expected) ->
         (({js|Wrong Type Error: |js} ^ expected) ^ {js| was expected at path |js}) ^ path
-    | ((NoValueError path) [@explicit_arity]) -> {js|No Value Error: expected a value at |js} ^ path
+    | NoValueError path -> {js|No Value Error: expected a value at |js} ^ path
     | ((RecordParseError (path, suberror)) [@implicit_arity]) ->
         (({js|Record parse error: at path |js} ^ path) ^ {js| received record parse error - |js})
         ^ suberror
-    | ((CustomError error) [@explicit_arity]) -> {js|Other parse error: |js} ^ error
+    | CustomError error -> {js|Other parse error: |js} ^ error
 
   let parseJsonString jsonString rootParser =
     (let treeResult =
-       try Ok (Yojson.Basic.from_string jsonString) [@explicit_arity]
-       with ((Yojson.Json_error err) [@explicit_arity]) ->
-         Error (SyntaxError err [@explicit_arity]) [@explicit_arity]
+       try Ok (Yojson.Basic.from_string jsonString)
+       with Yojson.Json_error err -> Error (SyntaxError err)
      in
      let open Base.Result in
-     treeResult >>= fun [@u] tree -> rootParser (Ok { tree; path = "$" } [@explicit_arity]))
+     treeResult >>= fun [@u] tree -> rootParser (Ok { tree; path = "$" }))
     [@ns.braces]
 
   let parseJsonFile jsonFile rootParser =
     (let treeResult =
-       try Ok (Yojson.Basic.from_file jsonFile) [@explicit_arity]
-       with ((Yojson.Json_error err) [@explicit_arity]) ->
-         Error (SyntaxError err [@explicit_arity]) [@explicit_arity]
+       try Ok (Yojson.Basic.from_file jsonFile)
+       with Yojson.Json_error err -> Error (SyntaxError err)
      in
      let open Base.Result in
-     treeResult >>= fun [@u] tree -> rootParser (Ok { tree; path = "$" } [@explicit_arity]))
+     treeResult >>= fun [@u] tree -> rootParser (Ok { tree; path = "$" }))
     [@ns.braces]
 
   type nonrec 'a parser = (jsonTreeRef, jsonParseError) Result.t -> ('a, jsonParseError) Result.t
@@ -60,9 +56,7 @@ module Decode = struct
   let parseObject (x : jsonTreeResult) : (jsonObjectRef, jsonParseError) Result.t =
     let open Result in
     x >>= fun [@u] { tree; path } ->
-    match tree with
-    | `Assoc items -> Ok { object_ = items; path } [@explicit_arity]
-    | _ -> Error (NoValueError path [@explicit_arity]) [@explicit_arity]
+    match tree with `Assoc items -> Ok { object_ = items; path } | _ -> Error (NoValueError path)
 
   let parseRecord recordParser (recordObject : jsonTreeResult) =
     recordObject |> parseObject
@@ -70,37 +64,27 @@ module Decode = struct
            List.fold
              ~f:(fun records (key, value) ->
                Result.bind records ~f:(fun recordsValue ->
-                   let record =
-                     recordParser key
-                       (Ok { path = path ^ {|.|} ^ key; tree = value } [@explicit_arity])
-                   in
+                   let record = recordParser key (Ok { path = path ^ {|.|} ^ key; tree = value }) in
                    match record with
-                   | ((Ok recordValue) [@explicit_arity]) ->
-                       Ok (recordValue :: recordsValue) [@explicit_arity]
-                   | ((Error ((CustomError y) [@explicit_arity])) [@explicit_arity]) ->
-                       Error (RecordParseError (path ^ "." ^ key, y) [@explicit_arity])
-                       [@explicit_arity]
-                   | ((Error x) [@explicit_arity]) -> Error x [@explicit_arity]))
-             ~init:(Ok [] [@explicit_arity]) object_)
+                   | Ok recordValue -> Ok (recordValue :: recordsValue)
+                   | Error (CustomError y) -> Error (RecordParseError (path ^ "." ^ key, y))
+                   | Error x -> Error x))
+             ~init:(Ok []) object_)
 
   let parseString x =
     Result.bind x ~f:(fun { tree; path } ->
-        match tree with
-        | `String str -> Ok str [@explicit_arity]
-        | _ -> Error (WrongType ("string", path) [@explicit_arity]) [@explicit_arity])
+        match tree with `String str -> Ok str | _ -> Error (WrongType ("string", path)))
 
   let parseNumber x =
     Result.bind x ~f:(fun [@u] { tree; path } ->
         match tree with
-        | `Int num -> Ok (Int.to_float num) [@explicit_arity]
-        | `Float num -> Ok num [@explicit_arity]
-        | _ -> Error (WrongType (path, "number") [@implicit_arity]) [@explicit_arity])
+        | `Int num -> Ok (Int.to_float num)
+        | `Float num -> Ok num
+        | _ -> Error (WrongType (path, "number")))
 
   let parseInteger x =
     Result.bind x ~f:(fun [@u] { tree; path } ->
-        match tree with
-        | `Int i -> Ok i [@explicit_arity]
-        | _ -> Error (WrongType (path, "integer") [@implicit_arity]) [@explicit_arity])
+        match tree with `Int i -> Ok i | _ -> Error (WrongType (path, "integer")))
 
   let parseArray itemParser arrayRef =
     let open Result in
@@ -111,15 +95,13 @@ module Decode = struct
           ~f:(fun i progress next ->
             progress >>= fun [@u] items ->
             let record =
-              itemParser
-                (Ok { path = (path ^ {js|.|js}) ^ Int.to_string i; tree = next } [@explicit_arity])
+              itemParser (Ok { path = (path ^ {js|.|js}) ^ Int.to_string i; tree = next })
             in
             match record with
-            | ((Ok recordValue) [@explicit_arity]) ->
-                Ok (Base.List.append items [ recordValue ]) [@explicit_arity]
-            | ((Error y) [@explicit_arity]) -> Error y [@explicit_arity])
-          ~init:(Ok [] [@explicit_arity])
-    | _ -> Error (WrongType (path, "array") [@implicit_arity]) [@explicit_arity]
+            | Ok recordValue -> Ok (Base.List.append items [ recordValue ])
+            | Error y -> Error y)
+          ~init:(Ok [])
+    | _ -> Error (WrongType (path, "array") [@implicit_arity])
 
   let raw (recordObject : (jsonTreeRef, jsonParseError) Result.t) =
     let open Result in
@@ -129,76 +111,57 @@ module Decode = struct
     let open Result in
     objectRef >>= fun [@u] { object_; path } ->
     match List.Assoc.find object_ ~equal:String.equal fieldName with
-    | ((Some fieldValue) [@explicit_arity]) ->
-        Ok { tree = fieldValue; path = (path ^ {js|.|js}) ^ fieldName } [@explicit_arity]
-    | None ->
-        Error (NoValueError ((path ^ {js|.|js}) ^ fieldName) [@explicit_arity]) [@explicit_arity]
+    | Some fieldValue -> Ok { tree = fieldValue; path = (path ^ {js|.|js}) ^ fieldName }
+    | None -> Error (NoValueError ((path ^ {js|.|js}) ^ fieldName))
 
   let optional (decodedResult : ('a, jsonParseError) Result.t) =
     match decodedResult with
-    | ((Ok value) [@explicit_arity]) -> Ok (Some value [@explicit_arity]) [@explicit_arity]
-    | ((Error error) [@explicit_arity]) -> (
-        match error with
-        | NoValueError _ -> Ok None [@explicit_arity]
-        | _ -> Error error [@explicit_arity])
+    | Ok value -> Ok (Some value)
+    | Error error -> ( match error with NoValueError _ -> Ok None | _ -> Error error)
 end
 
 module ResultHelpers = struct
   let map2 result1 result2 mapper =
     match (result1, result2) with
-    | ((Ok result1) [@explicit_arity]), ((Ok result2) [@explicit_arity]) ->
-        Ok (mapper result1 result2) [@explicit_arity]
-    | ((Error error1) [@explicit_arity]), _ -> Error error1 [@explicit_arity]
-    | _, ((Error error2) [@explicit_arity]) -> Error error2 [@explicit_arity]
+    | Ok result1, Ok result2 -> Ok (mapper result1 result2)
+    | Error error1, _ -> Error error1
+    | _, Error error2 -> Error error2
 
   let map3 result1 result2 result3 mapper =
     match (result1, result2, result3) with
-    | ( ((Ok result1) [@explicit_arity]),
-        ((Ok result2) [@explicit_arity]),
-        ((Ok result3) [@explicit_arity]) ) ->
-        Ok (mapper result1 result2 result3) [@explicit_arity]
-    | ((Error error1) [@explicit_arity]), _, _ -> Error error1 [@explicit_arity]
-    | _, ((Error error2) [@explicit_arity]), _ -> Error error2 [@explicit_arity]
-    | _, _, ((Error error3) [@explicit_arity]) -> Error error3 [@explicit_arity]
+    | Ok result1, Ok result2, Ok result3 -> Ok (mapper result1 result2 result3)
+    | Error error1, _, _ -> Error error1
+    | _, Error error2, _ -> Error error2
+    | _, _, Error error3 -> Error error3
 
   let map4 r1 r2 r3 r4 mapper =
     match (r1, r2, r3, r4) with
-    | ( ((Ok r1) [@explicit_arity]),
-        ((Ok r2) [@explicit_arity]),
-        ((Ok r3) [@explicit_arity]),
-        ((Ok r4) [@explicit_arity]) ) ->
-        Ok (mapper r1 r2 r3 r4) [@explicit_arity]
-    | ((Error e1) [@explicit_arity]), _, _, _ -> Error e1 [@explicit_arity]
-    | _, ((Error e2) [@explicit_arity]), _, _ -> Error e2 [@explicit_arity]
-    | _, _, ((Error e3) [@explicit_arity]), _ -> Error e3 [@explicit_arity]
-    | _, _, _, ((Error e4) [@explicit_arity]) -> Error e4 [@explicit_arity]
+    | Ok r1, Ok r2, Ok r3, Ok r4 -> Ok (mapper r1 r2 r3 r4)
+    | Error e1, _, _, _ -> Error e1
+    | _, Error e2, _, _ -> Error e2
+    | _, _, Error e3, _ -> Error e3
+    | _, _, _, Error e4 -> Error e4
 
   let map5 r1 r2 r3 r4 r5 mapper =
     match (r1, r2, r3, r4, r5) with
-    | ( ((Ok r1) [@explicit_arity]),
-        ((Ok r2) [@explicit_arity]),
-        ((Ok r3) [@explicit_arity]),
-        ((Ok r4) [@explicit_arity]),
-        ((Ok r5) [@explicit_arity]) ) ->
-        Ok (mapper r1 r2 r3 r4 r5) [@explicit_arity]
-    | ((Error e1) [@explicit_arity]), _, _, _, _ -> Error e1 [@explicit_arity]
-    | _, ((Error e2) [@explicit_arity]), _, _, _ -> Error e2 [@explicit_arity]
-    | _, _, ((Error e3) [@explicit_arity]), _, _ -> Error e3 [@explicit_arity]
-    | _, _, _, ((Error e4) [@explicit_arity]), _ -> Error e4 [@explicit_arity]
-    | _, _, _, _, ((Error e5) [@explicit_arity]) -> Error e5 [@explicit_arity]
+    | Ok r1, Ok r2, Ok r3, Ok r4, Ok r5 -> Ok (mapper r1 r2 r3 r4 r5)
+    | Error e1, _, _, _, _ -> Error e1
+    | _, Error e2, _, _, _ -> Error e2
+    | _, _, Error e3, _, _ -> Error e3
+    | _, _, _, Error e4, _ -> Error e4
+    | _, _, _, _, Error e5 -> Error e5
 
   let mapOptional
       (mapper : ('a, Decode.jsonParseError) Result.t -> ('b, Decode.jsonParseError) Result.t)
       (resultWithOption : ('a option, Decode.jsonParseError) Result.t) :
       ('b option, Decode.jsonParseError) Result.t =
     match[@ns.braces] resultWithOption with
-    | ((Ok optValue) [@explicit_arity]) -> (
+    | Ok optValue -> (
         match optValue with
-        | ((Some value) [@explicit_arity]) -> (
-            match mapper (Ok value [@explicit_arity]) with
-            | ((Ok result) [@explicit_arity]) ->
-                Ok (Some result [@explicit_arity]) [@explicit_arity]
-            | ((Error error) [@explicit_arity]) -> Error error [@explicit_arity])
-        | None -> Ok None [@explicit_arity])
-    | ((Error error) [@explicit_arity]) -> Error error [@explicit_arity]
+        | Some value -> (
+            match mapper (Ok value) with
+            | Ok result -> Ok (Some result)
+            | Error error -> Error error)
+        | None -> Ok None)
+    | Error error -> Error error
 end


### PR DESCRIPTION
Add type alias resolution to type generation to remove unnecessary alias intermediary types introduced by Smithy definitions.

e.g. `type put_item_request_list = put_item_request list` will now not be generated, with the right hand side of the expression used inline in record types and function prototypes.