### PR TITLE
feat: expose AWS request_id response metadata for JSON and Query protocols

### DIFF
--- a/codegen/AwsProtocolJson.ml
+++ b/codegen/AwsProtocolJson.ml
@@ -801,7 +801,7 @@ module Operations = struct
   let generate_request_handler ~name ~operation_name
       ~(operation_shape : Ast.Shape.operationShapeDetails) ~alias_context
       ~(namespace_resolver : Namespace_resolver.Namespace_resolver.t) () =
-    let shape_func_body =
+    let shape_func_body ~with_metadata =
       let input =
         operation_shape.input
         |> Option.value_map ~default:[%expr `Assoc ()] ~f:(fun input ->
@@ -817,7 +817,14 @@ module Operations = struct
         |> Option.value ~default:(Longident.Lident "base_unit_of_yojson")
       in
       let request_func_name =
-        B.pexp_ident (Location.mknoloc (make_lident ~names:[ Modules.protocolAwsJson; "request" ]))
+        B.pexp_ident
+          (Location.mknoloc
+             (make_lident
+                ~names:
+                  (let open Modules in
+                   [
+                     protocolAwsJson; (if with_metadata then "request_with_metadata" else "request");
+                   ])))
       in
       [%expr
         let input = [%e input] in
@@ -826,26 +833,30 @@ module Operations = struct
           ~error_deserializer]
     in
 
-    let shape_func =
-      Option.value_map operation_shape.input ~default:shape_func_body ~f:(fun input_name ->
+    let shape_func ~with_metadata =
+      Option.value_map operation_shape.input ~default:(shape_func_body ~with_metadata)
+        ~f:(fun input_name ->
           B.pexp_fun Nolabel None
             (B.ppat_constraint
                (B.ppat_var (Location.mknoloc "request"))
                (Types.resolve alias_context ~name:input_name ~namespace_resolver ()))
-            shape_func_body)
+            (shape_func_body ~with_metadata))
     in
-    [%stri let request = fun context -> [%e shape_func]]
+    [
+      [%stri let request = fun context -> [%e shape_func ~with_metadata:false]];
+      [%stri let request_with_metadata = fun context -> [%e shape_func ~with_metadata:true]];
+    ]
 
   let generate_operation_module ~name ~operation_name ~operation_shape ~dependencies ~alias_context
       ~(namespace_resolver : Namespace_resolver.Namespace_resolver.t) () =
     let module_name = SafeNames.safeConstructorName operation_name in
-    let request_handler =
+    let request_handlers =
       generate_request_handler ~name ~operation_name ~operation_shape ~alias_context
         ~namespace_resolver ()
     in
     let error_handler = generate_error_handler ~operation_shape ~namespace_resolver () in
     let error_to_string = generate_error_to_string ~operation_shape ~namespace_resolver () in
-    let module_items = [ error_to_string; error_handler; request_handler ] in
+    let module_items = error_to_string :: error_handler :: request_handlers in
     let module_expr = B.pmod_structure module_items in
     B.pstr_module (B.module_binding ~name:(Location.mknoloc (Some module_name)) ~expr:module_expr)
 
@@ -913,7 +924,12 @@ module Operations = struct
                 val request :
                   'http_type Smaws_Lib.Context.t ->
                   [%t input_type] ->
-                  ([%t output_type], [%t exception_type]) result]))
+                  ([%t output_type], [%t exception_type]) result
+
+                val request_with_metadata :
+                  'http_type Smaws_Lib.Context.t ->
+                  [%t input_type] ->
+                  ([%t output_type] Smaws_Lib.Response.t, [%t exception_type]) result]))
     |> Docs.attach_doc_to_signature_item ~loc ~doc_string
 
   let generate ~name ~operation_shapes ~alias_context

--- a/codegen/AwsProtocolJson.ml
+++ b/codegen/AwsProtocolJson.ml
@@ -929,7 +929,9 @@ module Operations = struct
                 val request_with_metadata :
                   'http_type Smaws_Lib.Context.t ->
                   [%t input_type] ->
-                  ([%t output_type] Smaws_Lib.Response.t, [%t exception_type]) result]))
+                  ( [%t output_type] Smaws_Lib.Response.t,
+                    [%t exception_type] * Smaws_Lib.Response.metadata )
+                  result]))
     |> Docs.attach_doc_to_signature_item ~loc ~doc_string
 
   let generate ~name ~operation_shapes ~alias_context

--- a/codegen/AwsProtocolQuery.ml
+++ b/codegen/AwsProtocolQuery.ml
@@ -1197,7 +1197,9 @@ module Operations = struct
                 val request_with_metadata :
                   'http_type Smaws_Lib.Context.t ->
                   [%t input_type] ->
-                  ([%t output_type] Smaws_Lib.Response.t, [%t exception_type]) result]))
+                  ( [%t output_type] Smaws_Lib.Response.t,
+                    [%t exception_type] * Smaws_Lib.Response.metadata )
+                  result]))
     |> Docs.attach_doc_to_signature_item ~loc ~doc_string
 
   let extract_xml_namespace (service : Shape.serviceShapeDetails) =

--- a/codegen/AwsProtocolQuery.ml
+++ b/codegen/AwsProtocolQuery.ml
@@ -1091,31 +1091,39 @@ module Operations = struct
              in
              B.pexp_ident (Location.mknoloc func_ident))
     in
-    let request_func =
-      B.pexp_ident (Location.mknoloc (make_lident ~names:(awsquery_mod @ [ "request" ])))
+    let request_func ~with_metadata =
+      B.pexp_ident
+        (Location.mknoloc
+           (make_lident
+              ~names:
+                (awsquery_mod @ [ (if with_metadata then "request_with_metadata" else "request") ])))
     in
-    let shape_func_body =
+    let shape_func_body ~with_metadata =
       [%expr
         let fields = [%e input_serializer] in
-        [%e request_func] ~action:[%e const_str action_name]
+        [%e request_func ~with_metadata] ~action:[%e const_str action_name]
           ~xmlNamespace:[%e const_str xml_namespace] ~service ~context ~fields
           ~output_deserializer:[%e output_deserializer] ~error_deserializer]
     in
-    let shape_func =
-      Option.value_map operation_shape.input ~default:shape_func_body ~f:(fun input_name ->
+    let shape_func ~with_metadata =
+      Option.value_map operation_shape.input ~default:(shape_func_body ~with_metadata)
+        ~f:(fun input_name ->
           B.pexp_fun Nolabel None
             (B.ppat_constraint
                (B.ppat_var (Location.mknoloc "request"))
                (Types.resolve alias_context ~name:input_name ~namespace_resolver ()))
-            shape_func_body)
+            (shape_func_body ~with_metadata))
     in
-    [%stri let request = fun context -> [%e shape_func]]
+    [
+      [%stri let request = fun context -> [%e shape_func ~with_metadata:false]];
+      [%stri let request_with_metadata = fun context -> [%e shape_func ~with_metadata:true]];
+    ]
 
   let generate_operation_module ~name ~operation_name ~operation_shape ~dependencies ~alias_context
       ~xml_namespace ~(namespace_resolver : Namespace_resolver.Namespace_resolver.t)
       ~(shape_resolver : Shape_resolver.t) () =
     let module_name = SafeNames.safeConstructorName operation_name in
-    let request_handler =
+    let request_handlers =
       generate_request_handler ~name ~operation_name ~operation_shape ~alias_context ~xml_namespace
         ~namespace_resolver ()
     in
@@ -1123,7 +1131,7 @@ module Operations = struct
       generate_error_handler ~operation_shape ~namespace_resolver ~shape_resolver ()
     in
     let error_to_string = generate_error_to_string ~operation_shape ~namespace_resolver () in
-    let module_items = [ error_to_string; error_handler; request_handler ] in
+    let module_items = error_to_string :: error_handler :: request_handlers in
     let module_expr = B.pmod_structure module_items in
     B.pstr_module (B.module_binding ~name:(Location.mknoloc (Some module_name)) ~expr:module_expr)
 
@@ -1184,7 +1192,12 @@ module Operations = struct
                 val request :
                   'http_type Smaws_Lib.Context.t ->
                   [%t input_type] ->
-                  ([%t output_type], [%t exception_type]) result]))
+                  ([%t output_type], [%t exception_type]) result
+
+                val request_with_metadata :
+                  'http_type Smaws_Lib.Context.t ->
+                  [%t input_type] ->
+                  ([%t output_type] Smaws_Lib.Response.t, [%t exception_type]) result]))
     |> Docs.attach_doc_to_signature_item ~loc ~doc_string
 
   let extract_xml_namespace (service : Shape.serviceShapeDetails) =

--- a/model_tests/protocols/json/json.mli
+++ b/model_tests/protocols/json/json.mli
@@ -124,6 +124,13 @@ module ContentTypeParameters : sig
     'http_type Smaws_Lib.Context.t ->
     content_type_parameters_input ->
     (content_type_parameters_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    content_type_parameters_input ->
+    ( content_type_parameters_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc
   "The example tests how servers must support requests containing a `Content-Type` header with \
@@ -136,6 +143,11 @@ module DatetimeOffsets : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (datetime_offsets_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (datetime_offsets_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -146,6 +158,13 @@ module EmptyOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -156,6 +175,13 @@ module EndpointOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -166,6 +192,13 @@ module EndpointWithHostLabelOperation : sig
     'http_type Smaws_Lib.Context.t ->
     host_label_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    host_label_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -176,6 +209,11 @@ module FractionalSeconds : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (fractional_seconds_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (fractional_seconds_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -196,6 +234,16 @@ module GreetingWithErrors : sig
       | `FooError of foo_error
       | `InvalidGreeting of invalid_greeting ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( greeting_with_errors_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ComplexError of complex_error
+      | `FooError of foo_error
+      | `InvalidGreeting of invalid_greeting ] )
+    result
 end
 [@@ocaml.doc
   "This operation has three possible return values: 1. A successful response in the form of \
@@ -210,6 +258,13 @@ module HostWithPathOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -220,6 +275,11 @@ module JsonEnums : sig
     'http_type Smaws_Lib.Context.t ->
     json_enums_input_output ->
     (json_enums_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    json_enums_input_output ->
+    (json_enums_input_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -230,6 +290,13 @@ module JsonIntEnums : sig
     'http_type Smaws_Lib.Context.t ->
     json_int_enums_input_output ->
     (json_int_enums_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    json_int_enums_input_output ->
+    ( json_int_enums_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc "This example serializes intEnums as top level properties, in lists, sets, and maps."]
 
@@ -240,6 +307,11 @@ module JsonUnions : sig
     'http_type Smaws_Lib.Context.t ->
     union_input_output ->
     (union_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    union_input_output ->
+    (union_input_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc "This operation uses unions for inputs and outputs."]
 
@@ -258,6 +330,15 @@ module KitchenSinkOperation : sig
       | `ErrorWithMembers of error_with_members
       | `ErrorWithoutMembers of error_without_members ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    kitchen_sink ->
+    ( kitchen_sink Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ErrorWithMembers of error_with_members
+      | `ErrorWithoutMembers of error_without_members ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -268,6 +349,13 @@ module NullOperation : sig
     'http_type Smaws_Lib.Context.t ->
     null_operation_input_output ->
     (null_operation_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    null_operation_input_output ->
+    ( null_operation_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -278,6 +366,13 @@ module OperationWithOptionalInputOutput : sig
     'http_type Smaws_Lib.Context.t ->
     operation_with_optional_input_output_input ->
     (operation_with_optional_input_output_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    operation_with_optional_input_output_input ->
+    ( operation_with_optional_input_output_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -288,6 +383,13 @@ module PutAndGetInlineDocuments : sig
     'http_type Smaws_Lib.Context.t ->
     put_and_get_inline_documents_input_output ->
     (put_and_get_inline_documents_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_and_get_inline_documents_input_output ->
+    ( put_and_get_inline_documents_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc "This example serializes an inline document as part of the payload."]
 
@@ -298,6 +400,13 @@ module PutWithContentEncoding : sig
     'http_type Smaws_Lib.Context.t ->
     put_with_content_encoding_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_with_content_encoding_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -308,6 +417,13 @@ module SimpleScalarProperties : sig
     'http_type Smaws_Lib.Context.t ->
     simple_scalar_properties_input_output ->
     (simple_scalar_properties_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    simple_scalar_properties_input_output ->
+    ( simple_scalar_properties_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -319,6 +435,13 @@ module SparseNullsOperation : sig
     'http_type Smaws_Lib.Context.t ->
     sparse_nulls_operation_input_output ->
     (sparse_nulls_operation_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    sparse_nulls_operation_input_output ->
+    ( sparse_nulls_operation_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 

--- a/model_tests/protocols/json/json.mli
+++ b/model_tests/protocols/json/json.mli
@@ -129,7 +129,7 @@ module ContentTypeParameters : sig
     'http_type Smaws_Lib.Context.t ->
     content_type_parameters_input ->
     ( content_type_parameters_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -147,7 +147,9 @@ module DatetimeOffsets : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (datetime_offsets_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( datetime_offsets_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -163,7 +165,7 @@ module EmptyOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -180,7 +182,7 @@ module EndpointOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -197,7 +199,7 @@ module EndpointWithHostLabelOperation : sig
     'http_type Smaws_Lib.Context.t ->
     host_label_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -213,7 +215,9 @@ module FractionalSeconds : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (fractional_seconds_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( fractional_seconds_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -242,7 +246,8 @@ module GreetingWithErrors : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ComplexError of complex_error
       | `FooError of foo_error
-      | `InvalidGreeting of invalid_greeting ] )
+      | `InvalidGreeting of invalid_greeting ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -263,7 +268,7 @@ module HostWithPathOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -279,7 +284,9 @@ module JsonEnums : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     json_enums_input_output ->
-    (json_enums_input_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( json_enums_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -295,7 +302,7 @@ module JsonIntEnums : sig
     'http_type Smaws_Lib.Context.t ->
     json_int_enums_input_output ->
     ( json_int_enums_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This example serializes intEnums as top level properties, in lists, sets, and maps."]
@@ -311,7 +318,9 @@ module JsonUnions : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     union_input_output ->
-    (union_input_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( union_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "This operation uses unions for inputs and outputs."]
 
@@ -337,7 +346,8 @@ module KitchenSinkOperation : sig
     ( kitchen_sink Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ErrorWithMembers of error_with_members
-      | `ErrorWithoutMembers of error_without_members ] )
+      | `ErrorWithoutMembers of error_without_members ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -354,7 +364,7 @@ module NullOperation : sig
     'http_type Smaws_Lib.Context.t ->
     null_operation_input_output ->
     ( null_operation_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -371,7 +381,7 @@ module OperationWithOptionalInputOutput : sig
     'http_type Smaws_Lib.Context.t ->
     operation_with_optional_input_output_input ->
     ( operation_with_optional_input_output_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -388,7 +398,7 @@ module PutAndGetInlineDocuments : sig
     'http_type Smaws_Lib.Context.t ->
     put_and_get_inline_documents_input_output ->
     ( put_and_get_inline_documents_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This example serializes an inline document as part of the payload."]
@@ -405,7 +415,7 @@ module PutWithContentEncoding : sig
     'http_type Smaws_Lib.Context.t ->
     put_with_content_encoding_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -422,7 +432,7 @@ module SimpleScalarProperties : sig
     'http_type Smaws_Lib.Context.t ->
     simple_scalar_properties_input_output ->
     ( simple_scalar_properties_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -440,7 +450,7 @@ module SparseNullsOperation : sig
     'http_type Smaws_Lib.Context.t ->
     sparse_nulls_operation_input_output ->
     ( sparse_nulls_operation_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]

--- a/model_tests/protocols/json/operations.ml
+++ b/model_tests/protocols/json/operations.ml
@@ -15,6 +15,13 @@ module ContentTypeParameters = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.content_type_parameters_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : content_type_parameters_input) =
+    let input = Json_serializers.content_type_parameters_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"JsonProtocol.ContentTypeParameters" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.content_type_parameters_output_of_yojson
+      ~error_deserializer
 end
 
 module DatetimeOffsets = struct
@@ -30,6 +37,12 @@ module DatetimeOffsets = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.DatetimeOffsets" ~service ~context
       ~input ~output_deserializer:Json_deserializers.datetime_offsets_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"JsonProtocol.DatetimeOffsets"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.datetime_offsets_output_of_yojson ~error_deserializer
 end
 
 module EmptyOperation = struct
@@ -45,6 +58,13 @@ module EmptyOperation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.EmptyOperation" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"JsonProtocol.EmptyOperation"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module EndpointOperation = struct
@@ -59,6 +79,13 @@ module EndpointOperation = struct
     let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.EndpointOperation" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"JsonProtocol.EndpointOperation"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -76,6 +103,13 @@ module EndpointWithHostLabelOperation = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : host_label_input) =
+    let input = Json_serializers.host_label_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"JsonProtocol.EndpointWithHostLabelOperation" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module FractionalSeconds = struct
@@ -90,6 +124,13 @@ module FractionalSeconds = struct
     let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.FractionalSeconds" ~service
       ~context ~input ~output_deserializer:Json_deserializers.fractional_seconds_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"JsonProtocol.FractionalSeconds"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.fractional_seconds_output_of_yojson
       ~error_deserializer
 end
 
@@ -116,6 +157,13 @@ module GreetingWithErrors = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.GreetingWithErrors" ~service
       ~context ~input ~output_deserializer:Json_deserializers.greeting_with_errors_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"JsonProtocol.GreetingWithErrors"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.greeting_with_errors_output_of_yojson
+      ~error_deserializer
 end
 
 module HostWithPathOperation = struct
@@ -130,6 +178,13 @@ module HostWithPathOperation = struct
     let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.HostWithPathOperation" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"JsonProtocol.HostWithPathOperation" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -146,6 +201,12 @@ module JsonEnums = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.JsonEnums" ~service ~context
       ~input ~output_deserializer:Json_deserializers.json_enums_input_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : json_enums_input_output) =
+    let input = Json_serializers.json_enums_input_output_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"JsonProtocol.JsonEnums" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.json_enums_input_output_of_yojson
+      ~error_deserializer
 end
 
 module JsonIntEnums = struct
@@ -161,6 +222,13 @@ module JsonIntEnums = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.JsonIntEnums" ~service ~context
       ~input ~output_deserializer:Json_deserializers.json_int_enums_input_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : json_int_enums_input_output) =
+    let input = Json_serializers.json_int_enums_input_output_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"JsonProtocol.JsonIntEnums"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.json_int_enums_input_output_of_yojson
+      ~error_deserializer
 end
 
 module JsonUnions = struct
@@ -175,6 +243,12 @@ module JsonUnions = struct
     let input = Json_serializers.union_input_output_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.JsonUnions" ~service ~context
       ~input ~output_deserializer:Json_deserializers.union_input_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : union_input_output) =
+    let input = Json_serializers.union_input_output_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"JsonProtocol.JsonUnions" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.union_input_output_of_yojson
       ~error_deserializer
 end
 
@@ -200,6 +274,12 @@ module KitchenSinkOperation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.KitchenSinkOperation" ~service
       ~context ~input ~output_deserializer:Json_deserializers.kitchen_sink_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : kitchen_sink) =
+    let input = Json_serializers.kitchen_sink_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"JsonProtocol.KitchenSinkOperation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.kitchen_sink_of_yojson ~error_deserializer
 end
 
 module NullOperation = struct
@@ -215,6 +295,13 @@ module NullOperation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.NullOperation" ~service ~context
       ~input ~output_deserializer:Json_deserializers.null_operation_input_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : null_operation_input_output) =
+    let input = Json_serializers.null_operation_input_output_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"JsonProtocol.NullOperation"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.null_operation_input_output_of_yojson
+      ~error_deserializer
 end
 
 module OperationWithOptionalInputOutput = struct
@@ -229,6 +316,13 @@ module OperationWithOptionalInputOutput = struct
     let input = Json_serializers.operation_with_optional_input_output_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.OperationWithOptionalInputOutput"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.operation_with_optional_input_output_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : operation_with_optional_input_output_input) =
+    let input = Json_serializers.operation_with_optional_input_output_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"JsonProtocol.OperationWithOptionalInputOutput" ~service ~context ~input
       ~output_deserializer:Json_deserializers.operation_with_optional_input_output_output_of_yojson
       ~error_deserializer
 end
@@ -247,6 +341,13 @@ module PutAndGetInlineDocuments = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.put_and_get_inline_documents_input_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_and_get_inline_documents_input_output) =
+    let input = Json_serializers.put_and_get_inline_documents_input_output_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"JsonProtocol.PutAndGetInlineDocuments" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_and_get_inline_documents_input_output_of_yojson
+      ~error_deserializer
 end
 
 module PutWithContentEncoding = struct
@@ -261,6 +362,13 @@ module PutWithContentEncoding = struct
     let input = Json_serializers.put_with_content_encoding_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.PutWithContentEncoding" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_with_content_encoding_input) =
+    let input = Json_serializers.put_with_content_encoding_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"JsonProtocol.PutWithContentEncoding" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -278,6 +386,13 @@ module SimpleScalarProperties = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.simple_scalar_properties_input_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : simple_scalar_properties_input_output) =
+    let input = Json_serializers.simple_scalar_properties_input_output_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"JsonProtocol.SimpleScalarProperties" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.simple_scalar_properties_input_output_of_yojson
+      ~error_deserializer
 end
 
 module SparseNullsOperation = struct
@@ -292,6 +407,13 @@ module SparseNullsOperation = struct
     let input = Json_serializers.sparse_nulls_operation_input_output_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"JsonProtocol.SparseNullsOperation" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.sparse_nulls_operation_input_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : sparse_nulls_operation_input_output) =
+    let input = Json_serializers.sparse_nulls_operation_input_output_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"JsonProtocol.SparseNullsOperation" ~service ~context ~input
       ~output_deserializer:Json_deserializers.sparse_nulls_operation_input_output_of_yojson
       ~error_deserializer
 end

--- a/model_tests/protocols/json/operations.mli
+++ b/model_tests/protocols/json/operations.mli
@@ -12,7 +12,7 @@ module ContentTypeParameters : sig
     'http_type Smaws_Lib.Context.t ->
     content_type_parameters_input ->
     ( content_type_parameters_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -30,7 +30,9 @@ module DatetimeOffsets : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (datetime_offsets_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( datetime_offsets_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -46,7 +48,7 @@ module EmptyOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -63,7 +65,7 @@ module EndpointOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -80,7 +82,7 @@ module EndpointWithHostLabelOperation : sig
     'http_type Smaws_Lib.Context.t ->
     host_label_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -96,7 +98,9 @@ module FractionalSeconds : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (fractional_seconds_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( fractional_seconds_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -125,7 +129,8 @@ module GreetingWithErrors : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ComplexError of complex_error
       | `FooError of foo_error
-      | `InvalidGreeting of invalid_greeting ] )
+      | `InvalidGreeting of invalid_greeting ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -146,7 +151,7 @@ module HostWithPathOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -162,7 +167,9 @@ module JsonEnums : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     json_enums_input_output ->
-    (json_enums_input_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( json_enums_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -178,7 +185,7 @@ module JsonIntEnums : sig
     'http_type Smaws_Lib.Context.t ->
     json_int_enums_input_output ->
     ( json_int_enums_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This example serializes intEnums as top level properties, in lists, sets, and maps."]
@@ -194,7 +201,9 @@ module JsonUnions : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     union_input_output ->
-    (union_input_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( union_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "This operation uses unions for inputs and outputs."]
 
@@ -220,7 +229,8 @@ module KitchenSinkOperation : sig
     ( kitchen_sink Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ErrorWithMembers of error_with_members
-      | `ErrorWithoutMembers of error_without_members ] )
+      | `ErrorWithoutMembers of error_without_members ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -237,7 +247,7 @@ module NullOperation : sig
     'http_type Smaws_Lib.Context.t ->
     null_operation_input_output ->
     ( null_operation_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -254,7 +264,7 @@ module OperationWithOptionalInputOutput : sig
     'http_type Smaws_Lib.Context.t ->
     operation_with_optional_input_output_input ->
     ( operation_with_optional_input_output_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -271,7 +281,7 @@ module PutAndGetInlineDocuments : sig
     'http_type Smaws_Lib.Context.t ->
     put_and_get_inline_documents_input_output ->
     ( put_and_get_inline_documents_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This example serializes an inline document as part of the payload."]
@@ -288,7 +298,7 @@ module PutWithContentEncoding : sig
     'http_type Smaws_Lib.Context.t ->
     put_with_content_encoding_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -305,7 +315,7 @@ module SimpleScalarProperties : sig
     'http_type Smaws_Lib.Context.t ->
     simple_scalar_properties_input_output ->
     ( simple_scalar_properties_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -322,7 +332,7 @@ module SparseNullsOperation : sig
     'http_type Smaws_Lib.Context.t ->
     sparse_nulls_operation_input_output ->
     ( sparse_nulls_operation_input_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]

--- a/model_tests/protocols/json/operations.mli
+++ b/model_tests/protocols/json/operations.mli
@@ -7,6 +7,13 @@ module ContentTypeParameters : sig
     'http_type Smaws_Lib.Context.t ->
     content_type_parameters_input ->
     (content_type_parameters_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    content_type_parameters_input ->
+    ( content_type_parameters_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc
   "The example tests how servers must support requests containing a `Content-Type` header with \
@@ -19,6 +26,11 @@ module DatetimeOffsets : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (datetime_offsets_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (datetime_offsets_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -29,6 +41,13 @@ module EmptyOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -39,6 +58,13 @@ module EndpointOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -49,6 +75,13 @@ module EndpointWithHostLabelOperation : sig
     'http_type Smaws_Lib.Context.t ->
     host_label_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    host_label_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -59,6 +92,11 @@ module FractionalSeconds : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (fractional_seconds_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (fractional_seconds_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -79,6 +117,16 @@ module GreetingWithErrors : sig
       | `FooError of foo_error
       | `InvalidGreeting of invalid_greeting ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( greeting_with_errors_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ComplexError of complex_error
+      | `FooError of foo_error
+      | `InvalidGreeting of invalid_greeting ] )
+    result
 end
 [@@ocaml.doc
   "This operation has three possible return values: 1. A successful response in the form of \
@@ -93,6 +141,13 @@ module HostWithPathOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -103,6 +158,11 @@ module JsonEnums : sig
     'http_type Smaws_Lib.Context.t ->
     json_enums_input_output ->
     (json_enums_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    json_enums_input_output ->
+    (json_enums_input_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -113,6 +173,13 @@ module JsonIntEnums : sig
     'http_type Smaws_Lib.Context.t ->
     json_int_enums_input_output ->
     (json_int_enums_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    json_int_enums_input_output ->
+    ( json_int_enums_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc "This example serializes intEnums as top level properties, in lists, sets, and maps."]
 
@@ -123,6 +190,11 @@ module JsonUnions : sig
     'http_type Smaws_Lib.Context.t ->
     union_input_output ->
     (union_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    union_input_output ->
+    (union_input_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc "This operation uses unions for inputs and outputs."]
 
@@ -141,6 +213,15 @@ module KitchenSinkOperation : sig
       | `ErrorWithMembers of error_with_members
       | `ErrorWithoutMembers of error_without_members ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    kitchen_sink ->
+    ( kitchen_sink Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ErrorWithMembers of error_with_members
+      | `ErrorWithoutMembers of error_without_members ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -151,6 +232,13 @@ module NullOperation : sig
     'http_type Smaws_Lib.Context.t ->
     null_operation_input_output ->
     (null_operation_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    null_operation_input_output ->
+    ( null_operation_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -161,6 +249,13 @@ module OperationWithOptionalInputOutput : sig
     'http_type Smaws_Lib.Context.t ->
     operation_with_optional_input_output_input ->
     (operation_with_optional_input_output_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    operation_with_optional_input_output_input ->
+    ( operation_with_optional_input_output_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -171,6 +266,13 @@ module PutAndGetInlineDocuments : sig
     'http_type Smaws_Lib.Context.t ->
     put_and_get_inline_documents_input_output ->
     (put_and_get_inline_documents_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_and_get_inline_documents_input_output ->
+    ( put_and_get_inline_documents_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc "This example serializes an inline document as part of the payload."]
 
@@ -181,6 +283,13 @@ module PutWithContentEncoding : sig
     'http_type Smaws_Lib.Context.t ->
     put_with_content_encoding_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_with_content_encoding_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -191,6 +300,13 @@ module SimpleScalarProperties : sig
     'http_type Smaws_Lib.Context.t ->
     simple_scalar_properties_input_output ->
     (simple_scalar_properties_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    simple_scalar_properties_input_output ->
+    ( simple_scalar_properties_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -201,5 +317,12 @@ module SparseNullsOperation : sig
     'http_type Smaws_Lib.Context.t ->
     sparse_nulls_operation_input_output ->
     (sparse_nulls_operation_input_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    sparse_nulls_operation_input_output ->
+    ( sparse_nulls_operation_input_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc ""]

--- a/model_tests/protocols/query/operations.ml
+++ b/model_tests/protocols/query/operations.ml
@@ -14,6 +14,12 @@ module DatetimeOffsets = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"DatetimeOffsets"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:datetime_offsets_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"DatetimeOffsets"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:datetime_offsets_output_of_xml ~error_deserializer
 end
 
 module EmptyInputAndEmptyOutput = struct
@@ -25,6 +31,12 @@ module EmptyInputAndEmptyOutput = struct
   let request context (request : empty_input_and_empty_output_input) =
     let fields = empty_input_and_empty_output_input_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"EmptyInputAndEmptyOutput"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:empty_input_and_empty_output_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : empty_input_and_empty_output_input) =
+    let fields = empty_input_and_empty_output_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"EmptyInputAndEmptyOutput"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:empty_input_and_empty_output_output_of_xml ~error_deserializer
 end
@@ -40,6 +52,12 @@ module EndpointOperation = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"EndpointOperation"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"EndpointOperation"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
 
 module EndpointWithHostLabelOperation = struct
@@ -51,6 +69,12 @@ module EndpointWithHostLabelOperation = struct
   let request context (request : host_label_input) =
     let fields = host_label_input_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"EndpointWithHostLabelOperation"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : host_label_input) =
+    let fields = host_label_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"EndpointWithHostLabelOperation"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
@@ -66,6 +90,12 @@ module FlattenedXmlMap = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"FlattenedXmlMap"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:flattened_xml_map_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"FlattenedXmlMap"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:flattened_xml_map_output_of_xml ~error_deserializer
 end
 
 module FlattenedXmlMapWithXmlName = struct
@@ -77,6 +107,12 @@ module FlattenedXmlMapWithXmlName = struct
   let request context (request : Smaws_Lib.Smithy_api.Types.unit_) =
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"FlattenedXmlMapWithXmlName"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:flattened_xml_map_with_xml_name_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"FlattenedXmlMapWithXmlName"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:flattened_xml_map_with_xml_name_output_of_xml ~error_deserializer
 end
@@ -92,6 +128,12 @@ module FlattenedXmlMapWithXmlNamespace = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"FlattenedXmlMapWithXmlNamespace"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:flattened_xml_map_with_xml_namespace_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"FlattenedXmlMapWithXmlNamespace"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:flattened_xml_map_with_xml_namespace_output_of_xml ~error_deserializer
 end
 
 module FractionalSeconds = struct
@@ -103,6 +145,12 @@ module FractionalSeconds = struct
   let request context (request : Smaws_Lib.Smithy_api.Types.unit_) =
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"FractionalSeconds"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:fractional_seconds_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"FractionalSeconds"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:fractional_seconds_output_of_xml ~error_deserializer
 end
@@ -144,6 +192,12 @@ module GreetingWithErrors = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"GreetingWithErrors"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:greeting_with_errors_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"GreetingWithErrors"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:greeting_with_errors_output_of_xml ~error_deserializer
 end
 
 module HostWithPathOperation = struct
@@ -155,6 +209,12 @@ module HostWithPathOperation = struct
   let request context (request : Smaws_Lib.Smithy_api.Types.unit_) =
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"HostWithPathOperation"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"HostWithPathOperation"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
@@ -170,6 +230,12 @@ module IgnoresWrappingXmlName = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"IgnoresWrappingXmlName"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:ignores_wrapping_xml_name_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"IgnoresWrappingXmlName"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:ignores_wrapping_xml_name_output_of_xml ~error_deserializer
 end
 
 module NestedStructures = struct
@@ -181,6 +247,12 @@ module NestedStructures = struct
   let request context (request : nested_structures_input) =
     let fields = nested_structures_input_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"NestedStructures"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : nested_structures_input) =
+    let fields = nested_structures_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"NestedStructures"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
@@ -196,6 +268,12 @@ module NoInputAndNoOutput = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"NoInputAndNoOutput"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"NoInputAndNoOutput"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
 
 module NoInputAndOutput = struct
@@ -207,6 +285,12 @@ module NoInputAndOutput = struct
   let request context (request : no_input_and_output_input) =
     let fields = no_input_and_output_input_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"NoInputAndOutput"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:no_input_and_output_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : no_input_and_output_input) =
+    let fields = no_input_and_output_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"NoInputAndOutput"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:no_input_and_output_output_of_xml ~error_deserializer
 end
@@ -222,6 +306,12 @@ module PutWithContentEncoding = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"PutWithContentEncoding"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : put_with_content_encoding_input) =
+    let fields = put_with_content_encoding_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"PutWithContentEncoding"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
 
 module QueryIdempotencyTokenAutoFill = struct
@@ -233,6 +323,12 @@ module QueryIdempotencyTokenAutoFill = struct
   let request context (request : query_idempotency_token_auto_fill_input) =
     let fields = query_idempotency_token_auto_fill_input_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"QueryIdempotencyTokenAutoFill"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : query_idempotency_token_auto_fill_input) =
+    let fields = query_idempotency_token_auto_fill_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"QueryIdempotencyTokenAutoFill"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
@@ -248,6 +344,12 @@ module QueryLists = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"QueryLists" ~xmlNamespace:"https://example.com/"
       ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : query_lists_input) =
+    let fields = query_lists_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"QueryLists"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
 
 module QueryMaps = struct
@@ -261,6 +363,12 @@ module QueryMaps = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"QueryMaps" ~xmlNamespace:"https://example.com/"
       ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : query_maps_input) =
+    let fields = query_maps_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"QueryMaps"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
 
 module QueryTimestamps = struct
@@ -272,6 +380,12 @@ module QueryTimestamps = struct
   let request context (request : query_timestamps_input) =
     let fields = query_timestamps_input_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"QueryTimestamps"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : query_timestamps_input) =
+    let fields = query_timestamps_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"QueryTimestamps"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
@@ -287,6 +401,12 @@ module RecursiveXmlShapes = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"RecursiveXmlShapes"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:recursive_xml_shapes_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"RecursiveXmlShapes"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:recursive_xml_shapes_output_of_xml ~error_deserializer
 end
 
 module SimpleInputParams = struct
@@ -298,6 +418,12 @@ module SimpleInputParams = struct
   let request context (request : simple_input_params_input) =
     let fields = simple_input_params_input_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"SimpleInputParams"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
+
+  let request_with_metadata context (request : simple_input_params_input) =
+    let fields = simple_input_params_input_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"SimpleInputParams"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:Smaws_Lib.Smithy_api.Query_deserializers.unit__of_xml ~error_deserializer
 end
@@ -313,6 +439,12 @@ module SimpleScalarXmlProperties = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"SimpleScalarXmlProperties"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:simple_scalar_xml_properties_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"SimpleScalarXmlProperties"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:simple_scalar_xml_properties_output_of_xml ~error_deserializer
 end
 
 module XmlBlobs = struct
@@ -325,6 +457,12 @@ module XmlBlobs = struct
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlBlobs" ~xmlNamespace:"https://example.com/"
       ~service ~context ~fields ~output_deserializer:xml_blobs_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlBlobs"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_blobs_output_of_xml ~error_deserializer
 end
 
 module XmlEmptyBlobs = struct
@@ -336,6 +474,12 @@ module XmlEmptyBlobs = struct
   let request context (request : Smaws_Lib.Smithy_api.Types.unit_) =
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlEmptyBlobs"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_blobs_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlEmptyBlobs"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:xml_blobs_output_of_xml ~error_deserializer
 end
@@ -351,6 +495,12 @@ module XmlEmptyLists = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlEmptyLists"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:xml_lists_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlEmptyLists"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_lists_output_of_xml ~error_deserializer
 end
 
 module XmlEmptyMaps = struct
@@ -363,6 +513,12 @@ module XmlEmptyMaps = struct
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlEmptyMaps" ~xmlNamespace:"https://example.com/"
       ~service ~context ~fields ~output_deserializer:xml_maps_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlEmptyMaps"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_maps_output_of_xml ~error_deserializer
 end
 
 module XmlEnums = struct
@@ -375,6 +531,12 @@ module XmlEnums = struct
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlEnums" ~xmlNamespace:"https://example.com/"
       ~service ~context ~fields ~output_deserializer:xml_enums_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlEnums"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_enums_output_of_xml ~error_deserializer
 end
 
 module XmlIntEnums = struct
@@ -387,6 +549,12 @@ module XmlIntEnums = struct
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlIntEnums" ~xmlNamespace:"https://example.com/"
       ~service ~context ~fields ~output_deserializer:xml_int_enums_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlIntEnums"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_int_enums_output_of_xml ~error_deserializer
 end
 
 module XmlLists = struct
@@ -399,6 +567,12 @@ module XmlLists = struct
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlLists" ~xmlNamespace:"https://example.com/"
       ~service ~context ~fields ~output_deserializer:xml_lists_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlLists"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_lists_output_of_xml ~error_deserializer
 end
 
 module XmlMaps = struct
@@ -411,6 +585,12 @@ module XmlMaps = struct
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlMaps" ~xmlNamespace:"https://example.com/"
       ~service ~context ~fields ~output_deserializer:xml_maps_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlMaps"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_maps_output_of_xml ~error_deserializer
 end
 
 module XmlMapsXmlName = struct
@@ -422,6 +602,12 @@ module XmlMapsXmlName = struct
   let request context (request : Smaws_Lib.Smithy_api.Types.unit_) =
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlMapsXmlName"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_maps_xml_name_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlMapsXmlName"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:xml_maps_xml_name_output_of_xml ~error_deserializer
 end
@@ -437,6 +623,12 @@ module XmlNamespaces = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlNamespaces"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:xml_namespaces_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlNamespaces"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_namespaces_output_of_xml ~error_deserializer
 end
 
 module XmlTimestamps = struct
@@ -448,6 +640,12 @@ module XmlTimestamps = struct
   let request context (request : Smaws_Lib.Smithy_api.Types.unit_) =
     let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"XmlTimestamps"
+      ~xmlNamespace:"https://example.com/" ~service ~context ~fields
+      ~output_deserializer:xml_timestamps_output_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let fields = Smaws_Lib.Smithy_api.Query_serializers.unit__to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"XmlTimestamps"
       ~xmlNamespace:"https://example.com/" ~service ~context ~fields
       ~output_deserializer:xml_timestamps_output_of_xml ~error_deserializer
 end

--- a/model_tests/protocols/query/operations.mli
+++ b/model_tests/protocols/query/operations.mli
@@ -7,6 +7,11 @@ module DatetimeOffsets : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (datetime_offsets_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (datetime_offsets_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -17,6 +22,13 @@ module EmptyInputAndEmptyOutput : sig
     'http_type Smaws_Lib.Context.t ->
     empty_input_and_empty_output_input ->
     (empty_input_and_empty_output_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    empty_input_and_empty_output_input ->
+    ( empty_input_and_empty_output_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "The example tests how requests and responses are serialized when there's no request or response \
@@ -29,6 +41,13 @@ module EndpointOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -39,6 +58,13 @@ module EndpointWithHostLabelOperation : sig
     'http_type Smaws_Lib.Context.t ->
     host_label_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    host_label_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -49,6 +75,11 @@ module FlattenedXmlMap : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (flattened_xml_map_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (flattened_xml_map_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "Flattened maps"]
 
@@ -59,6 +90,13 @@ module FlattenedXmlMapWithXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (flattened_xml_map_with_xml_name_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( flattened_xml_map_with_xml_name_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "Flattened maps with \\@xmlName"]
 
@@ -69,6 +107,13 @@ module FlattenedXmlMapWithXmlNamespace : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (flattened_xml_map_with_xml_namespace_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( flattened_xml_map_with_xml_namespace_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "Flattened maps with \\@xmlNamespace and \\@xmlName"]
 
@@ -79,6 +124,11 @@ module FractionalSeconds : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (fractional_seconds_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (fractional_seconds_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -99,6 +149,16 @@ module GreetingWithErrors : sig
       | `CustomCodeError of custom_code_error
       | `InvalidGreeting of invalid_greeting ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( greeting_with_errors_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ComplexError of complex_error
+      | `CustomCodeError of custom_code_error
+      | `InvalidGreeting of invalid_greeting ] )
+    result
 end
 [@@ocaml.doc
   "This operation has three possible return values: 1. A successful response in the form of \
@@ -111,6 +171,13 @@ module HostWithPathOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -121,6 +188,13 @@ module IgnoresWrappingXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (ignores_wrapping_xml_name_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( ignores_wrapping_xml_name_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "The xmlName trait on the output structure is ignored in AWS Query. The wrapping element is \
@@ -134,6 +208,13 @@ module NestedStructures : sig
     'http_type Smaws_Lib.Context.t ->
     nested_structures_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    nested_structures_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "This test serializes nested and recursive structure members."]
 
@@ -144,6 +225,13 @@ module NoInputAndNoOutput : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "The example tests how requests and responses are serialized when there's no request or response \
@@ -157,6 +245,13 @@ module NoInputAndOutput : sig
     'http_type Smaws_Lib.Context.t ->
     no_input_and_output_input ->
     (no_input_and_output_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    no_input_and_output_input ->
+    ( no_input_and_output_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "The example tests how requests and responses are serialized when there's no request payload or \
@@ -169,6 +264,13 @@ module PutWithContentEncoding : sig
     'http_type Smaws_Lib.Context.t ->
     put_with_content_encoding_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_with_content_encoding_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -179,6 +281,13 @@ module QueryIdempotencyTokenAutoFill : sig
     'http_type Smaws_Lib.Context.t ->
     query_idempotency_token_auto_fill_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_idempotency_token_auto_fill_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "Automatically adds idempotency tokens."]
 
@@ -189,6 +298,13 @@ module QueryLists : sig
     'http_type Smaws_Lib.Context.t ->
     query_lists_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_lists_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "This test serializes simple and complex lists."]
 
@@ -199,6 +315,13 @@ module QueryMaps : sig
     'http_type Smaws_Lib.Context.t ->
     query_maps_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_maps_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "This test serializes simple and complex maps."]
 
@@ -209,6 +332,13 @@ module QueryTimestamps : sig
     'http_type Smaws_Lib.Context.t ->
     query_timestamps_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_timestamps_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "This test serializes timestamps. 1. Timestamps are serialized as RFC 3339 date-time values by \
@@ -222,6 +352,13 @@ module RecursiveXmlShapes : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (recursive_xml_shapes_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( recursive_xml_shapes_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "Recursive shapes"]
 
@@ -232,6 +369,13 @@ module SimpleInputParams : sig
     'http_type Smaws_Lib.Context.t ->
     simple_input_params_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    simple_input_params_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "This test serializes strings, numbers, and boolean values."]
 
@@ -242,6 +386,13 @@ module SimpleScalarXmlProperties : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (simple_scalar_xml_properties_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( simple_scalar_xml_properties_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -252,6 +403,11 @@ module XmlBlobs : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_blobs_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_blobs_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "Blobs are base64 encoded"]
 
@@ -262,6 +418,11 @@ module XmlEmptyBlobs : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_blobs_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_blobs_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -272,6 +433,11 @@ module XmlEmptyLists : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_lists_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_lists_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -282,6 +448,11 @@ module XmlEmptyMaps : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_maps_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_maps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -292,6 +463,11 @@ module XmlEnums : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_enums_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_enums_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -302,6 +478,11 @@ module XmlIntEnums : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_int_enums_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_int_enums_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -312,6 +493,11 @@ module XmlLists : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_lists_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_lists_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc
   "This test case serializes XML lists for the following cases for both input and output: 1. \
@@ -326,6 +512,11 @@ module XmlMaps : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_maps_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_maps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "The example tests basic map serialization."]
 
@@ -336,6 +527,11 @@ module XmlMapsXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_maps_xml_name_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_maps_xml_name_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -346,6 +542,11 @@ module XmlNamespaces : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_namespaces_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_namespaces_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -356,6 +557,11 @@ module XmlTimestamps : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_timestamps_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_timestamps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc
   "This tests how timestamps are serialized, including using the default format of date-time and \

--- a/model_tests/protocols/query/operations.mli
+++ b/model_tests/protocols/query/operations.mli
@@ -11,7 +11,9 @@ module DatetimeOffsets : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (datetime_offsets_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( datetime_offsets_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -27,7 +29,7 @@ module EmptyInputAndEmptyOutput : sig
     'http_type Smaws_Lib.Context.t ->
     empty_input_and_empty_output_input ->
     ( empty_input_and_empty_output_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -46,7 +48,7 @@ module EndpointOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -63,7 +65,7 @@ module EndpointWithHostLabelOperation : sig
     'http_type Smaws_Lib.Context.t ->
     host_label_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -79,7 +81,9 @@ module FlattenedXmlMap : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (flattened_xml_map_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( flattened_xml_map_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "Flattened maps"]
 
@@ -95,7 +99,7 @@ module FlattenedXmlMapWithXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( flattened_xml_map_with_xml_name_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Flattened maps with \\@xmlName"]
@@ -112,7 +116,7 @@ module FlattenedXmlMapWithXmlNamespace : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( flattened_xml_map_with_xml_namespace_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Flattened maps with \\@xmlNamespace and \\@xmlName"]
@@ -128,7 +132,9 @@ module FractionalSeconds : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (fractional_seconds_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( fractional_seconds_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -157,7 +163,8 @@ module GreetingWithErrors : sig
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `ComplexError of complex_error
       | `CustomCodeError of custom_code_error
-      | `InvalidGreeting of invalid_greeting ] )
+      | `InvalidGreeting of invalid_greeting ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -176,7 +183,7 @@ module HostWithPathOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -193,7 +200,7 @@ module IgnoresWrappingXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( ignores_wrapping_xml_name_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -213,7 +220,7 @@ module NestedStructures : sig
     'http_type Smaws_Lib.Context.t ->
     nested_structures_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This test serializes nested and recursive structure members."]
@@ -230,7 +237,7 @@ module NoInputAndNoOutput : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -250,7 +257,7 @@ module NoInputAndOutput : sig
     'http_type Smaws_Lib.Context.t ->
     no_input_and_output_input ->
     ( no_input_and_output_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -269,7 +276,7 @@ module PutWithContentEncoding : sig
     'http_type Smaws_Lib.Context.t ->
     put_with_content_encoding_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -286,7 +293,7 @@ module QueryIdempotencyTokenAutoFill : sig
     'http_type Smaws_Lib.Context.t ->
     query_idempotency_token_auto_fill_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Automatically adds idempotency tokens."]
@@ -303,7 +310,7 @@ module QueryLists : sig
     'http_type Smaws_Lib.Context.t ->
     query_lists_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This test serializes simple and complex lists."]
@@ -320,7 +327,7 @@ module QueryMaps : sig
     'http_type Smaws_Lib.Context.t ->
     query_maps_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This test serializes simple and complex maps."]
@@ -337,7 +344,7 @@ module QueryTimestamps : sig
     'http_type Smaws_Lib.Context.t ->
     query_timestamps_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -357,7 +364,7 @@ module RecursiveXmlShapes : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( recursive_xml_shapes_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Recursive shapes"]
@@ -374,7 +381,7 @@ module SimpleInputParams : sig
     'http_type Smaws_Lib.Context.t ->
     simple_input_params_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This test serializes strings, numbers, and boolean values."]
@@ -391,7 +398,7 @@ module SimpleScalarXmlProperties : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( simple_scalar_xml_properties_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -407,7 +414,9 @@ module XmlBlobs : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_blobs_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_blobs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "Blobs are base64 encoded"]
 
@@ -422,7 +431,9 @@ module XmlEmptyBlobs : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_blobs_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_blobs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -437,7 +448,9 @@ module XmlEmptyLists : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_lists_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_lists_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -452,7 +465,9 @@ module XmlEmptyMaps : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_maps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_maps_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -467,7 +482,9 @@ module XmlEnums : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_enums_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_enums_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -482,7 +499,9 @@ module XmlIntEnums : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_int_enums_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_int_enums_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -497,7 +516,9 @@ module XmlLists : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_lists_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_lists_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "This test case serializes XML lists for the following cases for both input and output: 1. \
@@ -516,7 +537,9 @@ module XmlMaps : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_maps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_maps_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "The example tests basic map serialization."]
 
@@ -531,7 +554,9 @@ module XmlMapsXmlName : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_maps_xml_name_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_maps_xml_name_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -546,7 +571,9 @@ module XmlNamespaces : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_namespaces_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_namespaces_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -561,7 +588,9 @@ module XmlTimestamps : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_timestamps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_timestamps_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "This tests how timestamps are serialized, including using the default format of date-time and \

--- a/model_tests/protocols/query/query.mli
+++ b/model_tests/protocols/query/query.mli
@@ -219,7 +219,9 @@ module DatetimeOffsets : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (datetime_offsets_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( datetime_offsets_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -235,7 +237,7 @@ module EmptyInputAndEmptyOutput : sig
     'http_type Smaws_Lib.Context.t ->
     empty_input_and_empty_output_input ->
     ( empty_input_and_empty_output_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -254,7 +256,7 @@ module EndpointOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -271,7 +273,7 @@ module EndpointWithHostLabelOperation : sig
     'http_type Smaws_Lib.Context.t ->
     host_label_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -287,7 +289,9 @@ module FlattenedXmlMap : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (flattened_xml_map_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( flattened_xml_map_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "Flattened maps"]
 
@@ -303,7 +307,7 @@ module FlattenedXmlMapWithXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( flattened_xml_map_with_xml_name_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Flattened maps with \\@xmlName"]
@@ -320,7 +324,7 @@ module FlattenedXmlMapWithXmlNamespace : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( flattened_xml_map_with_xml_namespace_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Flattened maps with \\@xmlNamespace and \\@xmlName"]
@@ -336,7 +340,9 @@ module FractionalSeconds : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (fractional_seconds_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( fractional_seconds_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -365,7 +371,8 @@ module GreetingWithErrors : sig
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `ComplexError of complex_error
       | `CustomCodeError of custom_code_error
-      | `InvalidGreeting of invalid_greeting ] )
+      | `InvalidGreeting of invalid_greeting ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -384,7 +391,7 @@ module HostWithPathOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -401,7 +408,7 @@ module IgnoresWrappingXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( ignores_wrapping_xml_name_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -421,7 +428,7 @@ module NestedStructures : sig
     'http_type Smaws_Lib.Context.t ->
     nested_structures_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This test serializes nested and recursive structure members."]
@@ -438,7 +445,7 @@ module NoInputAndNoOutput : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -458,7 +465,7 @@ module NoInputAndOutput : sig
     'http_type Smaws_Lib.Context.t ->
     no_input_and_output_input ->
     ( no_input_and_output_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -477,7 +484,7 @@ module PutWithContentEncoding : sig
     'http_type Smaws_Lib.Context.t ->
     put_with_content_encoding_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -494,7 +501,7 @@ module QueryIdempotencyTokenAutoFill : sig
     'http_type Smaws_Lib.Context.t ->
     query_idempotency_token_auto_fill_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Automatically adds idempotency tokens."]
@@ -511,7 +518,7 @@ module QueryLists : sig
     'http_type Smaws_Lib.Context.t ->
     query_lists_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This test serializes simple and complex lists."]
@@ -528,7 +535,7 @@ module QueryMaps : sig
     'http_type Smaws_Lib.Context.t ->
     query_maps_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This test serializes simple and complex maps."]
@@ -545,7 +552,7 @@ module QueryTimestamps : sig
     'http_type Smaws_Lib.Context.t ->
     query_timestamps_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -565,7 +572,7 @@ module RecursiveXmlShapes : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( recursive_xml_shapes_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Recursive shapes"]
@@ -582,7 +589,7 @@ module SimpleInputParams : sig
     'http_type Smaws_Lib.Context.t ->
     simple_input_params_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "This test serializes strings, numbers, and boolean values."]
@@ -599,7 +606,7 @@ module SimpleScalarXmlProperties : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( simple_scalar_xml_properties_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc ""]
@@ -615,7 +622,9 @@ module XmlBlobs : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_blobs_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_blobs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "Blobs are base64 encoded"]
 
@@ -630,7 +639,9 @@ module XmlEmptyBlobs : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_blobs_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_blobs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -645,7 +656,9 @@ module XmlEmptyLists : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_lists_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_lists_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -660,7 +673,9 @@ module XmlEmptyMaps : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_maps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_maps_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -675,7 +690,9 @@ module XmlEnums : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_enums_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_enums_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -690,7 +707,9 @@ module XmlIntEnums : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_int_enums_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_int_enums_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -705,7 +724,9 @@ module XmlLists : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_lists_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_lists_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "This test case serializes XML lists for the following cases for both input and output: 1. \
@@ -724,7 +745,9 @@ module XmlMaps : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_maps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_maps_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "The example tests basic map serialization."]
 
@@ -739,7 +762,9 @@ module XmlMapsXmlName : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_maps_xml_name_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_maps_xml_name_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -754,7 +779,9 @@ module XmlNamespaces : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_namespaces_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_namespaces_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -770,7 +797,9 @@ module XmlTimestamps : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
-    (xml_timestamps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+    ( xml_timestamps_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "This tests how timestamps are serialized, including using the default format of date-time and \

--- a/model_tests/protocols/query/query.mli
+++ b/model_tests/protocols/query/query.mli
@@ -215,6 +215,11 @@ module DatetimeOffsets : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (datetime_offsets_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (datetime_offsets_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -225,6 +230,13 @@ module EmptyInputAndEmptyOutput : sig
     'http_type Smaws_Lib.Context.t ->
     empty_input_and_empty_output_input ->
     (empty_input_and_empty_output_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    empty_input_and_empty_output_input ->
+    ( empty_input_and_empty_output_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "The example tests how requests and responses are serialized when there's no request or response \
@@ -237,6 +249,13 @@ module EndpointOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -247,6 +266,13 @@ module EndpointWithHostLabelOperation : sig
     'http_type Smaws_Lib.Context.t ->
     host_label_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    host_label_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -257,6 +283,11 @@ module FlattenedXmlMap : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (flattened_xml_map_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (flattened_xml_map_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "Flattened maps"]
 
@@ -267,6 +298,13 @@ module FlattenedXmlMapWithXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (flattened_xml_map_with_xml_name_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( flattened_xml_map_with_xml_name_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "Flattened maps with \\@xmlName"]
 
@@ -277,6 +315,13 @@ module FlattenedXmlMapWithXmlNamespace : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (flattened_xml_map_with_xml_namespace_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( flattened_xml_map_with_xml_namespace_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "Flattened maps with \\@xmlNamespace and \\@xmlName"]
 
@@ -287,6 +332,11 @@ module FractionalSeconds : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (fractional_seconds_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (fractional_seconds_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -307,6 +357,16 @@ module GreetingWithErrors : sig
       | `CustomCodeError of custom_code_error
       | `InvalidGreeting of invalid_greeting ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( greeting_with_errors_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ComplexError of complex_error
+      | `CustomCodeError of custom_code_error
+      | `InvalidGreeting of invalid_greeting ] )
+    result
 end
 [@@ocaml.doc
   "This operation has three possible return values: 1. A successful response in the form of \
@@ -319,6 +379,13 @@ module HostWithPathOperation : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -329,6 +396,13 @@ module IgnoresWrappingXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (ignores_wrapping_xml_name_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( ignores_wrapping_xml_name_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "The xmlName trait on the output structure is ignored in AWS Query. The wrapping element is \
@@ -342,6 +416,13 @@ module NestedStructures : sig
     'http_type Smaws_Lib.Context.t ->
     nested_structures_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    nested_structures_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "This test serializes nested and recursive structure members."]
 
@@ -352,6 +433,13 @@ module NoInputAndNoOutput : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "The example tests how requests and responses are serialized when there's no request or response \
@@ -365,6 +453,13 @@ module NoInputAndOutput : sig
     'http_type Smaws_Lib.Context.t ->
     no_input_and_output_input ->
     (no_input_and_output_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    no_input_and_output_input ->
+    ( no_input_and_output_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "The example tests how requests and responses are serialized when there's no request payload or \
@@ -377,6 +472,13 @@ module PutWithContentEncoding : sig
     'http_type Smaws_Lib.Context.t ->
     put_with_content_encoding_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_with_content_encoding_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -387,6 +489,13 @@ module QueryIdempotencyTokenAutoFill : sig
     'http_type Smaws_Lib.Context.t ->
     query_idempotency_token_auto_fill_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_idempotency_token_auto_fill_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "Automatically adds idempotency tokens."]
 
@@ -397,6 +506,13 @@ module QueryLists : sig
     'http_type Smaws_Lib.Context.t ->
     query_lists_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_lists_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "This test serializes simple and complex lists."]
 
@@ -407,6 +523,13 @@ module QueryMaps : sig
     'http_type Smaws_Lib.Context.t ->
     query_maps_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_maps_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "This test serializes simple and complex maps."]
 
@@ -417,6 +540,13 @@ module QueryTimestamps : sig
     'http_type Smaws_Lib.Context.t ->
     query_timestamps_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_timestamps_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "This test serializes timestamps. 1. Timestamps are serialized as RFC 3339 date-time values by \
@@ -430,6 +560,13 @@ module RecursiveXmlShapes : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (recursive_xml_shapes_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( recursive_xml_shapes_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "Recursive shapes"]
 
@@ -440,6 +577,13 @@ module SimpleInputParams : sig
     'http_type Smaws_Lib.Context.t ->
     simple_input_params_input ->
     (Smaws_Lib.Smithy_api.Types.unit_, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    simple_input_params_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc "This test serializes strings, numbers, and boolean values."]
 
@@ -450,6 +594,13 @@ module SimpleScalarXmlProperties : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (simple_scalar_xml_properties_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( simple_scalar_xml_properties_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc ""]
 
@@ -460,6 +611,11 @@ module XmlBlobs : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_blobs_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_blobs_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "Blobs are base64 encoded"]
 
@@ -470,6 +626,11 @@ module XmlEmptyBlobs : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_blobs_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_blobs_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -480,6 +641,11 @@ module XmlEmptyLists : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_lists_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_lists_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -490,6 +656,11 @@ module XmlEmptyMaps : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_maps_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_maps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -500,6 +671,11 @@ module XmlEnums : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_enums_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_enums_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -510,6 +686,11 @@ module XmlIntEnums : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_int_enums_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_int_enums_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "This example serializes enums as top level properties, in lists, sets, and maps."]
 
@@ -520,6 +701,11 @@ module XmlLists : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_lists_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_lists_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc
   "This test case serializes XML lists for the following cases for both input and output: 1. \
@@ -534,6 +720,11 @@ module XmlMaps : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_maps_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_maps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc "The example tests basic map serialization."]
 
@@ -544,6 +735,11 @@ module XmlMapsXmlName : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_maps_xml_name_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_maps_xml_name_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -554,6 +750,11 @@ module XmlNamespaces : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_namespaces_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_namespaces_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc ""]
 
@@ -565,6 +766,11 @@ module XmlTimestamps : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (xml_timestamps_output, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    (xml_timestamps_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
 end
 [@@ocaml.doc
   "This tests how timestamps are serialized, including using the default format of date-time and \

--- a/sdks/acm/Smaws_Client_ACM.mli
+++ b/sdks/acm/Smaws_Client_ACM.mli
@@ -649,6 +649,21 @@ module AddTagsToCertificate : sig
       | `TooManyTagsException of too_many_tags_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_to_certificate_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagException of invalid_tag_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TagPolicyException of tag_policy_exception
+      | `ThrottlingException of throttling_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more tags to an ACM certificate. Tags are labels that you can use to identify and \
@@ -695,6 +710,20 @@ module CreateAcmeDomainValidation : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_acme_domain_validation_request ->
+    ( create_acme_domain_validation_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a domain validation for an ACME endpoint. Domain validations authorize the endpoint to \
@@ -716,6 +745,19 @@ module CreateAcmeEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     create_acme_endpoint_request ->
     ( create_acme_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_acme_endpoint_request ->
+    ( create_acme_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -755,6 +797,20 @@ module CreateAcmeExternalAccountBinding : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_acme_external_account_binding_request ->
+    ( create_acme_external_account_binding_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an external account binding (EAB) for an ACME endpoint. An EAB provides credentials \
@@ -775,6 +831,18 @@ module DeleteAcmeDomainValidation : sig
     'http_type Smaws_Lib.Context.t ->
     delete_acme_domain_validation_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_acme_domain_validation_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -808,6 +876,18 @@ module DeleteAcmeEndpoint : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_acme_endpoint_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an ACME endpoint. After deletion, the endpoint URL is no longer accessible and ACME \
@@ -827,6 +907,17 @@ module DeleteAcmeExternalAccountBinding : sig
     'http_type Smaws_Lib.Context.t ->
     delete_acme_external_account_binding_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_acme_external_account_binding_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -854,6 +945,20 @@ module DeleteCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     delete_certificate_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_certificate_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -909,6 +1014,18 @@ module DescribeAcmeAccount : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_acme_account_request ->
+    ( describe_acme_account_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed metadata about the specified ACME account, including its status, public key \
@@ -928,6 +1045,18 @@ module DescribeAcmeDomainValidation : sig
     'http_type Smaws_Lib.Context.t ->
     describe_acme_domain_validation_request ->
     ( describe_acme_domain_validation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_acme_domain_validation_request ->
+    ( describe_acme_domain_validation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -961,6 +1090,18 @@ module DescribeAcmeEndpoint : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_acme_endpoint_request ->
+    ( describe_acme_endpoint_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed metadata about the specified ACME endpoint, including its status, URL, \
@@ -980,6 +1121,18 @@ module DescribeAcmeExternalAccountBinding : sig
     'http_type Smaws_Lib.Context.t ->
     describe_acme_external_account_binding_request ->
     ( describe_acme_external_account_binding_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_acme_external_account_binding_request ->
+    ( describe_acme_external_account_binding_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1009,6 +1162,16 @@ module DescribeCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_certificate_request ->
+    ( describe_certificate_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed metadata about the specified ACM certificate.\n\n\
@@ -1030,6 +1193,18 @@ module ExportCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     export_certificate_request ->
     ( export_certificate_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `RequestInProgressException of request_in_progress_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    export_certificate_request ->
+    ( export_certificate_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `RequestInProgressException of request_in_progress_exception
@@ -1069,6 +1244,15 @@ module GetAccountConfiguration : sig
       | `AccessDeniedException of access_denied_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( get_account_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the account configuration options associated with an Amazon Web Services account.\n"]
@@ -1094,6 +1278,18 @@ module GetAcmeExternalAccountBindingCredentials : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_acme_external_account_binding_credentials_request ->
+    ( get_acme_external_account_binding_credentials_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the key ID and MAC key credentials for an external account binding. These credentials \
@@ -1112,6 +1308,17 @@ module GetCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     get_certificate_request ->
     ( get_certificate_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `RequestInProgressException of request_in_progress_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_certificate_request ->
+    ( get_certificate_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `RequestInProgressException of request_in_progress_exception
@@ -1146,6 +1353,22 @@ module ImportCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     import_certificate_request ->
     ( import_certificate_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagException of invalid_tag_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TagPolicyException of tag_policy_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_certificate_request ->
+    ( import_certificate_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArnException of invalid_arn_exception
@@ -1246,6 +1469,18 @@ module ListAcmeAccounts : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_acme_accounts_request ->
+    ( list_acme_accounts_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of ACME accounts registered with the specified ACME endpoint. ACME accounts \
@@ -1272,6 +1507,18 @@ module ListAcmeDomainValidations : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_acme_domain_validations_request ->
+    ( list_acme_domain_validations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves a list of domain validations for the specified ACME endpoint.\n"]
 
@@ -1288,6 +1535,17 @@ module ListAcmeEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     list_acme_endpoints_request ->
     ( list_acme_endpoints_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_acme_endpoints_request ->
+    ( list_acme_endpoints_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1320,6 +1578,18 @@ module ListAcmeExternalAccountBindings : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_acme_external_account_bindings_request ->
+    ( list_acme_external_account_bindings_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves a list of external account bindings for the specified ACME endpoint.\n"]
 
@@ -1334,6 +1604,15 @@ module ListCertificates : sig
     'http_type Smaws_Lib.Context.t ->
     list_certificates_request ->
     ( list_certificates_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgsException of invalid_args_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_certificates_request ->
+    ( list_certificates_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgsException of invalid_args_exception
       | `ValidationException of validation_exception ] )
@@ -1366,6 +1645,16 @@ module ListTagsForCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_certificate_request ->
+    ( list_tags_for_certificate_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the tags that have been applied to the ACM certificate. Use the certificate's Amazon \
@@ -1387,6 +1676,15 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
@@ -1420,6 +1718,17 @@ module PutAccountConfiguration : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_account_configuration_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or modifies account-level configurations in ACM. \n\n\
@@ -1445,6 +1754,20 @@ module RemoveTagsFromCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     remove_tags_from_certificate_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagException of invalid_tag_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TagPolicyException of tag_policy_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_from_certificate_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1487,6 +1810,17 @@ module RenewCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    renew_certificate_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `RequestInProgressException of request_in_progress_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Renews an {{:https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html}eligible ACM \
@@ -1513,6 +1847,20 @@ module RequestCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     request_certificate_request ->
     ( request_certificate_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidDomainValidationOptionsException of invalid_domain_validation_options_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagException of invalid_tag_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `TagPolicyException of tag_policy_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    request_certificate_request ->
+    ( request_certificate_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidDomainValidationOptionsException of invalid_domain_validation_options_exception
@@ -1564,6 +1912,18 @@ module ResendValidationEmail : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    resend_validation_email_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidDomainValidationOptionsException of invalid_domain_validation_options_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Resends the email that requests domain ownership validation. The domain owner or an authorized \
@@ -1600,6 +1960,19 @@ module RevokeAcmeAccount : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    revoke_acme_account_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Revokes an ACME account, preventing it from requesting or revoking certificates. This operation \
@@ -1620,6 +1993,19 @@ module RevokeAcmeExternalAccountBinding : sig
     'http_type Smaws_Lib.Context.t ->
     revoke_acme_external_account_binding_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    revoke_acme_external_account_binding_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1659,6 +2045,20 @@ module RevokeCertificate : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    revoke_certificate_request ->
+    ( revoke_certificate_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Revokes a public ACM certificate. You can only revoke certificates that have been previously \
@@ -1680,6 +2080,16 @@ module SearchCertificates : sig
     'http_type Smaws_Lib.Context.t ->
     search_certificates_request ->
     ( search_certificates_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    search_certificates_request ->
+    ( search_certificates_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ThrottlingException of throttling_exception
@@ -1709,6 +2119,16 @@ module TagResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more tags to an ACM resource. Tags are labels that you can use to identify and \
@@ -1732,6 +2152,15 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
@@ -1769,6 +2198,19 @@ module UpdateAcmeDomainValidation : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_acme_domain_validation_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates the prevalidation configuration of an existing domain validation.\n"]
 
@@ -1787,6 +2229,19 @@ module UpdateAcmeEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     update_acme_endpoint_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_acme_endpoint_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1815,6 +2270,18 @@ module UpdateCertificateOptions : sig
     'http_type Smaws_Lib.Context.t ->
     update_certificate_options_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidStateException of invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_certificate_options_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidStateException of invalid_state_exception

--- a/sdks/acm/Smaws_Client_ACM.mli
+++ b/sdks/acm/Smaws_Client_ACM.mli
@@ -662,7 +662,8 @@ module AddTagsToCertificate : sig
       | `TagPolicyException of tag_policy_exception
       | `ThrottlingException of throttling_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -722,7 +723,8 @@ module CreateAcmeDomainValidation : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -764,7 +766,8 @@ module CreateAcmeEndpoint : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -809,7 +812,8 @@ module CreateAcmeExternalAccountBinding : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -848,7 +852,8 @@ module DeleteAcmeDomainValidation : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -886,7 +891,8 @@ module DeleteAcmeEndpoint : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -922,7 +928,8 @@ module DeleteAcmeExternalAccountBinding : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -966,7 +973,8 @@ module DeleteCertificate : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1024,7 +1032,8 @@ module DescribeAcmeAccount : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1062,7 +1071,8 @@ module DescribeAcmeDomainValidation : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1100,7 +1110,8 @@ module DescribeAcmeEndpoint : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1138,7 +1149,8 @@ module DescribeAcmeExternalAccountBinding : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1170,7 +1182,8 @@ module DescribeCertificate : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1210,7 +1223,8 @@ module ExportCertificate : sig
       | `RequestInProgressException of request_in_progress_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1251,7 +1265,8 @@ module GetAccountConfiguration : sig
     ( get_account_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1288,7 +1303,8 @@ module GetAcmeExternalAccountBindingCredentials : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1323,7 +1339,8 @@ module GetCertificate : sig
       | `InvalidArnException of invalid_arn_exception
       | `RequestInProgressException of request_in_progress_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1378,7 +1395,8 @@ module ImportCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TagPolicyException of tag_policy_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1479,7 +1497,8 @@ module ListAcmeAccounts : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1517,7 +1536,8 @@ module ListAcmeDomainValidations : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of domain validations for the specified ACME endpoint.\n"]
@@ -1550,7 +1570,8 @@ module ListAcmeEndpoints : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1588,7 +1609,8 @@ module ListAcmeExternalAccountBindings : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of external account bindings for the specified ACME endpoint.\n"]
@@ -1615,7 +1637,8 @@ module ListCertificates : sig
     ( list_certificates_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgsException of invalid_args_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1653,7 +1676,8 @@ module ListTagsForCertificate : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1687,7 +1711,8 @@ module ListTagsForResource : sig
     ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1727,7 +1752,8 @@ module PutAccountConfiguration : sig
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1775,7 +1801,8 @@ module RemoveTagsFromCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TagPolicyException of tag_policy_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1819,7 +1846,8 @@ module RenewCertificate : sig
       | `InvalidArnException of invalid_arn_exception
       | `RequestInProgressException of request_in_progress_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1868,7 +1896,8 @@ module RequestCertificate : sig
       | `InvalidTagException of invalid_tag_exception
       | `LimitExceededException of limit_exceeded_exception
       | `TagPolicyException of tag_policy_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1922,7 +1951,8 @@ module ResendValidationEmail : sig
       | `InvalidDomainValidationOptionsException of invalid_domain_validation_options_exception
       | `InvalidStateException of invalid_state_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1971,7 +2001,8 @@ module RevokeAcmeAccount : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2012,7 +2043,8 @@ module RevokeAcmeExternalAccountBinding : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2057,7 +2089,8 @@ module RevokeCertificate : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2093,7 +2126,8 @@ module SearchCertificates : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2127,7 +2161,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2163,7 +2198,8 @@ module UntagResource : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2209,7 +2245,8 @@ module UpdateAcmeDomainValidation : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the prevalidation configuration of an existing domain validation.\n"]
@@ -2248,7 +2285,8 @@ module UpdateAcmeEndpoint : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2287,7 +2325,8 @@ module UpdateCertificateOptions : sig
       | `InvalidStateException of invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/acm/operations.ml
+++ b/sdks/acm/operations.ml
@@ -44,6 +44,13 @@ module AddTagsToCertificate = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_tags_to_certificate_request) =
+    let input = Json_serializers.add_tags_to_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.AddTagsToCertificate" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module CreateAcmeDomainValidation = struct
@@ -87,6 +94,13 @@ module CreateAcmeDomainValidation = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_acme_domain_validation_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_acme_domain_validation_request) =
+    let input = Json_serializers.create_acme_domain_validation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.CreateAcmeDomainValidation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_acme_domain_validation_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateAcmeEndpoint = struct
@@ -124,6 +138,13 @@ module CreateAcmeEndpoint = struct
     let input = Json_serializers.create_acme_endpoint_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.CreateAcmeEndpoint" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.create_acme_endpoint_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_acme_endpoint_request) =
+    let input = Json_serializers.create_acme_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.CreateAcmeEndpoint" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_acme_endpoint_response_of_yojson
       ~error_deserializer
 end
@@ -170,6 +191,14 @@ module CreateAcmeExternalAccountBinding = struct
       ~output_deserializer:
         Json_deserializers.create_acme_external_account_binding_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_acme_external_account_binding_request) =
+    let input = Json_serializers.create_acme_external_account_binding_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.CreateAcmeExternalAccountBinding" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.create_acme_external_account_binding_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteAcmeDomainValidation = struct
@@ -203,6 +232,13 @@ module DeleteAcmeDomainValidation = struct
     let input = Json_serializers.delete_acme_domain_validation_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.DeleteAcmeDomainValidation"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_acme_domain_validation_request) =
+    let input = Json_serializers.delete_acme_domain_validation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.DeleteAcmeDomainValidation" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -239,6 +275,13 @@ module DeleteAcmeEndpoint = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.DeleteAcmeEndpoint" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_acme_endpoint_request) =
+    let input = Json_serializers.delete_acme_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.DeleteAcmeEndpoint" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteAcmeExternalAccountBinding = struct
@@ -268,6 +311,13 @@ module DeleteAcmeExternalAccountBinding = struct
   let request context (request : delete_acme_external_account_binding_request) =
     let input = Json_serializers.delete_acme_external_account_binding_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"CertificateManager.DeleteAcmeExternalAccountBinding" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_acme_external_account_binding_request) =
+    let input = Json_serializers.delete_acme_external_account_binding_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"CertificateManager.DeleteAcmeExternalAccountBinding" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -311,6 +361,13 @@ module DeleteCertificate = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.DeleteCertificate" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_certificate_request) =
+    let input = Json_serializers.delete_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.DeleteCertificate" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DescribeAcmeAccount = struct
@@ -347,6 +404,13 @@ module DescribeAcmeAccount = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_acme_account_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_acme_account_request) =
+    let input = Json_serializers.describe_acme_account_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.DescribeAcmeAccount" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_acme_account_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAcmeDomainValidation = struct
@@ -380,6 +444,13 @@ module DescribeAcmeDomainValidation = struct
   let request context (request : describe_acme_domain_validation_request) =
     let input = Json_serializers.describe_acme_domain_validation_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"CertificateManager.DescribeAcmeDomainValidation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_acme_domain_validation_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_acme_domain_validation_request) =
+    let input = Json_serializers.describe_acme_domain_validation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"CertificateManager.DescribeAcmeDomainValidation" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_acme_domain_validation_response_of_yojson
       ~error_deserializer
@@ -419,6 +490,13 @@ module DescribeAcmeEndpoint = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_acme_endpoint_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_acme_endpoint_request) =
+    let input = Json_serializers.describe_acme_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.DescribeAcmeEndpoint" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_acme_endpoint_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAcmeExternalAccountBinding = struct
@@ -456,6 +534,14 @@ module DescribeAcmeExternalAccountBinding = struct
       ~output_deserializer:
         Json_deserializers.describe_acme_external_account_binding_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_acme_external_account_binding_request) =
+    let input = Json_serializers.describe_acme_external_account_binding_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.DescribeAcmeExternalAccountBinding" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_acme_external_account_binding_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeCertificate = struct
@@ -483,6 +569,13 @@ module DescribeCertificate = struct
     let input = Json_serializers.describe_certificate_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.DescribeCertificate"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_certificate_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_certificate_request) =
+    let input = Json_serializers.describe_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.DescribeCertificate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_certificate_response_of_yojson
       ~error_deserializer
 end
@@ -520,6 +613,13 @@ module ExportCertificate = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.ExportCertificate" ~service
       ~context ~input ~output_deserializer:Json_deserializers.export_certificate_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : export_certificate_request) =
+    let input = Json_serializers.export_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ExportCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.export_certificate_response_of_yojson
+      ~error_deserializer
 end
 
 module GetAccountConfiguration = struct
@@ -543,6 +643,13 @@ module GetAccountConfiguration = struct
     let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.GetAccountConfiguration"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_account_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.GetAccountConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_account_configuration_response_of_yojson
       ~error_deserializer
 end
@@ -585,6 +692,18 @@ module GetAcmeExternalAccountBindingCredentials = struct
       ~output_deserializer:
         Json_deserializers.get_acme_external_account_binding_credentials_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : get_acme_external_account_binding_credentials_request) =
+    let input =
+      Json_serializers.get_acme_external_account_binding_credentials_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.GetAcmeExternalAccountBindingCredentials" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.get_acme_external_account_binding_credentials_response_of_yojson
+      ~error_deserializer
 end
 
 module GetCertificate = struct
@@ -617,6 +736,12 @@ module GetCertificate = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.GetCertificate" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_certificate_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_certificate_request) =
+    let input = Json_serializers.get_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.GetCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_certificate_response_of_yojson ~error_deserializer
 end
 
 module ImportCertificate = struct
@@ -664,6 +789,13 @@ module ImportCertificate = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.ImportCertificate" ~service
       ~context ~input ~output_deserializer:Json_deserializers.import_certificate_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : import_certificate_request) =
+    let input = Json_serializers.import_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ImportCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.import_certificate_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAcmeAccounts = struct
@@ -698,6 +830,13 @@ module ListAcmeAccounts = struct
     let input = Json_serializers.list_acme_accounts_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.ListAcmeAccounts" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_acme_accounts_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_acme_accounts_request) =
+    let input = Json_serializers.list_acme_accounts_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ListAcmeAccounts" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_acme_accounts_response_of_yojson
       ~error_deserializer
 end
 
@@ -735,6 +874,13 @@ module ListAcmeDomainValidations = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_acme_domain_validations_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_acme_domain_validations_request) =
+    let input = Json_serializers.list_acme_domain_validations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ListAcmeDomainValidations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_acme_domain_validations_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAcmeEndpoints = struct
@@ -765,6 +911,13 @@ module ListAcmeEndpoints = struct
     let input = Json_serializers.list_acme_endpoints_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.ListAcmeEndpoints" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_acme_endpoints_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_acme_endpoints_request) =
+    let input = Json_serializers.list_acme_endpoints_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ListAcmeEndpoints" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_acme_endpoints_response_of_yojson
       ~error_deserializer
 end
 
@@ -802,6 +955,13 @@ module ListAcmeExternalAccountBindings = struct
       ~shape_name:"CertificateManager.ListAcmeExternalAccountBindings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_acme_external_account_bindings_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_acme_external_account_bindings_request) =
+    let input = Json_serializers.list_acme_external_account_bindings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ListAcmeExternalAccountBindings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_acme_external_account_bindings_response_of_yojson
+      ~error_deserializer
 end
 
 module ListCertificates = struct
@@ -825,6 +985,13 @@ module ListCertificates = struct
     let input = Json_serializers.list_certificates_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.ListCertificates" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_certificates_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_certificates_request) =
+    let input = Json_serializers.list_certificates_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ListCertificates" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_certificates_response_of_yojson
       ~error_deserializer
 end
 
@@ -855,6 +1022,13 @@ module ListTagsForCertificate = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_certificate_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_certificate_request) =
+    let input = Json_serializers.list_tags_for_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ListTagsForCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_certificate_response_of_yojson
+      ~error_deserializer
 end
 
 module ListTagsForResource = struct
@@ -879,6 +1053,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.ListTagsForResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
 end
@@ -910,6 +1091,13 @@ module PutAccountConfiguration = struct
     let input = Json_serializers.put_account_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.PutAccountConfiguration"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_account_configuration_request) =
+    let input = Json_serializers.put_account_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.PutAccountConfiguration" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -954,6 +1142,13 @@ module RemoveTagsFromCertificate = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : remove_tags_from_certificate_request) =
+    let input = Json_serializers.remove_tags_from_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.RemoveTagsFromCertificate" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module RenewCertificate = struct
@@ -985,6 +1180,13 @@ module RenewCertificate = struct
     let input = Json_serializers.renew_certificate_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.RenewCertificate" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : renew_certificate_request) =
+    let input = Json_serializers.renew_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.RenewCertificate" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1028,6 +1230,13 @@ module RequestCertificate = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.RequestCertificate" ~service
       ~context ~input ~output_deserializer:Json_deserializers.request_certificate_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : request_certificate_request) =
+    let input = Json_serializers.request_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.RequestCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.request_certificate_response_of_yojson
+      ~error_deserializer
 end
 
 module ResendValidationEmail = struct
@@ -1063,6 +1272,13 @@ module ResendValidationEmail = struct
     let input = Json_serializers.resend_validation_email_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.ResendValidationEmail"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : resend_validation_email_request) =
+    let input = Json_serializers.resend_validation_email_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.ResendValidationEmail" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -1103,6 +1319,13 @@ module RevokeAcmeAccount = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.RevokeAcmeAccount" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : revoke_acme_account_request) =
+    let input = Json_serializers.revoke_acme_account_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.RevokeAcmeAccount" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module RevokeAcmeExternalAccountBinding = struct
@@ -1139,6 +1362,13 @@ module RevokeAcmeExternalAccountBinding = struct
   let request context (request : revoke_acme_external_account_binding_request) =
     let input = Json_serializers.revoke_acme_external_account_binding_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"CertificateManager.RevokeAcmeExternalAccountBinding" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : revoke_acme_external_account_binding_request) =
+    let input = Json_serializers.revoke_acme_external_account_binding_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"CertificateManager.RevokeAcmeExternalAccountBinding" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -1182,6 +1412,13 @@ module RevokeCertificate = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.RevokeCertificate" ~service
       ~context ~input ~output_deserializer:Json_deserializers.revoke_certificate_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : revoke_certificate_request) =
+    let input = Json_serializers.revoke_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.RevokeCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.revoke_certificate_response_of_yojson
+      ~error_deserializer
 end
 
 module SearchCertificates = struct
@@ -1208,6 +1445,13 @@ module SearchCertificates = struct
     let input = Json_serializers.search_certificates_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.SearchCertificates" ~service
       ~context ~input ~output_deserializer:Json_deserializers.search_certificates_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : search_certificates_request) =
+    let input = Json_serializers.search_certificates_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.SearchCertificates" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.search_certificates_response_of_yojson
       ~error_deserializer
 end
 
@@ -1238,6 +1482,13 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.TagResource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CertificateManager.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1262,6 +1513,13 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.UntagResource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CertificateManager.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1302,6 +1560,13 @@ module UpdateAcmeDomainValidation = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_acme_domain_validation_request) =
+    let input = Json_serializers.update_acme_domain_validation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.UpdateAcmeDomainValidation" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UpdateAcmeEndpoint = struct
@@ -1340,6 +1605,13 @@ module UpdateAcmeEndpoint = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.UpdateAcmeEndpoint" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_acme_endpoint_request) =
+    let input = Json_serializers.update_acme_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.UpdateAcmeEndpoint" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UpdateCertificateOptions = struct
@@ -1373,6 +1645,13 @@ module UpdateCertificateOptions = struct
     let input = Json_serializers.update_certificate_options_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CertificateManager.UpdateCertificateOptions"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_certificate_options_request) =
+    let input = Json_serializers.update_certificate_options_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CertificateManager.UpdateCertificateOptions" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end

--- a/sdks/acm/operations.mli
+++ b/sdks/acm/operations.mli
@@ -27,6 +27,21 @@ module AddTagsToCertificate : sig
       | `TooManyTagsException of too_many_tags_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_to_certificate_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagException of invalid_tag_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TagPolicyException of tag_policy_exception
+      | `ThrottlingException of throttling_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more tags to an ACM certificate. Tags are labels that you can use to identify and \
@@ -73,6 +88,20 @@ module CreateAcmeDomainValidation : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_acme_domain_validation_request ->
+    ( create_acme_domain_validation_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a domain validation for an ACME endpoint. Domain validations authorize the endpoint to \
@@ -94,6 +123,19 @@ module CreateAcmeEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     create_acme_endpoint_request ->
     ( create_acme_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_acme_endpoint_request ->
+    ( create_acme_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -133,6 +175,20 @@ module CreateAcmeExternalAccountBinding : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_acme_external_account_binding_request ->
+    ( create_acme_external_account_binding_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an external account binding (EAB) for an ACME endpoint. An EAB provides credentials \
@@ -153,6 +209,18 @@ module DeleteAcmeDomainValidation : sig
     'http_type Smaws_Lib.Context.t ->
     delete_acme_domain_validation_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_acme_domain_validation_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -186,6 +254,18 @@ module DeleteAcmeEndpoint : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_acme_endpoint_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an ACME endpoint. After deletion, the endpoint URL is no longer accessible and ACME \
@@ -205,6 +285,17 @@ module DeleteAcmeExternalAccountBinding : sig
     'http_type Smaws_Lib.Context.t ->
     delete_acme_external_account_binding_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_acme_external_account_binding_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -232,6 +323,20 @@ module DeleteCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     delete_certificate_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_certificate_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -287,6 +392,18 @@ module DescribeAcmeAccount : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_acme_account_request ->
+    ( describe_acme_account_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed metadata about the specified ACME account, including its status, public key \
@@ -306,6 +423,18 @@ module DescribeAcmeDomainValidation : sig
     'http_type Smaws_Lib.Context.t ->
     describe_acme_domain_validation_request ->
     ( describe_acme_domain_validation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_acme_domain_validation_request ->
+    ( describe_acme_domain_validation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -339,6 +468,18 @@ module DescribeAcmeEndpoint : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_acme_endpoint_request ->
+    ( describe_acme_endpoint_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed metadata about the specified ACME endpoint, including its status, URL, \
@@ -358,6 +499,18 @@ module DescribeAcmeExternalAccountBinding : sig
     'http_type Smaws_Lib.Context.t ->
     describe_acme_external_account_binding_request ->
     ( describe_acme_external_account_binding_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_acme_external_account_binding_request ->
+    ( describe_acme_external_account_binding_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -387,6 +540,16 @@ module DescribeCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_certificate_request ->
+    ( describe_certificate_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed metadata about the specified ACM certificate.\n\n\
@@ -408,6 +571,18 @@ module ExportCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     export_certificate_request ->
     ( export_certificate_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `RequestInProgressException of request_in_progress_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    export_certificate_request ->
+    ( export_certificate_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `RequestInProgressException of request_in_progress_exception
@@ -447,6 +622,15 @@ module GetAccountConfiguration : sig
       | `AccessDeniedException of access_denied_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( get_account_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the account configuration options associated with an Amazon Web Services account.\n"]
@@ -472,6 +656,18 @@ module GetAcmeExternalAccountBindingCredentials : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_acme_external_account_binding_credentials_request ->
+    ( get_acme_external_account_binding_credentials_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the key ID and MAC key credentials for an external account binding. These credentials \
@@ -490,6 +686,17 @@ module GetCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     get_certificate_request ->
     ( get_certificate_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `RequestInProgressException of request_in_progress_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_certificate_request ->
+    ( get_certificate_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `RequestInProgressException of request_in_progress_exception
@@ -524,6 +731,22 @@ module ImportCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     import_certificate_request ->
     ( import_certificate_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagException of invalid_tag_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TagPolicyException of tag_policy_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_certificate_request ->
+    ( import_certificate_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArnException of invalid_arn_exception
@@ -624,6 +847,18 @@ module ListAcmeAccounts : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_acme_accounts_request ->
+    ( list_acme_accounts_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of ACME accounts registered with the specified ACME endpoint. ACME accounts \
@@ -650,6 +885,18 @@ module ListAcmeDomainValidations : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_acme_domain_validations_request ->
+    ( list_acme_domain_validations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves a list of domain validations for the specified ACME endpoint.\n"]
 
@@ -666,6 +913,17 @@ module ListAcmeEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     list_acme_endpoints_request ->
     ( list_acme_endpoints_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_acme_endpoints_request ->
+    ( list_acme_endpoints_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -698,6 +956,18 @@ module ListAcmeExternalAccountBindings : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_acme_external_account_bindings_request ->
+    ( list_acme_external_account_bindings_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves a list of external account bindings for the specified ACME endpoint.\n"]
 
@@ -712,6 +982,15 @@ module ListCertificates : sig
     'http_type Smaws_Lib.Context.t ->
     list_certificates_request ->
     ( list_certificates_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgsException of invalid_args_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_certificates_request ->
+    ( list_certificates_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgsException of invalid_args_exception
       | `ValidationException of validation_exception ] )
@@ -744,6 +1023,16 @@ module ListTagsForCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_certificate_request ->
+    ( list_tags_for_certificate_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the tags that have been applied to the ACM certificate. Use the certificate's Amazon \
@@ -765,6 +1054,15 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
@@ -798,6 +1096,17 @@ module PutAccountConfiguration : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_account_configuration_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or modifies account-level configurations in ACM. \n\n\
@@ -823,6 +1132,20 @@ module RemoveTagsFromCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     remove_tags_from_certificate_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagException of invalid_tag_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TagPolicyException of tag_policy_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_from_certificate_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -865,6 +1188,17 @@ module RenewCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    renew_certificate_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `RequestInProgressException of request_in_progress_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Renews an {{:https://docs.aws.amazon.com/acm/latest/userguide/managed-renewal.html}eligible ACM \
@@ -891,6 +1225,20 @@ module RequestCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     request_certificate_request ->
     ( request_certificate_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidDomainValidationOptionsException of invalid_domain_validation_options_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagException of invalid_tag_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `TagPolicyException of tag_policy_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    request_certificate_request ->
+    ( request_certificate_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidDomainValidationOptionsException of invalid_domain_validation_options_exception
@@ -942,6 +1290,18 @@ module ResendValidationEmail : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    resend_validation_email_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidDomainValidationOptionsException of invalid_domain_validation_options_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Resends the email that requests domain ownership validation. The domain owner or an authorized \
@@ -978,6 +1338,19 @@ module RevokeAcmeAccount : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    revoke_acme_account_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Revokes an ACME account, preventing it from requesting or revoking certificates. This operation \
@@ -998,6 +1371,19 @@ module RevokeAcmeExternalAccountBinding : sig
     'http_type Smaws_Lib.Context.t ->
     revoke_acme_external_account_binding_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    revoke_acme_external_account_binding_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1037,6 +1423,20 @@ module RevokeCertificate : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    revoke_certificate_request ->
+    ( revoke_certificate_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Revokes a public ACM certificate. You can only revoke certificates that have been previously \
@@ -1058,6 +1458,16 @@ module SearchCertificates : sig
     'http_type Smaws_Lib.Context.t ->
     search_certificates_request ->
     ( search_certificates_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    search_certificates_request ->
+    ( search_certificates_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ThrottlingException of throttling_exception
@@ -1087,6 +1497,16 @@ module TagResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more tags to an ACM resource. Tags are labels that you can use to identify and \
@@ -1110,6 +1530,15 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
@@ -1147,6 +1576,19 @@ module UpdateAcmeDomainValidation : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_acme_domain_validation_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates the prevalidation configuration of an existing domain validation.\n"]
 
@@ -1165,6 +1607,19 @@ module UpdateAcmeEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     update_acme_endpoint_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_acme_endpoint_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1192,6 +1647,18 @@ module UpdateCertificateOptions : sig
     'http_type Smaws_Lib.Context.t ->
     update_certificate_options_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidStateException of invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_certificate_options_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidStateException of invalid_state_exception

--- a/sdks/acm/operations.mli
+++ b/sdks/acm/operations.mli
@@ -40,7 +40,8 @@ module AddTagsToCertificate : sig
       | `TagPolicyException of tag_policy_exception
       | `ThrottlingException of throttling_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -100,7 +101,8 @@ module CreateAcmeDomainValidation : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -142,7 +144,8 @@ module CreateAcmeEndpoint : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -187,7 +190,8 @@ module CreateAcmeExternalAccountBinding : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -226,7 +230,8 @@ module DeleteAcmeDomainValidation : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -264,7 +269,8 @@ module DeleteAcmeEndpoint : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -300,7 +306,8 @@ module DeleteAcmeExternalAccountBinding : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -344,7 +351,8 @@ module DeleteCertificate : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -402,7 +410,8 @@ module DescribeAcmeAccount : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -440,7 +449,8 @@ module DescribeAcmeDomainValidation : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -478,7 +488,8 @@ module DescribeAcmeEndpoint : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -516,7 +527,8 @@ module DescribeAcmeExternalAccountBinding : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -548,7 +560,8 @@ module DescribeCertificate : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -588,7 +601,8 @@ module ExportCertificate : sig
       | `RequestInProgressException of request_in_progress_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -629,7 +643,8 @@ module GetAccountConfiguration : sig
     ( get_account_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -666,7 +681,8 @@ module GetAcmeExternalAccountBindingCredentials : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -701,7 +717,8 @@ module GetCertificate : sig
       | `InvalidArnException of invalid_arn_exception
       | `RequestInProgressException of request_in_progress_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -756,7 +773,8 @@ module ImportCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TagPolicyException of tag_policy_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -857,7 +875,8 @@ module ListAcmeAccounts : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -895,7 +914,8 @@ module ListAcmeDomainValidations : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of domain validations for the specified ACME endpoint.\n"]
@@ -928,7 +948,8 @@ module ListAcmeEndpoints : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -966,7 +987,8 @@ module ListAcmeExternalAccountBindings : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of external account bindings for the specified ACME endpoint.\n"]
@@ -993,7 +1015,8 @@ module ListCertificates : sig
     ( list_certificates_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgsException of invalid_args_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1031,7 +1054,8 @@ module ListTagsForCertificate : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1065,7 +1089,8 @@ module ListTagsForResource : sig
     ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1105,7 +1130,8 @@ module PutAccountConfiguration : sig
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1153,7 +1179,8 @@ module RemoveTagsFromCertificate : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TagPolicyException of tag_policy_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1197,7 +1224,8 @@ module RenewCertificate : sig
       | `InvalidArnException of invalid_arn_exception
       | `RequestInProgressException of request_in_progress_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1246,7 +1274,8 @@ module RequestCertificate : sig
       | `InvalidTagException of invalid_tag_exception
       | `LimitExceededException of limit_exceeded_exception
       | `TagPolicyException of tag_policy_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1300,7 +1329,8 @@ module ResendValidationEmail : sig
       | `InvalidDomainValidationOptionsException of invalid_domain_validation_options_exception
       | `InvalidStateException of invalid_state_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1349,7 +1379,8 @@ module RevokeAcmeAccount : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1390,7 +1421,8 @@ module RevokeAcmeExternalAccountBinding : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1435,7 +1467,8 @@ module RevokeCertificate : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1471,7 +1504,8 @@ module SearchCertificates : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1505,7 +1539,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1541,7 +1576,8 @@ module UntagResource : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1587,7 +1623,8 @@ module UpdateAcmeDomainValidation : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the prevalidation configuration of an existing domain validation.\n"]
@@ -1626,7 +1663,8 @@ module UpdateAcmeEndpoint : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1664,7 +1702,8 @@ module UpdateCertificateOptions : sig
       | `InvalidStateException of invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/apprunner/Smaws_Client_AppRunner.mli
+++ b/sdks/apprunner/Smaws_Client_AppRunner.mli
@@ -648,6 +648,16 @@ module AssociateCustomDomain : sig
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_custom_domain_request ->
+    ( associate_custom_domain_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associate your own domain name with the App Runner subdomain URL of your App Runner service.\n\n\
@@ -672,6 +682,16 @@ module CreateAutoScalingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     create_auto_scaling_configuration_request ->
     ( create_auto_scaling_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_auto_scaling_configuration_request ->
+    ( create_auto_scaling_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -712,6 +732,16 @@ module CreateConnection : sig
       | `InvalidRequestException of invalid_request_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_connection_request ->
+    ( create_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an App Runner connection resource. App Runner requires a connection resource when you \
@@ -734,6 +764,16 @@ module CreateObservabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     create_observability_configuration_request ->
     ( create_observability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_observability_configuration_request ->
+    ( create_observability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -774,6 +814,16 @@ module CreateService : sig
       | `InvalidRequestException of invalid_request_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_request ->
+    ( create_service_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an App Runner service. After the service is created, the action also automatically \
@@ -796,6 +846,16 @@ module CreateVpcConnector : sig
     'http_type Smaws_Lib.Context.t ->
     create_vpc_connector_request ->
     ( create_vpc_connector_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vpc_connector_request ->
+    ( create_vpc_connector_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -825,6 +885,17 @@ module CreateVpcIngressConnection : sig
       | `InvalidStateException of invalid_state_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vpc_ingress_connection_request ->
+    ( create_vpc_ingress_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an App Runner VPC Ingress Connection resource. App Runner requires this resource when \
@@ -842,6 +913,16 @@ module DeleteAutoScalingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_auto_scaling_configuration_request ->
     ( delete_auto_scaling_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_auto_scaling_configuration_request ->
+    ( delete_auto_scaling_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -871,6 +952,16 @@ module DeleteConnection : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_connection_request ->
+    ( delete_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Delete an App Runner connection. You must first ensure that there are no running App Runner \
@@ -888,6 +979,16 @@ module DeleteObservabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_observability_configuration_request ->
     ( delete_observability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_observability_configuration_request ->
+    ( delete_observability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -912,6 +1013,17 @@ module DeleteService : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_request ->
     ( delete_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_request ->
+    ( delete_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -946,6 +1058,16 @@ module DeleteVpcConnector : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vpc_connector_request ->
+    ( delete_vpc_connector_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Delete an App Runner VPC connector resource. You can't delete a connector that's used by one or \
@@ -964,6 +1086,17 @@ module DeleteVpcIngressConnection : sig
     'http_type Smaws_Lib.Context.t ->
     delete_vpc_ingress_connection_request ->
     ( delete_vpc_ingress_connection_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vpc_ingress_connection_request ->
+    ( delete_vpc_ingress_connection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1007,6 +1140,16 @@ module DescribeAutoScalingConfiguration : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_auto_scaling_configuration_request ->
+    ( describe_auto_scaling_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Return a full description of an App Runner automatic scaling configuration resource.\n"]
@@ -1023,6 +1166,16 @@ module DescribeCustomDomains : sig
     'http_type Smaws_Lib.Context.t ->
     describe_custom_domains_request ->
     ( describe_custom_domains_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_custom_domains_request ->
+    ( describe_custom_domains_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1049,6 +1202,16 @@ module DescribeObservabilityConfiguration : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_observability_configuration_request ->
+    ( describe_observability_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Return a full description of an App Runner observability configuration resource.\n"]
 
@@ -1064,6 +1227,16 @@ module DescribeService : sig
     'http_type Smaws_Lib.Context.t ->
     describe_service_request ->
     ( describe_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_service_request ->
+    ( describe_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1089,6 +1262,16 @@ module DescribeVpcConnector : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_vpc_connector_request ->
+    ( describe_vpc_connector_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Return a description of an App Runner VPC connector resource.\n"]
 
@@ -1104,6 +1287,16 @@ module DescribeVpcIngressConnection : sig
     'http_type Smaws_Lib.Context.t ->
     describe_vpc_ingress_connection_request ->
     ( describe_vpc_ingress_connection_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_vpc_ingress_connection_request ->
+    ( describe_vpc_ingress_connection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1125,6 +1318,17 @@ module DisassociateCustomDomain : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_custom_domain_request ->
     ( disassociate_custom_domain_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_custom_domain_request ->
+    ( disassociate_custom_domain_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1155,6 +1359,15 @@ module ListAutoScalingConfigurations : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_auto_scaling_configurations_request ->
+    ( list_auto_scaling_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of active App Runner automatic scaling configurations in your Amazon Web \
@@ -1180,6 +1393,15 @@ module ListConnections : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_connections_request ->
+    ( list_connections_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of App Runner connections that are associated with your Amazon Web Services \
@@ -1196,6 +1418,15 @@ module ListObservabilityConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     list_observability_configurations_request ->
     ( list_observability_configurations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_observability_configurations_request ->
+    ( list_observability_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
@@ -1227,6 +1458,16 @@ module ListOperations : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_operations_request ->
+    ( list_operations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Return a list of operations that occurred on an App Runner service.\n\n\
@@ -1249,6 +1490,15 @@ module ListServices : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_services_request ->
+    ( list_services_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of running App Runner services in your Amazon Web Services account.\n"]
 
@@ -1264,6 +1514,16 @@ module ListServicesForAutoScalingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     list_services_for_auto_scaling_configuration_request ->
     ( list_services_for_auto_scaling_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_services_for_auto_scaling_configuration_request ->
+    ( list_services_for_auto_scaling_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1292,6 +1552,17 @@ module ListTagsForResource : sig
       | `InvalidStateException of invalid_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "List tags that are associated with for an App Runner resource. The response contains a list of \
@@ -1308,6 +1579,15 @@ module ListVpcConnectors : sig
     'http_type Smaws_Lib.Context.t ->
     list_vpc_connectors_request ->
     ( list_vpc_connectors_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vpc_connectors_request ->
+    ( list_vpc_connectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
@@ -1330,6 +1610,15 @@ module ListVpcIngressConnections : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vpc_ingress_connections_request ->
+    ( list_vpc_ingress_connections_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
 end
 [@@ocaml.doc
   "Return a list of App Runner VPC Ingress Connections in your Amazon Web Services account.\n"]
@@ -1347,6 +1636,17 @@ module PauseService : sig
     'http_type Smaws_Lib.Context.t ->
     pause_service_request ->
     ( pause_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    pause_service_request ->
+    ( pause_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1380,6 +1680,17 @@ module ResumeService : sig
       | `InvalidStateException of invalid_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    resume_service_request ->
+    ( resume_service_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Resume an active App Runner service. App Runner provisions compute capacity for the service.\n\n\
@@ -1399,6 +1710,16 @@ module StartDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     start_deployment_request ->
     ( start_deployment_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_deployment_request ->
+    ( start_deployment_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1435,6 +1756,17 @@ module TagResource : sig
       | `InvalidStateException of invalid_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Add tags to, or update the tag values of, an App Runner resource. A tag is a key-value pair.\n"]
@@ -1452,6 +1784,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1478,6 +1821,16 @@ module UpdateDefaultAutoScalingConfiguration : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_default_auto_scaling_configuration_request ->
+    ( update_default_auto_scaling_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Update an auto scaling configuration to be the default. The existing default auto scaling \
@@ -1496,6 +1849,17 @@ module UpdateService : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_request ->
     ( update_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_request ->
+    ( update_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -1529,6 +1893,17 @@ module UpdateVpcIngressConnection : sig
     'http_type Smaws_Lib.Context.t ->
     update_vpc_ingress_connection_request ->
     ( update_vpc_ingress_connection_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_vpc_ingress_connection_request ->
+    ( update_vpc_ingress_connection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception

--- a/sdks/apprunner/Smaws_Client_AppRunner.mli
+++ b/sdks/apprunner/Smaws_Client_AppRunner.mli
@@ -656,7 +656,8 @@ module AssociateCustomDomain : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `InvalidStateException of invalid_state_exception ] )
+      | `InvalidStateException of invalid_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -695,7 +696,8 @@ module CreateAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -740,7 +742,8 @@ module CreateConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -777,7 +780,8 @@ module CreateObservabilityConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -822,7 +826,8 @@ module CreateService : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -859,7 +864,8 @@ module CreateVpcConnector : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -894,7 +900,8 @@ module CreateVpcIngressConnection : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -926,7 +933,8 @@ module DeleteAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -960,7 +968,8 @@ module DeleteConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -992,7 +1001,8 @@ module DeleteObservabilityConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1028,7 +1038,8 @@ module DeleteService : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1066,7 +1077,8 @@ module DeleteVpcConnector : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1101,7 +1113,8 @@ module DeleteVpcIngressConnection : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1148,7 +1161,8 @@ module DescribeAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1179,7 +1193,8 @@ module DescribeCustomDomains : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1210,7 +1225,8 @@ module DescribeObservabilityConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Return a full description of an App Runner observability configuration resource.\n"]
@@ -1240,7 +1256,8 @@ module DescribeService : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Return a full description of an App Runner service.\n"]
@@ -1270,7 +1287,8 @@ module DescribeVpcConnector : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Return a description of an App Runner VPC connector resource.\n"]
@@ -1300,7 +1318,8 @@ module DescribeVpcIngressConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Return a full description of an App Runner VPC Ingress Connection resource.\n"]
@@ -1333,7 +1352,8 @@ module DisassociateCustomDomain : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1366,7 +1386,8 @@ module ListAutoScalingConfigurations : sig
     ( list_auto_scaling_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1400,7 +1421,8 @@ module ListConnections : sig
     ( list_connections_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1429,7 +1451,8 @@ module ListObservabilityConfigurations : sig
     ( list_observability_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1466,7 +1489,8 @@ module ListOperations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1497,7 +1521,8 @@ module ListServices : sig
     ( list_services_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of running App Runner services in your Amazon Web Services account.\n"]
@@ -1527,7 +1552,8 @@ module ListServicesForAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1561,7 +1587,8 @@ module ListTagsForResource : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1590,7 +1617,8 @@ module ListVpcConnectors : sig
     ( list_vpc_connectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of App Runner VPC connectors in your Amazon Web Services account.\n"]
@@ -1617,7 +1645,8 @@ module ListVpcIngressConnections : sig
     ( list_vpc_ingress_connections_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1651,7 +1680,8 @@ module PauseService : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1689,7 +1719,8 @@ module ResumeService : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1723,7 +1754,8 @@ module StartDeployment : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1765,7 +1797,8 @@ module TagResource : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1799,7 +1832,8 @@ module UntagResource : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Remove tags from an App Runner resource.\n"]
@@ -1829,7 +1863,8 @@ module UpdateDefaultAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1864,7 +1899,8 @@ module UpdateService : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1908,7 +1944,8 @@ module UpdateVpcIngressConnection : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/apprunner/operations.ml
+++ b/sdks/apprunner/operations.ml
@@ -29,6 +29,13 @@ module AssociateCustomDomain = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.associate_custom_domain_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_custom_domain_request) =
+    let input = Json_serializers.associate_custom_domain_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.AssociateCustomDomain"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_custom_domain_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateAutoScalingConfiguration = struct
@@ -58,6 +65,13 @@ module CreateAutoScalingConfiguration = struct
     let input = Json_serializers.create_auto_scaling_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.CreateAutoScalingConfiguration"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_auto_scaling_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_auto_scaling_configuration_request) =
+    let input = Json_serializers.create_auto_scaling_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.CreateAutoScalingConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_auto_scaling_configuration_response_of_yojson
       ~error_deserializer
 end
@@ -90,6 +104,13 @@ module CreateConnection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.CreateConnection" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_connection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_connection_request) =
+    let input = Json_serializers.create_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.CreateConnection"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_connection_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateObservabilityConfiguration = struct
@@ -119,6 +140,13 @@ module CreateObservabilityConfiguration = struct
     let input = Json_serializers.create_observability_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.CreateObservabilityConfiguration"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_observability_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_observability_configuration_request) =
+    let input = Json_serializers.create_observability_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.CreateObservabilityConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_observability_configuration_response_of_yojson
       ~error_deserializer
 end
@@ -151,6 +179,12 @@ module CreateService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.CreateService" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_service_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_service_request) =
+    let input = Json_serializers.create_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.CreateService" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.create_service_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateVpcConnector = struct
@@ -180,6 +214,13 @@ module CreateVpcConnector = struct
     let input = Json_serializers.create_vpc_connector_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.CreateVpcConnector" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_vpc_connector_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_vpc_connector_request) =
+    let input = Json_serializers.create_vpc_connector_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.CreateVpcConnector"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_vpc_connector_response_of_yojson
       ~error_deserializer
 end
 
@@ -215,6 +256,13 @@ module CreateVpcIngressConnection = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_vpc_ingress_connection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_vpc_ingress_connection_request) =
+    let input = Json_serializers.create_vpc_ingress_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.CreateVpcIngressConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_vpc_ingress_connection_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteAutoScalingConfiguration = struct
@@ -244,6 +292,13 @@ module DeleteAutoScalingConfiguration = struct
     let input = Json_serializers.delete_auto_scaling_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.DeleteAutoScalingConfiguration"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_auto_scaling_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_auto_scaling_configuration_request) =
+    let input = Json_serializers.delete_auto_scaling_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.DeleteAutoScalingConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_auto_scaling_configuration_response_of_yojson
       ~error_deserializer
 end
@@ -276,6 +331,13 @@ module DeleteConnection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.DeleteConnection" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_connection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_connection_request) =
+    let input = Json_serializers.delete_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.DeleteConnection"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_connection_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteObservabilityConfiguration = struct
@@ -305,6 +367,13 @@ module DeleteObservabilityConfiguration = struct
     let input = Json_serializers.delete_observability_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.DeleteObservabilityConfiguration"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_observability_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_observability_configuration_request) =
+    let input = Json_serializers.delete_observability_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.DeleteObservabilityConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_observability_configuration_response_of_yojson
       ~error_deserializer
 end
@@ -340,6 +409,12 @@ module DeleteService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.DeleteService" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_service_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_service_request) =
+    let input = Json_serializers.delete_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.DeleteService" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.delete_service_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteVpcConnector = struct
@@ -369,6 +444,13 @@ module DeleteVpcConnector = struct
     let input = Json_serializers.delete_vpc_connector_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.DeleteVpcConnector" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_vpc_connector_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_vpc_connector_request) =
+    let input = Json_serializers.delete_vpc_connector_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.DeleteVpcConnector"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_vpc_connector_response_of_yojson
       ~error_deserializer
 end
 
@@ -404,6 +486,13 @@ module DeleteVpcIngressConnection = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.delete_vpc_ingress_connection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_vpc_ingress_connection_request) =
+    let input = Json_serializers.delete_vpc_ingress_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.DeleteVpcIngressConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_vpc_ingress_connection_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAutoScalingConfiguration = struct
@@ -435,6 +524,13 @@ module DescribeAutoScalingConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_auto_scaling_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_auto_scaling_configuration_request) =
+    let input = Json_serializers.describe_auto_scaling_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.DescribeAutoScalingConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_auto_scaling_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeCustomDomains = struct
@@ -464,6 +560,13 @@ module DescribeCustomDomains = struct
     let input = Json_serializers.describe_custom_domains_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.DescribeCustomDomains" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_custom_domains_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_custom_domains_request) =
+    let input = Json_serializers.describe_custom_domains_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.DescribeCustomDomains"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_custom_domains_response_of_yojson
       ~error_deserializer
 end
@@ -498,6 +601,14 @@ module DescribeObservabilityConfiguration = struct
       ~output_deserializer:
         Json_deserializers.describe_observability_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_observability_configuration_request) =
+    let input = Json_serializers.describe_observability_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.DescribeObservabilityConfiguration" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_observability_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeService = struct
@@ -527,6 +638,13 @@ module DescribeService = struct
     let input = Json_serializers.describe_service_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.DescribeService" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_service_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_service_request) =
+    let input = Json_serializers.describe_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.DescribeService"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_service_response_of_yojson
       ~error_deserializer
 end
 
@@ -559,6 +677,13 @@ module DescribeVpcConnector = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.describe_vpc_connector_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_vpc_connector_request) =
+    let input = Json_serializers.describe_vpc_connector_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.DescribeVpcConnector"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_vpc_connector_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeVpcIngressConnection = struct
@@ -588,6 +713,13 @@ module DescribeVpcIngressConnection = struct
     let input = Json_serializers.describe_vpc_ingress_connection_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.DescribeVpcIngressConnection"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_vpc_ingress_connection_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_vpc_ingress_connection_request) =
+    let input = Json_serializers.describe_vpc_ingress_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.DescribeVpcIngressConnection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_vpc_ingress_connection_response_of_yojson
       ~error_deserializer
 end
@@ -624,6 +756,13 @@ module DisassociateCustomDomain = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_custom_domain_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_custom_domain_request) =
+    let input = Json_serializers.disassociate_custom_domain_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.DisassociateCustomDomain" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_custom_domain_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAutoScalingConfigurations = struct
@@ -649,6 +788,13 @@ module ListAutoScalingConfigurations = struct
     let input = Json_serializers.list_auto_scaling_configurations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.ListAutoScalingConfigurations"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_auto_scaling_configurations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_auto_scaling_configurations_request) =
+    let input = Json_serializers.list_auto_scaling_configurations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.ListAutoScalingConfigurations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_auto_scaling_configurations_response_of_yojson
       ~error_deserializer
 end
@@ -677,6 +823,13 @@ module ListConnections = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.ListConnections" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_connections_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_connections_request) =
+    let input = Json_serializers.list_connections_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.ListConnections"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_connections_response_of_yojson
+      ~error_deserializer
 end
 
 module ListObservabilityConfigurations = struct
@@ -702,6 +855,13 @@ module ListObservabilityConfigurations = struct
     let input = Json_serializers.list_observability_configurations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.ListObservabilityConfigurations"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_observability_configurations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_observability_configurations_request) =
+    let input = Json_serializers.list_observability_configurations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.ListObservabilityConfigurations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_observability_configurations_response_of_yojson
       ~error_deserializer
 end
@@ -734,6 +894,12 @@ module ListOperations = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.ListOperations" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_operations_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_operations_request) =
+    let input = Json_serializers.list_operations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.ListOperations"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_operations_response_of_yojson ~error_deserializer
 end
 
 module ListServices = struct
@@ -759,6 +925,12 @@ module ListServices = struct
     let input = Json_serializers.list_services_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.ListServices" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_services_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_services_request) =
+    let input = Json_serializers.list_services_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.ListServices" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_services_response_of_yojson
       ~error_deserializer
 end
 
@@ -790,6 +962,17 @@ module ListServicesForAutoScalingConfiguration = struct
       Json_serializers.list_services_for_auto_scaling_configuration_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AppRunner.ListServicesForAutoScalingConfiguration" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.list_services_for_auto_scaling_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_services_for_auto_scaling_configuration_request)
+      =
+    let input =
+      Json_serializers.list_services_for_auto_scaling_configuration_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AppRunner.ListServicesForAutoScalingConfiguration" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.list_services_for_auto_scaling_configuration_response_of_yojson
@@ -828,6 +1011,13 @@ module ListTagsForResource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.ListTagsForResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module ListVpcConnectors = struct
@@ -854,6 +1044,13 @@ module ListVpcConnectors = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.ListVpcConnectors" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_vpc_connectors_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_vpc_connectors_request) =
+    let input = Json_serializers.list_vpc_connectors_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.ListVpcConnectors"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_vpc_connectors_response_of_yojson
+      ~error_deserializer
 end
 
 module ListVpcIngressConnections = struct
@@ -879,6 +1076,13 @@ module ListVpcIngressConnections = struct
     let input = Json_serializers.list_vpc_ingress_connections_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.ListVpcIngressConnections" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_vpc_ingress_connections_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_vpc_ingress_connections_request) =
+    let input = Json_serializers.list_vpc_ingress_connections_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.ListVpcIngressConnections" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_vpc_ingress_connections_response_of_yojson
       ~error_deserializer
 end
@@ -914,6 +1118,12 @@ module PauseService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.PauseService" ~service ~context
       ~input ~output_deserializer:Json_deserializers.pause_service_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : pause_service_request) =
+    let input = Json_serializers.pause_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.PauseService" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.pause_service_response_of_yojson
+      ~error_deserializer
 end
 
 module ResumeService = struct
@@ -947,6 +1157,12 @@ module ResumeService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.ResumeService" ~service ~context
       ~input ~output_deserializer:Json_deserializers.resume_service_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : resume_service_request) =
+    let input = Json_serializers.resume_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.ResumeService" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.resume_service_response_of_yojson
+      ~error_deserializer
 end
 
 module StartDeployment = struct
@@ -976,6 +1192,13 @@ module StartDeployment = struct
     let input = Json_serializers.start_deployment_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.StartDeployment" ~service ~context
       ~input ~output_deserializer:Json_deserializers.start_deployment_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_deployment_request) =
+    let input = Json_serializers.start_deployment_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.StartDeployment"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_deployment_response_of_yojson
       ~error_deserializer
 end
 
@@ -1009,6 +1232,12 @@ module TagResource = struct
     let input = Json_serializers.tag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.TagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.TagResource" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1042,6 +1271,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.UntagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.UntagResource" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateDefaultAutoScalingConfiguration = struct
@@ -1072,6 +1307,16 @@ module UpdateDefaultAutoScalingConfiguration = struct
       Json_serializers.update_default_auto_scaling_configuration_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AppRunner.UpdateDefaultAutoScalingConfiguration" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.update_default_auto_scaling_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_default_auto_scaling_configuration_request) =
+    let input =
+      Json_serializers.update_default_auto_scaling_configuration_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AppRunner.UpdateDefaultAutoScalingConfiguration" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.update_default_auto_scaling_configuration_response_of_yojson
@@ -1109,6 +1354,12 @@ module UpdateService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.UpdateService" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_service_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_service_request) =
+    let input = Json_serializers.update_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AppRunner.UpdateService" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.update_service_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateVpcIngressConnection = struct
@@ -1141,6 +1392,13 @@ module UpdateVpcIngressConnection = struct
     let input = Json_serializers.update_vpc_ingress_connection_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AppRunner.UpdateVpcIngressConnection" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_vpc_ingress_connection_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_vpc_ingress_connection_request) =
+    let input = Json_serializers.update_vpc_ingress_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AppRunner.UpdateVpcIngressConnection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_vpc_ingress_connection_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/apprunner/operations.mli
+++ b/sdks/apprunner/operations.mli
@@ -17,6 +17,16 @@ module AssociateCustomDomain : sig
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_custom_domain_request ->
+    ( associate_custom_domain_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associate your own domain name with the App Runner subdomain URL of your App Runner service.\n\n\
@@ -41,6 +51,16 @@ module CreateAutoScalingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     create_auto_scaling_configuration_request ->
     ( create_auto_scaling_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_auto_scaling_configuration_request ->
+    ( create_auto_scaling_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -81,6 +101,16 @@ module CreateConnection : sig
       | `InvalidRequestException of invalid_request_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_connection_request ->
+    ( create_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an App Runner connection resource. App Runner requires a connection resource when you \
@@ -103,6 +133,16 @@ module CreateObservabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     create_observability_configuration_request ->
     ( create_observability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_observability_configuration_request ->
+    ( create_observability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -143,6 +183,16 @@ module CreateService : sig
       | `InvalidRequestException of invalid_request_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_request ->
+    ( create_service_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an App Runner service. After the service is created, the action also automatically \
@@ -165,6 +215,16 @@ module CreateVpcConnector : sig
     'http_type Smaws_Lib.Context.t ->
     create_vpc_connector_request ->
     ( create_vpc_connector_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vpc_connector_request ->
+    ( create_vpc_connector_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -194,6 +254,17 @@ module CreateVpcIngressConnection : sig
       | `InvalidStateException of invalid_state_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vpc_ingress_connection_request ->
+    ( create_vpc_ingress_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an App Runner VPC Ingress Connection resource. App Runner requires this resource when \
@@ -211,6 +282,16 @@ module DeleteAutoScalingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_auto_scaling_configuration_request ->
     ( delete_auto_scaling_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_auto_scaling_configuration_request ->
+    ( delete_auto_scaling_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -240,6 +321,16 @@ module DeleteConnection : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_connection_request ->
+    ( delete_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Delete an App Runner connection. You must first ensure that there are no running App Runner \
@@ -257,6 +348,16 @@ module DeleteObservabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_observability_configuration_request ->
     ( delete_observability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_observability_configuration_request ->
+    ( delete_observability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -281,6 +382,17 @@ module DeleteService : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_request ->
     ( delete_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_request ->
+    ( delete_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -315,6 +427,16 @@ module DeleteVpcConnector : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vpc_connector_request ->
+    ( delete_vpc_connector_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Delete an App Runner VPC connector resource. You can't delete a connector that's used by one or \
@@ -333,6 +455,17 @@ module DeleteVpcIngressConnection : sig
     'http_type Smaws_Lib.Context.t ->
     delete_vpc_ingress_connection_request ->
     ( delete_vpc_ingress_connection_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vpc_ingress_connection_request ->
+    ( delete_vpc_ingress_connection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -376,6 +509,16 @@ module DescribeAutoScalingConfiguration : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_auto_scaling_configuration_request ->
+    ( describe_auto_scaling_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Return a full description of an App Runner automatic scaling configuration resource.\n"]
@@ -392,6 +535,16 @@ module DescribeCustomDomains : sig
     'http_type Smaws_Lib.Context.t ->
     describe_custom_domains_request ->
     ( describe_custom_domains_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_custom_domains_request ->
+    ( describe_custom_domains_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -418,6 +571,16 @@ module DescribeObservabilityConfiguration : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_observability_configuration_request ->
+    ( describe_observability_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Return a full description of an App Runner observability configuration resource.\n"]
 
@@ -433,6 +596,16 @@ module DescribeService : sig
     'http_type Smaws_Lib.Context.t ->
     describe_service_request ->
     ( describe_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_service_request ->
+    ( describe_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -458,6 +631,16 @@ module DescribeVpcConnector : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_vpc_connector_request ->
+    ( describe_vpc_connector_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Return a description of an App Runner VPC connector resource.\n"]
 
@@ -473,6 +656,16 @@ module DescribeVpcIngressConnection : sig
     'http_type Smaws_Lib.Context.t ->
     describe_vpc_ingress_connection_request ->
     ( describe_vpc_ingress_connection_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_vpc_ingress_connection_request ->
+    ( describe_vpc_ingress_connection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -494,6 +687,17 @@ module DisassociateCustomDomain : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_custom_domain_request ->
     ( disassociate_custom_domain_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_custom_domain_request ->
+    ( disassociate_custom_domain_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -524,6 +728,15 @@ module ListAutoScalingConfigurations : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_auto_scaling_configurations_request ->
+    ( list_auto_scaling_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of active App Runner automatic scaling configurations in your Amazon Web \
@@ -549,6 +762,15 @@ module ListConnections : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_connections_request ->
+    ( list_connections_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of App Runner connections that are associated with your Amazon Web Services \
@@ -565,6 +787,15 @@ module ListObservabilityConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     list_observability_configurations_request ->
     ( list_observability_configurations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_observability_configurations_request ->
+    ( list_observability_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
@@ -596,6 +827,16 @@ module ListOperations : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_operations_request ->
+    ( list_operations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Return a list of operations that occurred on an App Runner service.\n\n\
@@ -618,6 +859,15 @@ module ListServices : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_services_request ->
+    ( list_services_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of running App Runner services in your Amazon Web Services account.\n"]
 
@@ -633,6 +883,16 @@ module ListServicesForAutoScalingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     list_services_for_auto_scaling_configuration_request ->
     ( list_services_for_auto_scaling_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_services_for_auto_scaling_configuration_request ->
+    ( list_services_for_auto_scaling_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -661,6 +921,17 @@ module ListTagsForResource : sig
       | `InvalidStateException of invalid_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "List tags that are associated with for an App Runner resource. The response contains a list of \
@@ -677,6 +948,15 @@ module ListVpcConnectors : sig
     'http_type Smaws_Lib.Context.t ->
     list_vpc_connectors_request ->
     ( list_vpc_connectors_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vpc_connectors_request ->
+    ( list_vpc_connectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
@@ -699,6 +979,15 @@ module ListVpcIngressConnections : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vpc_ingress_connections_request ->
+    ( list_vpc_ingress_connections_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception ] )
+    result
 end
 [@@ocaml.doc
   "Return a list of App Runner VPC Ingress Connections in your Amazon Web Services account.\n"]
@@ -716,6 +1005,17 @@ module PauseService : sig
     'http_type Smaws_Lib.Context.t ->
     pause_service_request ->
     ( pause_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    pause_service_request ->
+    ( pause_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -749,6 +1049,17 @@ module ResumeService : sig
       | `InvalidStateException of invalid_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    resume_service_request ->
+    ( resume_service_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Resume an active App Runner service. App Runner provisions compute capacity for the service.\n\n\
@@ -768,6 +1079,16 @@ module StartDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     start_deployment_request ->
     ( start_deployment_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_deployment_request ->
+    ( start_deployment_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -804,6 +1125,17 @@ module TagResource : sig
       | `InvalidStateException of invalid_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Add tags to, or update the tag values of, an App Runner resource. A tag is a key-value pair.\n"]
@@ -821,6 +1153,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -847,6 +1190,16 @@ module UpdateDefaultAutoScalingConfiguration : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_default_auto_scaling_configuration_request ->
+    ( update_default_auto_scaling_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Update an auto scaling configuration to be the default. The existing default auto scaling \
@@ -865,6 +1218,17 @@ module UpdateService : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_request ->
     ( update_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_request ->
+    ( update_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
@@ -897,6 +1261,17 @@ module UpdateVpcIngressConnection : sig
     'http_type Smaws_Lib.Context.t ->
     update_vpc_ingress_connection_request ->
     ( update_vpc_ingress_connection_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceErrorException of internal_service_error_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `InvalidStateException of invalid_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_vpc_ingress_connection_request ->
+    ( update_vpc_ingress_connection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception

--- a/sdks/apprunner/operations.mli
+++ b/sdks/apprunner/operations.mli
@@ -25,7 +25,8 @@ module AssociateCustomDomain : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `InvalidStateException of invalid_state_exception ] )
+      | `InvalidStateException of invalid_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -64,7 +65,8 @@ module CreateAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -109,7 +111,8 @@ module CreateConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -146,7 +149,8 @@ module CreateObservabilityConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -191,7 +195,8 @@ module CreateService : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -228,7 +233,8 @@ module CreateVpcConnector : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -263,7 +269,8 @@ module CreateVpcIngressConnection : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ServiceQuotaExceededException of service_quota_exceeded_exception ] )
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -295,7 +302,8 @@ module DeleteAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -329,7 +337,8 @@ module DeleteConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -361,7 +370,8 @@ module DeleteObservabilityConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -397,7 +407,8 @@ module DeleteService : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -435,7 +446,8 @@ module DeleteVpcConnector : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -470,7 +482,8 @@ module DeleteVpcIngressConnection : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -517,7 +530,8 @@ module DescribeAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -548,7 +562,8 @@ module DescribeCustomDomains : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -579,7 +594,8 @@ module DescribeObservabilityConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Return a full description of an App Runner observability configuration resource.\n"]
@@ -609,7 +625,8 @@ module DescribeService : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Return a full description of an App Runner service.\n"]
@@ -639,7 +656,8 @@ module DescribeVpcConnector : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Return a description of an App Runner VPC connector resource.\n"]
@@ -669,7 +687,8 @@ module DescribeVpcIngressConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Return a full description of an App Runner VPC Ingress Connection resource.\n"]
@@ -702,7 +721,8 @@ module DisassociateCustomDomain : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -735,7 +755,8 @@ module ListAutoScalingConfigurations : sig
     ( list_auto_scaling_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -769,7 +790,8 @@ module ListConnections : sig
     ( list_connections_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -798,7 +820,8 @@ module ListObservabilityConfigurations : sig
     ( list_observability_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -835,7 +858,8 @@ module ListOperations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -866,7 +890,8 @@ module ListServices : sig
     ( list_services_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of running App Runner services in your Amazon Web Services account.\n"]
@@ -896,7 +921,8 @@ module ListServicesForAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -930,7 +956,8 @@ module ListTagsForResource : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -959,7 +986,8 @@ module ListVpcConnectors : sig
     ( list_vpc_connectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of App Runner VPC connectors in your Amazon Web Services account.\n"]
@@ -986,7 +1014,8 @@ module ListVpcIngressConnections : sig
     ( list_vpc_ingress_connections_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
-      | `InvalidRequestException of invalid_request_exception ] )
+      | `InvalidRequestException of invalid_request_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1020,7 +1049,8 @@ module PauseService : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1058,7 +1088,8 @@ module ResumeService : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1092,7 +1123,8 @@ module StartDeployment : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1134,7 +1166,8 @@ module TagResource : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1168,7 +1201,8 @@ module UntagResource : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Remove tags from an App Runner resource.\n"]
@@ -1198,7 +1232,8 @@ module UpdateDefaultAutoScalingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1233,7 +1268,8 @@ module UpdateService : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1276,7 +1312,8 @@ module UpdateVpcIngressConnection : sig
       | `InternalServiceErrorException of internal_service_error_exception
       | `InvalidRequestException of invalid_request_exception
       | `InvalidStateException of invalid_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/backup-gateway/Smaws_Client_BackupGateway.mli
+++ b/sdks/backup-gateway/Smaws_Client_BackupGateway.mli
@@ -303,7 +303,8 @@ module AssociateGatewayToServer : sig
     'http_type Smaws_Lib.Context.t ->
     associate_gateway_to_server_input ->
     ( associate_gateway_to_server_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `ConflictException of conflict_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `ConflictException of conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -321,7 +322,9 @@ module CreateGateway : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     create_gateway_input ->
-    (create_gateway_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( create_gateway_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "Creates a backup gateway. After you create a gateway, you can associate it with a server using \
@@ -346,7 +349,8 @@ module DeleteGateway : sig
     delete_gateway_input ->
     ( delete_gateway_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a backup gateway.\n"]
@@ -376,7 +380,8 @@ module DeleteHypervisor : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a hypervisor.\n"]
@@ -403,7 +408,8 @@ module DisassociateGatewayFromServer : sig
     ( disassociate_gateway_from_server_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -429,7 +435,8 @@ module GetBandwidthRateLimitSchedule : sig
     get_bandwidth_rate_limit_schedule_input ->
     ( get_bandwidth_rate_limit_schedule_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -456,7 +463,8 @@ module GetGateway : sig
     get_gateway_input ->
     ( get_gateway_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "By providing the ARN (Amazon Resource Name), this API returns the gateway.\n"]
@@ -480,7 +488,8 @@ module GetHypervisor : sig
     get_hypervisor_input ->
     ( get_hypervisor_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -507,7 +516,8 @@ module GetHypervisorPropertyMappings : sig
     get_hypervisor_property_mappings_input ->
     ( get_hypervisor_property_mappings_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -534,7 +544,8 @@ module GetVirtualMachine : sig
     get_virtual_machine_input ->
     ( get_virtual_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "By providing the ARN (Amazon Resource Name), this API returns the virtual machine.\n"]
@@ -561,7 +572,8 @@ module ImportHypervisorConfiguration : sig
     ( import_hypervisor_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
-      | `ConflictException of conflict_exception ] )
+      | `ConflictException of conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Connect to a hypervisor by importing its configuration.\n"]
@@ -577,7 +589,9 @@ module ListGateways : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     list_gateways_input ->
-    (list_gateways_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( list_gateways_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "Lists backup gateways owned by an Amazon Web Services account in an Amazon Web Services Region. \
@@ -594,7 +608,9 @@ module ListHypervisors : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     list_hypervisors_input ->
-    (list_hypervisors_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( list_hypervisors_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "Lists your hypervisors.\n"]
 
@@ -617,7 +633,8 @@ module ListTagsForResource : sig
     list_tags_for_resource_input ->
     ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -635,7 +652,7 @@ module ListVirtualMachines : sig
     'http_type Smaws_Lib.Context.t ->
     list_virtual_machines_input ->
     ( list_virtual_machines_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists your virtual machines.\n"]
@@ -659,7 +676,8 @@ module PutBandwidthRateLimitSchedule : sig
     put_bandwidth_rate_limit_schedule_input ->
     ( put_bandwidth_rate_limit_schedule_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -692,7 +710,8 @@ module PutHypervisorPropertyMappings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -722,7 +741,8 @@ module PutMaintenanceStartTime : sig
     ( put_maintenance_start_time_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Set the maintenance start time for a gateway.\n"]
@@ -749,7 +769,8 @@ module StartVirtualMachinesMetadataSync : sig
     ( start_virtual_machines_metadata_sync_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -774,7 +795,8 @@ module TagResource : sig
     tag_resource_input ->
     ( tag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Tag the resource.\n"]
@@ -801,7 +823,8 @@ module TestHypervisorConfiguration : sig
     ( test_hypervisor_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -827,7 +850,8 @@ module UntagResource : sig
     untag_resource_input ->
     ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tags from the resource.\n"]
@@ -854,7 +878,8 @@ module UpdateGatewayInformation : sig
     ( update_gateway_information_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -880,7 +905,8 @@ module UpdateGatewaySoftwareNow : sig
     update_gateway_software_now_input ->
     ( update_gateway_software_now_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -917,7 +943,8 @@ module UpdateHypervisor : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/backup-gateway/Smaws_Client_BackupGateway.mli
+++ b/sdks/backup-gateway/Smaws_Client_BackupGateway.mli
@@ -298,6 +298,13 @@ module AssociateGatewayToServer : sig
     ( associate_gateway_to_server_output,
       [> Smaws_Lib.Protocols.AwsJson.error | `ConflictException of conflict_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_gateway_to_server_input ->
+    ( associate_gateway_to_server_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `ConflictException of conflict_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates a backup gateway with your server. After you complete the association process, you \
@@ -310,6 +317,11 @@ module CreateGateway : sig
     'http_type Smaws_Lib.Context.t ->
     create_gateway_input ->
     (create_gateway_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_gateway_input ->
+    (create_gateway_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc
   "Creates a backup gateway. After you create a gateway, you can associate it with a server using \
@@ -325,6 +337,14 @@ module DeleteGateway : sig
     'http_type Smaws_Lib.Context.t ->
     delete_gateway_input ->
     ( delete_gateway_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_gateway_input ->
+    ( delete_gateway_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -348,6 +368,16 @@ module DeleteHypervisor : sig
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_hypervisor_input ->
+    ( delete_hypervisor_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a hypervisor.\n"]
 
@@ -362,6 +392,15 @@ module DisassociateGatewayFromServer : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_gateway_from_server_input ->
     ( disassociate_gateway_from_server_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_gateway_from_server_input ->
+    ( disassociate_gateway_from_server_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -384,6 +423,14 @@ module GetBandwidthRateLimitSchedule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bandwidth_rate_limit_schedule_input ->
+    ( get_bandwidth_rate_limit_schedule_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the bandwidth rate limit schedule for a specified gateway. By default, gateways do \
@@ -403,6 +450,14 @@ module GetGateway : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_gateway_input ->
+    ( get_gateway_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "By providing the ARN (Amazon Resource Name), this API returns the gateway.\n"]
 
@@ -416,6 +471,14 @@ module GetHypervisor : sig
     'http_type Smaws_Lib.Context.t ->
     get_hypervisor_input ->
     ( get_hypervisor_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_hypervisor_input ->
+    ( get_hypervisor_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -438,6 +501,14 @@ module GetHypervisorPropertyMappings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_hypervisor_property_mappings_input ->
+    ( get_hypervisor_property_mappings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "This action retrieves the property mappings for the specified hypervisor. A hypervisor property \
@@ -454,6 +525,14 @@ module GetVirtualMachine : sig
     'http_type Smaws_Lib.Context.t ->
     get_virtual_machine_input ->
     ( get_virtual_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_virtual_machine_input ->
+    ( get_virtual_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -475,6 +554,15 @@ module ImportHypervisorConfiguration : sig
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_hypervisor_configuration_input ->
+    ( import_hypervisor_configuration_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception ] )
+    result
 end
 [@@ocaml.doc "Connect to a hypervisor by importing its configuration.\n"]
 
@@ -485,6 +573,11 @@ module ListGateways : sig
     'http_type Smaws_Lib.Context.t ->
     list_gateways_input ->
     (list_gateways_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_gateways_input ->
+    (list_gateways_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc
   "Lists backup gateways owned by an Amazon Web Services account in an Amazon Web Services Region. \
@@ -497,6 +590,11 @@ module ListHypervisors : sig
     'http_type Smaws_Lib.Context.t ->
     list_hypervisors_input ->
     (list_hypervisors_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_hypervisors_input ->
+    (list_hypervisors_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc "Lists your hypervisors.\n"]
 
@@ -513,6 +611,14 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the tags applied to the resource identified by its Amazon Resource Name (ARN).\n"]
@@ -524,6 +630,13 @@ module ListVirtualMachines : sig
     'http_type Smaws_Lib.Context.t ->
     list_virtual_machines_input ->
     (list_virtual_machines_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_virtual_machines_input ->
+    ( list_virtual_machines_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc "Lists your virtual machines.\n"]
 
@@ -537,6 +650,14 @@ module PutBandwidthRateLimitSchedule : sig
     'http_type Smaws_Lib.Context.t ->
     put_bandwidth_rate_limit_schedule_input ->
     ( put_bandwidth_rate_limit_schedule_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_bandwidth_rate_limit_schedule_input ->
+    ( put_bandwidth_rate_limit_schedule_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -563,6 +684,16 @@ module PutHypervisorPropertyMappings : sig
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_hypervisor_property_mappings_input ->
+    ( put_hypervisor_property_mappings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "This action sets the property mappings for the specified hypervisor. A hypervisor property \
@@ -580,6 +711,15 @@ module PutMaintenanceStartTime : sig
     'http_type Smaws_Lib.Context.t ->
     put_maintenance_start_time_input ->
     ( put_maintenance_start_time_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_maintenance_start_time_input ->
+    ( put_maintenance_start_time_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -602,6 +742,15 @@ module StartVirtualMachinesMetadataSync : sig
       | `AccessDeniedException of access_denied_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_virtual_machines_metadata_sync_input ->
+    ( start_virtual_machines_metadata_sync_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "This action sends a request to sync metadata across the specified virtual machines.\n"]
@@ -619,6 +768,14 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Tag the resource.\n"]
 
@@ -633,6 +790,15 @@ module TestHypervisorConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     test_hypervisor_configuration_input ->
     ( test_hypervisor_configuration_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_hypervisor_configuration_input ->
+    ( test_hypervisor_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -655,6 +821,14 @@ module UntagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Removes tags from the resource.\n"]
 
@@ -669,6 +843,15 @@ module UpdateGatewayInformation : sig
     'http_type Smaws_Lib.Context.t ->
     update_gateway_information_input ->
     ( update_gateway_information_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_gateway_information_input ->
+    ( update_gateway_information_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -688,6 +871,14 @@ module UpdateGatewaySoftwareNow : sig
     'http_type Smaws_Lib.Context.t ->
     update_gateway_software_now_input ->
     ( update_gateway_software_now_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_gateway_software_now_input ->
+    ( update_gateway_software_now_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -713,6 +904,16 @@ module UpdateHypervisor : sig
     'http_type Smaws_Lib.Context.t ->
     update_hypervisor_input ->
     ( update_hypervisor_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_hypervisor_input ->
+    ( update_hypervisor_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/backup-gateway/operations.ml
+++ b/sdks/backup-gateway/operations.ml
@@ -21,6 +21,13 @@ module AssociateGatewayToServer = struct
       ~shape_name:"BackupOnPremises_v20210101.AssociateGatewayToServer" ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_gateway_to_server_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_gateway_to_server_input) =
+    let input = Json_serializers.associate_gateway_to_server_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.AssociateGatewayToServer" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_gateway_to_server_output_of_yojson
+      ~error_deserializer
 end
 
 module CreateGateway = struct
@@ -35,6 +42,12 @@ module CreateGateway = struct
     let input = Json_serializers.create_gateway_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.CreateGateway"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_gateway_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_gateway_input) =
+    let input = Json_serializers.create_gateway_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.CreateGateway" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_gateway_output_of_yojson ~error_deserializer
 end
 
@@ -57,6 +70,12 @@ module DeleteGateway = struct
     let input = Json_serializers.delete_gateway_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.DeleteGateway"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_gateway_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : delete_gateway_input) =
+    let input = Json_serializers.delete_gateway_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.DeleteGateway" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_gateway_output_of_yojson ~error_deserializer
 end
 
@@ -86,6 +105,12 @@ module DeleteHypervisor = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.DeleteHypervisor"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_hypervisor_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : delete_hypervisor_input) =
+    let input = Json_serializers.delete_hypervisor_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.DeleteHypervisor" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_hypervisor_output_of_yojson ~error_deserializer
 end
 
 module DisassociateGatewayFromServer = struct
@@ -109,6 +134,14 @@ module DisassociateGatewayFromServer = struct
   let request context (request : disassociate_gateway_from_server_input) =
     let input = Json_serializers.disassociate_gateway_from_server_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"BackupOnPremises_v20210101.DisassociateGatewayFromServer" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.disassociate_gateway_from_server_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_gateway_from_server_input) =
+    let input = Json_serializers.disassociate_gateway_from_server_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"BackupOnPremises_v20210101.DisassociateGatewayFromServer" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.disassociate_gateway_from_server_output_of_yojson
@@ -137,6 +170,14 @@ module GetBandwidthRateLimitSchedule = struct
       ~input
       ~output_deserializer:Json_deserializers.get_bandwidth_rate_limit_schedule_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_bandwidth_rate_limit_schedule_input) =
+    let input = Json_serializers.get_bandwidth_rate_limit_schedule_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.GetBandwidthRateLimitSchedule" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.get_bandwidth_rate_limit_schedule_output_of_yojson
+      ~error_deserializer
 end
 
 module GetGateway = struct
@@ -159,6 +200,12 @@ module GetGateway = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.GetGateway" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_gateway_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_gateway_input) =
+    let input = Json_serializers.get_gateway_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.GetGateway" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_gateway_output_of_yojson ~error_deserializer
 end
 
 module GetHypervisor = struct
@@ -180,6 +227,12 @@ module GetHypervisor = struct
     let input = Json_serializers.get_hypervisor_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.GetHypervisor"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_hypervisor_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_hypervisor_input) =
+    let input = Json_serializers.get_hypervisor_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.GetHypervisor" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_hypervisor_output_of_yojson ~error_deserializer
 end
 
@@ -205,6 +258,14 @@ module GetHypervisorPropertyMappings = struct
       ~input
       ~output_deserializer:Json_deserializers.get_hypervisor_property_mappings_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_hypervisor_property_mappings_input) =
+    let input = Json_serializers.get_hypervisor_property_mappings_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.GetHypervisorPropertyMappings" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.get_hypervisor_property_mappings_output_of_yojson
+      ~error_deserializer
 end
 
 module GetVirtualMachine = struct
@@ -226,6 +287,13 @@ module GetVirtualMachine = struct
     let input = Json_serializers.get_virtual_machine_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.GetVirtualMachine"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_virtual_machine_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_virtual_machine_input) =
+    let input = Json_serializers.get_virtual_machine_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.GetVirtualMachine" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_virtual_machine_output_of_yojson
       ~error_deserializer
 end
@@ -254,6 +322,14 @@ module ImportHypervisorConfiguration = struct
       ~input
       ~output_deserializer:Json_deserializers.import_hypervisor_configuration_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : import_hypervisor_configuration_input) =
+    let input = Json_serializers.import_hypervisor_configuration_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.ImportHypervisorConfiguration" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.import_hypervisor_configuration_output_of_yojson
+      ~error_deserializer
 end
 
 module ListGateways = struct
@@ -269,6 +345,12 @@ module ListGateways = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.ListGateways"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_gateways_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_gateways_input) =
+    let input = Json_serializers.list_gateways_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.ListGateways" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_gateways_output_of_yojson ~error_deserializer
 end
 
 module ListHypervisors = struct
@@ -283,6 +365,12 @@ module ListHypervisors = struct
     let input = Json_serializers.list_hypervisors_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.ListHypervisors"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_hypervisors_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_hypervisors_input) =
+    let input = Json_serializers.list_hypervisors_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.ListHypervisors" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_hypervisors_output_of_yojson ~error_deserializer
 end
 
@@ -307,6 +395,13 @@ module ListTagsForResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_input) =
+    let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
+      ~error_deserializer
 end
 
 module ListVirtualMachines = struct
@@ -321,6 +416,13 @@ module ListVirtualMachines = struct
     let input = Json_serializers.list_virtual_machines_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.ListVirtualMachines"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_virtual_machines_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_virtual_machines_input) =
+    let input = Json_serializers.list_virtual_machines_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.ListVirtualMachines" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_virtual_machines_output_of_yojson
       ~error_deserializer
 end
@@ -343,6 +445,14 @@ module PutBandwidthRateLimitSchedule = struct
   let request context (request : put_bandwidth_rate_limit_schedule_input) =
     let input = Json_serializers.put_bandwidth_rate_limit_schedule_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"BackupOnPremises_v20210101.PutBandwidthRateLimitSchedule" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.put_bandwidth_rate_limit_schedule_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_bandwidth_rate_limit_schedule_input) =
+    let input = Json_serializers.put_bandwidth_rate_limit_schedule_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"BackupOnPremises_v20210101.PutBandwidthRateLimitSchedule" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.put_bandwidth_rate_limit_schedule_output_of_yojson
@@ -377,6 +487,14 @@ module PutHypervisorPropertyMappings = struct
       ~input
       ~output_deserializer:Json_deserializers.put_hypervisor_property_mappings_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_hypervisor_property_mappings_input) =
+    let input = Json_serializers.put_hypervisor_property_mappings_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.PutHypervisorPropertyMappings" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.put_hypervisor_property_mappings_output_of_yojson
+      ~error_deserializer
 end
 
 module PutMaintenanceStartTime = struct
@@ -400,6 +518,13 @@ module PutMaintenanceStartTime = struct
   let request context (request : put_maintenance_start_time_input) =
     let input = Json_serializers.put_maintenance_start_time_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"BackupOnPremises_v20210101.PutMaintenanceStartTime" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_maintenance_start_time_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_maintenance_start_time_input) =
+    let input = Json_serializers.put_maintenance_start_time_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"BackupOnPremises_v20210101.PutMaintenanceStartTime" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_maintenance_start_time_output_of_yojson
       ~error_deserializer
@@ -430,6 +555,14 @@ module StartVirtualMachinesMetadataSync = struct
       ~input
       ~output_deserializer:Json_deserializers.start_virtual_machines_metadata_sync_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_virtual_machines_metadata_sync_input) =
+    let input = Json_serializers.start_virtual_machines_metadata_sync_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.StartVirtualMachinesMetadataSync" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.start_virtual_machines_metadata_sync_output_of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -452,6 +585,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.TagResource"
       ~service ~context ~input ~output_deserializer:Json_deserializers.tag_resource_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_input) =
+    let input = Json_serializers.tag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.TagResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_output_of_yojson ~error_deserializer
 end
 
 module TestHypervisorConfiguration = struct
@@ -478,6 +617,13 @@ module TestHypervisorConfiguration = struct
       ~shape_name:"BackupOnPremises_v20210101.TestHypervisorConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.test_hypervisor_configuration_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : test_hypervisor_configuration_input) =
+    let input = Json_serializers.test_hypervisor_configuration_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.TestHypervisorConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.test_hypervisor_configuration_output_of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -499,6 +645,12 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.UntagResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_input) =
+    let input = Json_serializers.untag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.UntagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.untag_resource_output_of_yojson ~error_deserializer
 end
 
@@ -526,6 +678,13 @@ module UpdateGatewayInformation = struct
       ~shape_name:"BackupOnPremises_v20210101.UpdateGatewayInformation" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_gateway_information_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_gateway_information_input) =
+    let input = Json_serializers.update_gateway_information_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.UpdateGatewayInformation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_gateway_information_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateGatewaySoftwareNow = struct
@@ -546,6 +705,13 @@ module UpdateGatewaySoftwareNow = struct
   let request context (request : update_gateway_software_now_input) =
     let input = Json_serializers.update_gateway_software_now_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"BackupOnPremises_v20210101.UpdateGatewaySoftwareNow" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_gateway_software_now_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_gateway_software_now_input) =
+    let input = Json_serializers.update_gateway_software_now_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"BackupOnPremises_v20210101.UpdateGatewaySoftwareNow" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_gateway_software_now_output_of_yojson
       ~error_deserializer
@@ -576,5 +742,11 @@ module UpdateHypervisor = struct
     let input = Json_serializers.update_hypervisor_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"BackupOnPremises_v20210101.UpdateHypervisor"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_hypervisor_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : update_hypervisor_input) =
+    let input = Json_serializers.update_hypervisor_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"BackupOnPremises_v20210101.UpdateHypervisor" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_hypervisor_output_of_yojson ~error_deserializer
 end

--- a/sdks/backup-gateway/operations.mli
+++ b/sdks/backup-gateway/operations.mli
@@ -15,7 +15,8 @@ module AssociateGatewayToServer : sig
     'http_type Smaws_Lib.Context.t ->
     associate_gateway_to_server_input ->
     ( associate_gateway_to_server_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `ConflictException of conflict_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `ConflictException of conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -33,7 +34,9 @@ module CreateGateway : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     create_gateway_input ->
-    (create_gateway_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( create_gateway_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "Creates a backup gateway. After you create a gateway, you can associate it with a server using \
@@ -58,7 +61,8 @@ module DeleteGateway : sig
     delete_gateway_input ->
     ( delete_gateway_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a backup gateway.\n"]
@@ -88,7 +92,8 @@ module DeleteHypervisor : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a hypervisor.\n"]
@@ -115,7 +120,8 @@ module DisassociateGatewayFromServer : sig
     ( disassociate_gateway_from_server_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -141,7 +147,8 @@ module GetBandwidthRateLimitSchedule : sig
     get_bandwidth_rate_limit_schedule_input ->
     ( get_bandwidth_rate_limit_schedule_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -168,7 +175,8 @@ module GetGateway : sig
     get_gateway_input ->
     ( get_gateway_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "By providing the ARN (Amazon Resource Name), this API returns the gateway.\n"]
@@ -192,7 +200,8 @@ module GetHypervisor : sig
     get_hypervisor_input ->
     ( get_hypervisor_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -219,7 +228,8 @@ module GetHypervisorPropertyMappings : sig
     get_hypervisor_property_mappings_input ->
     ( get_hypervisor_property_mappings_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -246,7 +256,8 @@ module GetVirtualMachine : sig
     get_virtual_machine_input ->
     ( get_virtual_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "By providing the ARN (Amazon Resource Name), this API returns the virtual machine.\n"]
@@ -273,7 +284,8 @@ module ImportHypervisorConfiguration : sig
     ( import_hypervisor_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
-      | `ConflictException of conflict_exception ] )
+      | `ConflictException of conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Connect to a hypervisor by importing its configuration.\n"]
@@ -289,7 +301,9 @@ module ListGateways : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     list_gateways_input ->
-    (list_gateways_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( list_gateways_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "Lists backup gateways owned by an Amazon Web Services account in an Amazon Web Services Region. \
@@ -306,7 +320,9 @@ module ListHypervisors : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     list_hypervisors_input ->
-    (list_hypervisors_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( list_hypervisors_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "Lists your hypervisors.\n"]
 
@@ -329,7 +345,8 @@ module ListTagsForResource : sig
     list_tags_for_resource_input ->
     ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -347,7 +364,7 @@ module ListVirtualMachines : sig
     'http_type Smaws_Lib.Context.t ->
     list_virtual_machines_input ->
     ( list_virtual_machines_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists your virtual machines.\n"]
@@ -371,7 +388,8 @@ module PutBandwidthRateLimitSchedule : sig
     put_bandwidth_rate_limit_schedule_input ->
     ( put_bandwidth_rate_limit_schedule_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -404,7 +422,8 @@ module PutHypervisorPropertyMappings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -434,7 +453,8 @@ module PutMaintenanceStartTime : sig
     ( put_maintenance_start_time_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Set the maintenance start time for a gateway.\n"]
@@ -461,7 +481,8 @@ module StartVirtualMachinesMetadataSync : sig
     ( start_virtual_machines_metadata_sync_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -486,7 +507,8 @@ module TagResource : sig
     tag_resource_input ->
     ( tag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Tag the resource.\n"]
@@ -513,7 +535,8 @@ module TestHypervisorConfiguration : sig
     ( test_hypervisor_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -539,7 +562,8 @@ module UntagResource : sig
     untag_resource_input ->
     ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tags from the resource.\n"]
@@ -566,7 +590,8 @@ module UpdateGatewayInformation : sig
     ( update_gateway_information_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -592,7 +617,8 @@ module UpdateGatewaySoftwareNow : sig
     update_gateway_software_now_input ->
     ( update_gateway_software_now_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -628,7 +654,8 @@ module UpdateHypervisor : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/backup-gateway/operations.mli
+++ b/sdks/backup-gateway/operations.mli
@@ -10,6 +10,13 @@ module AssociateGatewayToServer : sig
     ( associate_gateway_to_server_output,
       [> Smaws_Lib.Protocols.AwsJson.error | `ConflictException of conflict_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_gateway_to_server_input ->
+    ( associate_gateway_to_server_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `ConflictException of conflict_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates a backup gateway with your server. After you complete the association process, you \
@@ -22,6 +29,11 @@ module CreateGateway : sig
     'http_type Smaws_Lib.Context.t ->
     create_gateway_input ->
     (create_gateway_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_gateway_input ->
+    (create_gateway_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc
   "Creates a backup gateway. After you create a gateway, you can associate it with a server using \
@@ -37,6 +49,14 @@ module DeleteGateway : sig
     'http_type Smaws_Lib.Context.t ->
     delete_gateway_input ->
     ( delete_gateway_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_gateway_input ->
+    ( delete_gateway_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -60,6 +80,16 @@ module DeleteHypervisor : sig
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_hypervisor_input ->
+    ( delete_hypervisor_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a hypervisor.\n"]
 
@@ -74,6 +104,15 @@ module DisassociateGatewayFromServer : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_gateway_from_server_input ->
     ( disassociate_gateway_from_server_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_gateway_from_server_input ->
+    ( disassociate_gateway_from_server_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -96,6 +135,14 @@ module GetBandwidthRateLimitSchedule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bandwidth_rate_limit_schedule_input ->
+    ( get_bandwidth_rate_limit_schedule_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the bandwidth rate limit schedule for a specified gateway. By default, gateways do \
@@ -115,6 +162,14 @@ module GetGateway : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_gateway_input ->
+    ( get_gateway_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "By providing the ARN (Amazon Resource Name), this API returns the gateway.\n"]
 
@@ -128,6 +183,14 @@ module GetHypervisor : sig
     'http_type Smaws_Lib.Context.t ->
     get_hypervisor_input ->
     ( get_hypervisor_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_hypervisor_input ->
+    ( get_hypervisor_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -150,6 +213,14 @@ module GetHypervisorPropertyMappings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_hypervisor_property_mappings_input ->
+    ( get_hypervisor_property_mappings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "This action retrieves the property mappings for the specified hypervisor. A hypervisor property \
@@ -166,6 +237,14 @@ module GetVirtualMachine : sig
     'http_type Smaws_Lib.Context.t ->
     get_virtual_machine_input ->
     ( get_virtual_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_virtual_machine_input ->
+    ( get_virtual_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -187,6 +266,15 @@ module ImportHypervisorConfiguration : sig
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_hypervisor_configuration_input ->
+    ( import_hypervisor_configuration_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception ] )
+    result
 end
 [@@ocaml.doc "Connect to a hypervisor by importing its configuration.\n"]
 
@@ -197,6 +285,11 @@ module ListGateways : sig
     'http_type Smaws_Lib.Context.t ->
     list_gateways_input ->
     (list_gateways_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_gateways_input ->
+    (list_gateways_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc
   "Lists backup gateways owned by an Amazon Web Services account in an Amazon Web Services Region. \
@@ -209,6 +302,11 @@ module ListHypervisors : sig
     'http_type Smaws_Lib.Context.t ->
     list_hypervisors_input ->
     (list_hypervisors_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_hypervisors_input ->
+    (list_hypervisors_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc "Lists your hypervisors.\n"]
 
@@ -225,6 +323,14 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the tags applied to the resource identified by its Amazon Resource Name (ARN).\n"]
@@ -236,6 +342,13 @@ module ListVirtualMachines : sig
     'http_type Smaws_Lib.Context.t ->
     list_virtual_machines_input ->
     (list_virtual_machines_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_virtual_machines_input ->
+    ( list_virtual_machines_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc "Lists your virtual machines.\n"]
 
@@ -249,6 +362,14 @@ module PutBandwidthRateLimitSchedule : sig
     'http_type Smaws_Lib.Context.t ->
     put_bandwidth_rate_limit_schedule_input ->
     ( put_bandwidth_rate_limit_schedule_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_bandwidth_rate_limit_schedule_input ->
+    ( put_bandwidth_rate_limit_schedule_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -275,6 +396,16 @@ module PutHypervisorPropertyMappings : sig
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_hypervisor_property_mappings_input ->
+    ( put_hypervisor_property_mappings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "This action sets the property mappings for the specified hypervisor. A hypervisor property \
@@ -292,6 +423,15 @@ module PutMaintenanceStartTime : sig
     'http_type Smaws_Lib.Context.t ->
     put_maintenance_start_time_input ->
     ( put_maintenance_start_time_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_maintenance_start_time_input ->
+    ( put_maintenance_start_time_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -314,6 +454,15 @@ module StartVirtualMachinesMetadataSync : sig
       | `AccessDeniedException of access_denied_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_virtual_machines_metadata_sync_input ->
+    ( start_virtual_machines_metadata_sync_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "This action sends a request to sync metadata across the specified virtual machines.\n"]
@@ -331,6 +480,14 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Tag the resource.\n"]
 
@@ -345,6 +502,15 @@ module TestHypervisorConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     test_hypervisor_configuration_input ->
     ( test_hypervisor_configuration_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_hypervisor_configuration_input ->
+    ( test_hypervisor_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -367,6 +533,14 @@ module UntagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Removes tags from the resource.\n"]
 
@@ -381,6 +555,15 @@ module UpdateGatewayInformation : sig
     'http_type Smaws_Lib.Context.t ->
     update_gateway_information_input ->
     ( update_gateway_information_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_gateway_information_input ->
+    ( update_gateway_information_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -400,6 +583,14 @@ module UpdateGatewaySoftwareNow : sig
     'http_type Smaws_Lib.Context.t ->
     update_gateway_software_now_input ->
     ( update_gateway_software_now_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_gateway_software_now_input ->
+    ( update_gateway_software_now_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -424,6 +615,16 @@ module UpdateHypervisor : sig
     'http_type Smaws_Lib.Context.t ->
     update_hypervisor_input ->
     ( update_hypervisor_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_hypervisor_input ->
+    ( update_hypervisor_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/cloudtrail/Smaws_Client_CloudTrail.mli
+++ b/sdks/cloudtrail/Smaws_Client_CloudTrail.mli
@@ -1035,6 +1035,29 @@ module AddTags : sig
       | `TagsLimitExceededException of tags_limit_exceeded_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_request ->
+    ( add_tags_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `TagsLimitExceededException of tags_limit_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more tags to a trail, event data store, dashboard, or channel, up to a limit of 50. \
@@ -1064,6 +1087,23 @@ module CancelQuery : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_query_request ->
     ( cancel_query_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InactiveQueryException of inactive_query_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `QueryIdNotFoundException of query_id_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_query_request ->
+    ( cancel_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
@@ -1118,6 +1158,25 @@ module CreateChannel : sig
       | `TagsLimitExceededException of tags_limit_exceeded_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_channel_request ->
+    ( create_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelAlreadyExistsException of channel_already_exists_exception
+      | `ChannelMaxLimitExceededException of channel_max_limit_exceeded_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidSourceException of invalid_source_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TagsLimitExceededException of tags_limit_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a channel for CloudTrail to ingest events from a partner or external source. After you \
@@ -1141,6 +1200,21 @@ module CreateDashboard : sig
     'http_type Smaws_Lib.Context.t ->
     create_dashboard_request ->
     ( create_dashboard_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidQueryStatementException of invalid_query_statement_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_dashboard_request ->
+    ( create_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -1215,6 +1289,34 @@ module CreateEventDataStore : sig
     'http_type Smaws_Lib.Context.t ->
     create_event_data_store_request ->
     ( create_event_data_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreAlreadyExistsException of event_data_store_already_exists_exception
+      | `EventDataStoreMaxLimitExceededException of event_data_store_max_limit_exceeded_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidEventSelectorsException of invalid_event_selectors_exception
+      | `InvalidKmsKeyIdException of invalid_kms_key_id_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `KmsException of kms_exception
+      | `KmsKeyNotFoundException of kms_key_not_found_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `ThrottlingException of throttling_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_event_data_store_request ->
+    ( create_event_data_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
       | `ConflictException of conflict_exception
@@ -1323,6 +1425,50 @@ module CreateTrail : sig
       | `TrailNotProvidedException of trail_not_provided_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_trail_request ->
+    ( create_trail_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `CloudTrailInvalidClientTokenIdException of cloud_trail_invalid_client_token_id_exception
+      | `CloudWatchLogsDeliveryUnavailableException of
+        cloud_watch_logs_delivery_unavailable_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InsufficientS3BucketPolicyException of insufficient_s3_bucket_policy_exception
+      | `InsufficientSnsTopicPolicyException of insufficient_sns_topic_policy_exception
+      | `InvalidCloudWatchLogsLogGroupArnException of
+        invalid_cloud_watch_logs_log_group_arn_exception
+      | `InvalidCloudWatchLogsRoleArnException of invalid_cloud_watch_logs_role_arn_exception
+      | `InvalidKmsKeyIdException of invalid_kms_key_id_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidS3BucketNameException of invalid_s3_bucket_name_exception
+      | `InvalidS3PrefixException of invalid_s3_prefix_exception
+      | `InvalidSnsTopicNameException of invalid_sns_topic_name_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `KmsException of kms_exception
+      | `KmsKeyDisabledException of kms_key_disabled_exception
+      | `KmsKeyNotFoundException of kms_key_not_found_exception
+      | `MaximumNumberOfTrailsExceededException of maximum_number_of_trails_exceeded_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
+      | `TagsLimitExceededException of tags_limit_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailAlreadyExistsException of trail_already_exists_exception
+      | `TrailNotProvidedException of trail_not_provided_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a trail that specifies the settings for delivery of log data to an Amazon S3 bucket. \n"]
@@ -1346,6 +1492,17 @@ module DeleteChannel : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_channel_request ->
+    ( delete_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a channel.\n"]
 
@@ -1361,6 +1518,16 @@ module DeleteDashboard : sig
     'http_type Smaws_Lib.Context.t ->
     delete_dashboard_request ->
     ( delete_dashboard_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_dashboard_request ->
+    ( delete_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1396,6 +1563,29 @@ module DeleteEventDataStore : sig
     'http_type Smaws_Lib.Context.t ->
     delete_event_data_store_request ->
     ( delete_event_data_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelExistsForEDSException of channel_exists_for_eds_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreFederationEnabledException of event_data_store_federation_enabled_exception
+      | `EventDataStoreHasOngoingImportException of event_data_store_has_ongoing_import_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `EventDataStoreTerminationProtectedException of
+        event_data_store_termination_protected_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_event_data_store_request ->
+    ( delete_event_data_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ChannelExistsForEDSException of channel_exists_for_eds_exception
       | `ConflictException of conflict_exception
@@ -1453,6 +1643,20 @@ module DeleteResourcePolicy : sig
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_policy_request ->
+    ( delete_resource_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceARNNotValidException of resource_arn_not_valid_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Deletes the resource-based policy attached to the CloudTrail event data store, dashboard, or \
@@ -1479,6 +1683,25 @@ module DeleteTrail : sig
     'http_type Smaws_Lib.Context.t ->
     delete_trail_request ->
     ( delete_trail_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_trail_request ->
+    ( delete_trail_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `ConflictException of conflict_exception
@@ -1547,6 +1770,26 @@ module DeregisterOrganizationDelegatedAdmin : sig
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_organization_delegated_admin_request ->
+    ( deregister_organization_delegated_admin_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccountNotFoundException of account_not_found_exception
+      | `AccountNotRegisteredException of account_not_registered_exception
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotOrganizationManagementAccountException of not_organization_management_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes CloudTrail delegated administrator permissions from a member account in an organization.\n"]
@@ -1568,6 +1811,21 @@ module DescribeQuery : sig
     'http_type Smaws_Lib.Context.t ->
     describe_query_request ->
     ( describe_query_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `QueryIdNotFoundException of query_id_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_query_request ->
+    ( describe_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -1609,6 +1867,18 @@ module DescribeTrails : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_trails_request ->
+    ( describe_trails_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves settings for one or more trails associated with the current Region for your account.\n"]
@@ -1637,6 +1907,29 @@ module DisableFederation : sig
     'http_type Smaws_Lib.Context.t ->
     disable_federation_request ->
     ( disable_federation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_federation_request ->
+    ( disable_federation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
@@ -1708,6 +2001,30 @@ module EnableFederation : sig
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_federation_request ->
+    ( enable_federation_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreFederationEnabledException of event_data_store_federation_enabled_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Enables Lake query federation on the specified event data store. Federating an event data \
@@ -1746,6 +2063,21 @@ module GenerateQuery : sig
     'http_type Smaws_Lib.Context.t ->
     generate_query_request ->
     ( generate_query_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `GenerateResponseException of generate_response_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_query_request ->
+    ( generate_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -1796,6 +2128,17 @@ module GetChannel : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_channel_request ->
+    ( get_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc " Returns information about a specific channel. \n"]
 
@@ -1810,6 +2153,15 @@ module GetDashboard : sig
     'http_type Smaws_Lib.Context.t ->
     get_dashboard_request ->
     ( get_dashboard_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_dashboard_request ->
+    ( get_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
@@ -1838,6 +2190,25 @@ module GetEventConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     get_event_configuration_request ->
     ( get_event_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_event_configuration_request ->
+    ( get_event_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
@@ -1881,6 +2252,19 @@ module GetEventDataStore : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_event_data_store_request ->
+    ( get_event_data_store_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about an event data store specified as either an ARN or the ID portion of \
@@ -1901,6 +2285,19 @@ module GetEventSelectors : sig
     'http_type Smaws_Lib.Context.t ->
     get_event_selectors_request ->
     ( get_event_selectors_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_event_selectors_request ->
+    ( get_event_selectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `InvalidTrailNameException of invalid_trail_name_exception
@@ -1971,6 +2368,17 @@ module GetImport : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_import_request ->
+    ( get_import_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ImportNotFoundException of import_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc " Returns information about a specific import. \n"]
 
@@ -1993,6 +2401,23 @@ module GetInsightSelectors : sig
     'http_type Smaws_Lib.Context.t ->
     get_insight_selectors_request ->
     ( get_insight_selectors_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InsightNotEnabledException of insight_not_enabled_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_insight_selectors_request ->
+    ( get_insight_selectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `InsightNotEnabledException of insight_not_enabled_exception
@@ -2054,6 +2479,24 @@ module GetQueryResults : sig
       | `QueryIdNotFoundException of query_id_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_query_results_request ->
+    ( get_query_results_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidMaxResultsException of invalid_max_results_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `QueryIdNotFoundException of query_id_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets event data results of a query. You must specify the [QueryID] value returned by the \
@@ -2074,6 +2517,19 @@ module GetResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_policy_request ->
     ( get_resource_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceARNNotValidException of resource_arn_not_valid_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_policy_request ->
+    ( get_resource_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ResourceARNNotValidException of resource_arn_not_valid_exception
@@ -2108,6 +2564,18 @@ module GetTrail : sig
       | `TrailNotFoundException of trail_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_trail_request ->
+    ( get_trail_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns settings information for a specified trail.\n"]
 
@@ -2125,6 +2593,18 @@ module GetTrailStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_trail_status_request ->
     ( get_trail_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_trail_status_request ->
+    ( get_trail_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `InvalidTrailNameException of invalid_trail_name_exception
@@ -2156,6 +2636,16 @@ module ListChannels : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_channels_request ->
+    ( list_channels_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc " Lists the channels in the current account, and their source names. \n"]
 
@@ -2169,6 +2659,14 @@ module ListDashboards : sig
     'http_type Smaws_Lib.Context.t ->
     list_dashboards_request ->
     ( list_dashboards_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_dashboards_request ->
+    ( list_dashboards_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
@@ -2189,6 +2687,18 @@ module ListEventDataStores : sig
     'http_type Smaws_Lib.Context.t ->
     list_event_data_stores_request ->
     ( list_event_data_stores_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidMaxResultsException of invalid_max_results_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_event_data_stores_request ->
+    ( list_event_data_stores_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidMaxResultsException of invalid_max_results_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -2219,6 +2729,17 @@ module ListImportFailures : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_import_failures_request ->
+    ( list_import_failures_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc " Returns a list of failures for the specified import. \n"]
 
@@ -2243,6 +2764,18 @@ module ListImports : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_imports_request ->
+    ( list_imports_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Returns information on all imports, or a select set of imports by [ImportStatus] or \
@@ -2260,6 +2793,16 @@ module ListInsightsData : sig
     'http_type Smaws_Lib.Context.t ->
     list_insights_data_request ->
     ( list_insights_data_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_insights_data_request ->
+    ( list_insights_data_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
@@ -2302,6 +2845,17 @@ module ListInsightsMetricData : sig
     'http_type Smaws_Lib.Context.t ->
     list_insights_metric_data_request ->
     ( list_insights_metric_data_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_insights_metric_data_request ->
+    ( list_insights_metric_data_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidTrailNameException of invalid_trail_name_exception
@@ -2366,6 +2920,17 @@ module ListPublicKeys : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_public_keys_request ->
+    ( list_public_keys_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidTimeRangeException of invalid_time_range_exception
+      | `InvalidTokenException of invalid_token_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns all public keys whose private keys were used to sign the digest files within the \
@@ -2397,6 +2962,24 @@ module ListQueries : sig
     'http_type Smaws_Lib.Context.t ->
     list_queries_request ->
     ( list_queries_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidDateRangeException of invalid_date_range_exception
+      | `InvalidMaxResultsException of invalid_max_results_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidQueryStatusException of invalid_query_status_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_queries_request ->
+    ( list_queries_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -2453,6 +3036,25 @@ module ListTags : sig
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_request ->
+    ( list_tags_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidTokenException of invalid_token_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the tags for the specified trails, event data stores, dashboards, or channels in the \
@@ -2469,6 +3071,15 @@ module ListTrails : sig
     'http_type Smaws_Lib.Context.t ->
     list_trails_request ->
     ( list_trails_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_trails_request ->
+    ( list_trails_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
@@ -2492,6 +3103,20 @@ module LookupEvents : sig
     'http_type Smaws_Lib.Context.t ->
     lookup_events_request ->
     ( lookup_events_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidEventCategoryException of invalid_event_category_exception
+      | `InvalidLookupAttributesException of invalid_lookup_attributes_exception
+      | `InvalidMaxResultsException of invalid_max_results_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidTimeRangeException of invalid_time_range_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    lookup_events_request ->
+    ( lookup_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidEventCategoryException of invalid_event_category_exception
       | `InvalidLookupAttributesException of invalid_lookup_attributes_exception
@@ -2613,6 +3238,33 @@ module PutEventConfiguration : sig
       | `TrailNotFoundException of trail_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_event_configuration_request ->
+    ( put_event_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientIAMAccessPermissionException of insufficient_iam_access_permission_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the event configuration settings for the specified event data store or trail. This \
@@ -2641,6 +3293,26 @@ module PutEventSelectors : sig
     'http_type Smaws_Lib.Context.t ->
     put_event_selectors_request ->
     ( put_event_selectors_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidEventSelectorsException of invalid_event_selectors_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_event_selectors_request ->
+    ( put_event_selectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `ConflictException of conflict_exception
@@ -2778,6 +3450,29 @@ module PutInsightSelectors : sig
       | `TrailNotFoundException of trail_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_insight_selectors_request ->
+    ( put_insight_selectors_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InsufficientS3BucketPolicyException of insufficient_s3_bucket_policy_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidInsightSelectorsException of invalid_insight_selectors_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `KmsException of kms_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lets you enable Insights event logging on specific event categories by specifying the Insights \
@@ -2847,6 +3542,20 @@ module PutResourcePolicy : sig
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_policy_request ->
+    ( put_resource_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceARNNotValidException of resource_arn_not_valid_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyNotValidException of resource_policy_not_valid_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Attaches a resource-based permission policy to a CloudTrail event data store, dashboard, or \
@@ -2879,6 +3588,30 @@ module RegisterOrganizationDelegatedAdmin : sig
     'http_type Smaws_Lib.Context.t ->
     register_organization_delegated_admin_request ->
     ( register_organization_delegated_admin_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccountNotFoundException of account_not_found_exception
+      | `AccountRegisteredException of account_registered_exception
+      | `CannotDelegateManagementAccountException of cannot_delegate_management_account_exception
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConflictException of conflict_exception
+      | `DelegatedAdminAccountLimitExceededException of
+        delegated_admin_account_limit_exceeded_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientIAMAccessPermissionException of insufficient_iam_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotOrganizationManagementAccountException of not_organization_management_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_organization_delegated_admin_request ->
+    ( register_organization_delegated_admin_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccountNotFoundException of account_not_found_exception
       | `AccountRegisteredException of account_registered_exception
@@ -2945,6 +3678,28 @@ module RemoveTags : sig
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_request ->
+    ( remove_tags_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Removes the specified tags from a trail, event data store, dashboard, or channel.\n"]
 
@@ -2988,6 +3743,28 @@ module RestoreEventDataStore : sig
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_event_data_store_request ->
+    ( restore_event_data_store_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreMaxLimitExceededException of event_data_store_max_limit_exceeded_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Restores a deleted event data store specified by [EventDataStore], which accepts an event data \
@@ -3012,6 +3789,16 @@ module SearchSampleQueries : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    search_sample_queries_request ->
+    ( search_sample_queries_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Searches sample queries and returns a list of sample queries that are sorted by relevance. To \
@@ -3031,6 +3818,18 @@ module StartDashboardRefresh : sig
     'http_type Smaws_Lib.Context.t ->
     start_dashboard_refresh_request ->
     ( start_dashboard_refresh_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_dashboard_refresh_request ->
+    ( start_dashboard_refresh_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
       | `InactiveEventDataStoreException of inactive_event_data_store_exception
@@ -3084,6 +3883,25 @@ module StartEventDataStoreIngestion : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_event_data_store_ingestion_request ->
+    ( start_event_data_store_ingestion_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the ingestion of live events on an event data store specified as either an ARN or the ID \
@@ -3112,6 +3930,25 @@ module StartImport : sig
     'http_type Smaws_Lib.Context.t ->
     start_import_request ->
     ( start_import_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccountHasOngoingImportException of account_has_ongoing_import_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `ImportNotFoundException of import_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidImportSourceException of invalid_import_source_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_import_request ->
+    ( start_import_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccountHasOngoingImportException of account_has_ongoing_import_exception
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
@@ -3185,6 +4022,25 @@ module StartLogging : sig
       | `TrailNotFoundException of trail_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_logging_request ->
+    ( start_logging_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the recording of Amazon Web Services API calls and log file delivery for a trail. For a \
@@ -3215,6 +4071,27 @@ module StartQuery : sig
     'http_type Smaws_Lib.Context.t ->
     start_query_request ->
     ( start_query_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InsufficientS3BucketPolicyException of insufficient_s3_bucket_policy_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidQueryStatementException of invalid_query_statement_exception
+      | `InvalidS3BucketNameException of invalid_s3_bucket_name_exception
+      | `InvalidS3PrefixException of invalid_s3_prefix_exception
+      | `MaxConcurrentQueriesException of max_concurrent_queries_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_query_request ->
+    ( start_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -3276,6 +4153,25 @@ module StopEventDataStoreIngestion : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_event_data_store_ingestion_request ->
+    ( stop_event_data_store_ingestion_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops the ingestion of live events on an event data store specified as either an ARN or the ID \
@@ -3295,6 +4191,17 @@ module StopImport : sig
     'http_type Smaws_Lib.Context.t ->
     stop_import_request ->
     ( stop_import_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ImportNotFoundException of import_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_import_request ->
+    ( stop_import_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ImportNotFoundException of import_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -3325,6 +4232,25 @@ module StopLogging : sig
     'http_type Smaws_Lib.Context.t ->
     stop_logging_request ->
     ( stop_logging_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_logging_request ->
+    ( stop_logging_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `ConflictException of conflict_exception
@@ -3379,6 +4305,23 @@ module UpdateChannel : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_channel_request ->
+    ( update_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelAlreadyExistsException of channel_already_exists_exception
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates a channel specified by a required channel ARN or UUID.\n"]
 
@@ -3399,6 +4342,21 @@ module UpdateDashboard : sig
     'http_type Smaws_Lib.Context.t ->
     update_dashboard_request ->
     ( update_dashboard_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidQueryStatementException of invalid_query_statement_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_dashboard_request ->
+    ( update_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -3459,6 +4417,37 @@ module UpdateEventDataStore : sig
     'http_type Smaws_Lib.Context.t ->
     update_event_data_store_request ->
     ( update_event_data_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreAlreadyExistsException of event_data_store_already_exists_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreHasOngoingImportException of event_data_store_has_ongoing_import_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidEventSelectorsException of invalid_event_selectors_exception
+      | `InvalidInsightSelectorsException of invalid_insight_selectors_exception
+      | `InvalidKmsKeyIdException of invalid_kms_key_id_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `KmsException of kms_exception
+      | `KmsKeyNotFoundException of kms_key_not_found_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `ThrottlingException of throttling_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_event_data_store_request ->
+    ( update_event_data_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
       | `ConflictException of conflict_exception
@@ -3547,6 +4536,50 @@ module UpdateTrail : sig
     'http_type Smaws_Lib.Context.t ->
     update_trail_request ->
     ( update_trail_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `CloudTrailInvalidClientTokenIdException of cloud_trail_invalid_client_token_id_exception
+      | `CloudWatchLogsDeliveryUnavailableException of
+        cloud_watch_logs_delivery_unavailable_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InsufficientS3BucketPolicyException of insufficient_s3_bucket_policy_exception
+      | `InsufficientSnsTopicPolicyException of insufficient_sns_topic_policy_exception
+      | `InvalidCloudWatchLogsLogGroupArnException of
+        invalid_cloud_watch_logs_log_group_arn_exception
+      | `InvalidCloudWatchLogsRoleArnException of invalid_cloud_watch_logs_role_arn_exception
+      | `InvalidEventSelectorsException of invalid_event_selectors_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidKmsKeyIdException of invalid_kms_key_id_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidS3BucketNameException of invalid_s3_bucket_name_exception
+      | `InvalidS3PrefixException of invalid_s3_prefix_exception
+      | `InvalidSnsTopicNameException of invalid_sns_topic_name_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `KmsException of kms_exception
+      | `KmsKeyDisabledException of kms_key_disabled_exception
+      | `KmsKeyNotFoundException of kms_key_not_found_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `TrailNotProvidedException of trail_not_provided_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_trail_request ->
+    ( update_trail_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception

--- a/sdks/cloudtrail/Smaws_Client_CloudTrail.mli
+++ b/sdks/cloudtrail/Smaws_Client_CloudTrail.mli
@@ -1056,7 +1056,8 @@ module AddTags : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `TagsLimitExceededException of tags_limit_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1114,7 +1115,8 @@ module CancelQuery : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `QueryIdNotFoundException of query_id_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1175,7 +1177,8 @@ module CreateChannel : sig
       | `InvalidTagParameterException of invalid_tag_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TagsLimitExceededException of tags_limit_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1223,7 +1226,8 @@ module CreateDashboard : sig
       | `InvalidQueryStatementException of invalid_query_statement_exception
       | `InvalidTagParameterException of invalid_tag_parameter_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1338,7 +1342,8 @@ module CreateEventDataStore : sig
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `ThrottlingException of throttling_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a new event data store.\n"]
@@ -1467,7 +1472,8 @@ module CreateTrail : sig
       | `ThrottlingException of throttling_exception
       | `TrailAlreadyExistsException of trail_already_exists_exception
       | `TrailNotProvidedException of trail_not_provided_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1501,7 +1507,8 @@ module DeleteChannel : sig
       | `ChannelARNInvalidException of channel_arn_invalid_exception
       | `ChannelNotFoundException of channel_not_found_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a channel.\n"]
@@ -1531,7 +1538,8 @@ module DeleteDashboard : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1602,7 +1610,8 @@ module DeleteEventDataStore : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `NotOrganizationMasterAccountException of not_organization_master_account_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1655,7 +1664,8 @@ module DeleteResourcePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyNotFoundException of resource_policy_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1714,7 +1724,8 @@ module DeleteTrail : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1788,7 +1799,8 @@ module DeregisterOrganizationDelegatedAdmin : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1834,7 +1846,8 @@ module DescribeQuery : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `QueryIdNotFoundException of query_id_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1877,7 +1890,8 @@ module DescribeTrails : sig
       | `InvalidTrailNameException of invalid_trail_name_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1946,7 +1960,8 @@ module DisableFederation : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2023,7 +2038,8 @@ module EnableFederation : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2086,7 +2102,8 @@ module GenerateQuery : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2137,7 +2154,8 @@ module GetChannel : sig
       | `ChannelARNInvalidException of channel_arn_invalid_exception
       | `ChannelNotFoundException of channel_not_found_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns information about a specific channel. \n"]
@@ -2164,7 +2182,8 @@ module GetDashboard : sig
     ( get_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns the specified dashboard. \n"]
@@ -2221,7 +2240,8 @@ module GetEventConfiguration : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2263,7 +2283,8 @@ module GetEventDataStore : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2304,7 +2325,8 @@ module GetEventSelectors : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2377,7 +2399,8 @@ module GetImport : sig
       | `ImportNotFoundException of import_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns information about a specific import. \n"]
@@ -2428,7 +2451,8 @@ module GetInsightSelectors : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2495,7 +2519,8 @@ module GetQueryResults : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `QueryIdNotFoundException of query_id_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2536,7 +2561,8 @@ module GetResourcePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyNotFoundException of resource_policy_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2574,7 +2600,8 @@ module GetTrail : sig
       | `InvalidTrailNameException of invalid_trail_name_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns settings information for a specified trail.\n"]
@@ -2610,7 +2637,8 @@ module GetTrailStatus : sig
       | `InvalidTrailNameException of invalid_trail_name_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2644,7 +2672,8 @@ module ListChannels : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Lists the channels in the current account, and their source names. \n"]
@@ -2668,7 +2697,8 @@ module ListDashboards : sig
     list_dashboards_request ->
     ( list_dashboards_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns information about all dashboards in the account, in the current Region. \n"]
@@ -2704,7 +2734,8 @@ module ListEventDataStores : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2738,7 +2769,8 @@ module ListImportFailures : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns a list of failures for the specified import. \n"]
@@ -2774,7 +2806,8 @@ module ListImports : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2806,7 +2839,8 @@ module ListInsightsData : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2860,7 +2894,8 @@ module ListInsightsMetricData : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidTrailNameException of invalid_trail_name_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2929,7 +2964,8 @@ module ListPublicKeys : sig
       | `InvalidTimeRangeException of invalid_time_range_exception
       | `InvalidTokenException of invalid_token_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2991,7 +3027,8 @@ module ListQueries : sig
       | `InvalidQueryStatusException of invalid_query_status_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3053,7 +3090,8 @@ module ListTags : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3082,7 +3120,8 @@ module ListTrails : sig
     ( list_trails_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists trails that are in the current account.\n"]
@@ -3124,7 +3163,8 @@ module LookupEvents : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidTimeRangeException of invalid_time_range_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3263,7 +3303,8 @@ module PutEventConfiguration : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3326,7 +3367,8 @@ module PutEventSelectors : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3471,7 +3513,8 @@ module PutInsightSelectors : sig
       | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3554,7 +3597,8 @@ module PutResourcePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyNotValidException of resource_policy_not_valid_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3629,7 +3673,8 @@ module RegisterOrganizationDelegatedAdmin : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3698,7 +3743,8 @@ module RemoveTags : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the specified tags from a trail, event data store, dashboard, or channel.\n"]
@@ -3763,7 +3809,8 @@ module RestoreEventDataStore : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3797,7 +3844,8 @@ module SearchSampleQueries : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3835,7 +3883,8 @@ module StartDashboardRefresh : sig
       | `InactiveEventDataStoreException of inactive_event_data_store_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3900,7 +3949,8 @@ module StartEventDataStoreIngestion : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `NotOrganizationMasterAccountException of not_organization_master_account_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3961,7 +4011,8 @@ module StartImport : sig
       | `InvalidImportSourceException of invalid_import_source_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4039,7 +4090,8 @@ module StartLogging : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4106,7 +4158,8 @@ module StartQuery : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4170,7 +4223,8 @@ module StopEventDataStoreIngestion : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `NotOrganizationMasterAccountException of not_organization_master_account_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4206,7 +4260,8 @@ module StopImport : sig
       | `ImportNotFoundException of import_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Stops a specified import. \n"]
@@ -4263,7 +4318,8 @@ module StopLogging : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4320,7 +4376,8 @@ module UpdateChannel : sig
       | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a channel specified by a required channel ARN or UUID.\n"]
@@ -4365,7 +4422,8 @@ module UpdateDashboard : sig
       | `InvalidQueryStatementException of invalid_query_statement_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4472,7 +4530,8 @@ module UpdateEventDataStore : sig
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `ThrottlingException of throttling_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4617,7 +4676,8 @@ module UpdateTrail : sig
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
       | `TrailNotProvidedException of trail_not_provided_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/cloudtrail/operations.ml
+++ b/sdks/cloudtrail/operations.ml
@@ -85,6 +85,12 @@ module AddTags = struct
     let input = Json_serializers.add_tags_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.AddTags" ~service ~context
       ~input ~output_deserializer:Json_deserializers.add_tags_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : add_tags_request) =
+    let input = Json_serializers.add_tags_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.AddTags"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.add_tags_response_of_yojson
+      ~error_deserializer
 end
 
 module CancelQuery = struct
@@ -145,6 +151,12 @@ module CancelQuery = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.CancelQuery" ~service
       ~context ~input ~output_deserializer:Json_deserializers.cancel_query_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : cancel_query_request) =
+    let input = Json_serializers.cancel_query_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.CancelQuery"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_query_response_of_yojson ~error_deserializer
 end
 
 module CreateChannel = struct
@@ -215,6 +227,12 @@ module CreateChannel = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.CreateChannel" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_channel_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_channel_request) =
+    let input = Json_serializers.create_channel_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.CreateChannel" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_channel_response_of_yojson ~error_deserializer
 end
 
 module CreateDashboard = struct
@@ -266,6 +284,13 @@ module CreateDashboard = struct
     let input = Json_serializers.create_dashboard_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.CreateDashboard" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_dashboard_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_dashboard_request) =
+    let input = Json_serializers.create_dashboard_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.CreateDashboard" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_dashboard_response_of_yojson
       ~error_deserializer
 end
 
@@ -365,6 +390,13 @@ module CreateEventDataStore = struct
     let input = Json_serializers.create_event_data_store_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.CreateEventDataStore"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_event_data_store_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_event_data_store_request) =
+    let input = Json_serializers.create_event_data_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.CreateEventDataStore" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_event_data_store_response_of_yojson
       ~error_deserializer
 end
@@ -528,6 +560,12 @@ module CreateTrail = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.CreateTrail" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_trail_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_trail_request) =
+    let input = Json_serializers.create_trail_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.CreateTrail"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_trail_response_of_yojson ~error_deserializer
 end
 
 module DeleteChannel = struct
@@ -562,6 +600,12 @@ module DeleteChannel = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.DeleteChannel" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_channel_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_channel_request) =
+    let input = Json_serializers.delete_channel_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.DeleteChannel" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_channel_response_of_yojson ~error_deserializer
 end
 
 module DeleteDashboard = struct
@@ -590,6 +634,13 @@ module DeleteDashboard = struct
     let input = Json_serializers.delete_dashboard_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.DeleteDashboard" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_dashboard_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_dashboard_request) =
+    let input = Json_serializers.delete_dashboard_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.DeleteDashboard" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_dashboard_response_of_yojson
       ~error_deserializer
 end
 
@@ -675,6 +726,13 @@ module DeleteEventDataStore = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_event_data_store_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_event_data_store_request) =
+    let input = Json_serializers.delete_event_data_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.DeleteEventDataStore" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_event_data_store_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteResourcePolicy = struct
@@ -721,6 +779,13 @@ module DeleteResourcePolicy = struct
     let input = Json_serializers.delete_resource_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.DeleteResourcePolicy"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_resource_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_resource_policy_request) =
+    let input = Json_serializers.delete_resource_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.DeleteResourcePolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_resource_policy_response_of_yojson
       ~error_deserializer
 end
@@ -786,6 +851,12 @@ module DeleteTrail = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.DeleteTrail" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_trail_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_trail_request) =
+    let input = Json_serializers.delete_trail_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.DeleteTrail"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_trail_response_of_yojson ~error_deserializer
 end
 
 module DeregisterOrganizationDelegatedAdmin = struct
@@ -857,6 +928,17 @@ module DeregisterOrganizationDelegatedAdmin = struct
       ~output_deserializer:
         Json_deserializers.deregister_organization_delegated_admin_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deregister_organization_delegated_admin_request) =
+    let input =
+      Json_serializers.deregister_organization_delegated_admin_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.DeregisterOrganizationDelegatedAdmin" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.deregister_organization_delegated_admin_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeQuery = struct
@@ -911,6 +993,12 @@ module DescribeQuery = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.DescribeQuery" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_query_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_query_request) =
+    let input = Json_serializers.describe_query_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.DescribeQuery" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_query_response_of_yojson ~error_deserializer
 end
 
 module DescribeTrails = struct
@@ -950,6 +1038,12 @@ module DescribeTrails = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.DescribeTrails" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_trails_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_trails_request) =
+    let input = Json_serializers.describe_trails_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.DescribeTrails" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_trails_response_of_yojson ~error_deserializer
 end
 
 module DisableFederation = struct
@@ -1032,6 +1126,13 @@ module DisableFederation = struct
     let input = Json_serializers.disable_federation_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.DisableFederation" ~service
       ~context ~input ~output_deserializer:Json_deserializers.disable_federation_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disable_federation_request) =
+    let input = Json_serializers.disable_federation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.DisableFederation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disable_federation_response_of_yojson
       ~error_deserializer
 end
 
@@ -1121,6 +1222,13 @@ module EnableFederation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.EnableFederation" ~service
       ~context ~input ~output_deserializer:Json_deserializers.enable_federation_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : enable_federation_request) =
+    let input = Json_serializers.enable_federation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.EnableFederation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enable_federation_response_of_yojson
+      ~error_deserializer
 end
 
 module GenerateQuery = struct
@@ -1175,6 +1283,12 @@ module GenerateQuery = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GenerateQuery" ~service
       ~context ~input ~output_deserializer:Json_deserializers.generate_query_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : generate_query_request) =
+    let input = Json_serializers.generate_query_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.GenerateQuery" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.generate_query_response_of_yojson ~error_deserializer
 end
 
 module GetChannel = struct
@@ -1209,6 +1323,12 @@ module GetChannel = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GetChannel" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_channel_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_channel_request) =
+    let input = Json_serializers.get_channel_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.GetChannel"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_channel_response_of_yojson ~error_deserializer
 end
 
 module GetDashboard = struct
@@ -1235,6 +1355,12 @@ module GetDashboard = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GetDashboard" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_dashboard_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_dashboard_request) =
+    let input = Json_serializers.get_dashboard_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.GetDashboard"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_dashboard_response_of_yojson ~error_deserializer
 end
 
 module GetEventConfiguration = struct
@@ -1307,6 +1433,13 @@ module GetEventConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_event_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_event_configuration_request) =
+    let input = Json_serializers.get_event_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.GetEventConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_event_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module GetEventDataStore = struct
@@ -1353,6 +1486,13 @@ module GetEventDataStore = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_event_data_store_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_event_data_store_request) =
+    let input = Json_serializers.get_event_data_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.GetEventDataStore" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_event_data_store_response_of_yojson
+      ~error_deserializer
 end
 
 module GetEventSelectors = struct
@@ -1395,6 +1535,13 @@ module GetEventSelectors = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GetEventSelectors" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_event_selectors_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_event_selectors_request) =
+    let input = Json_serializers.get_event_selectors_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.GetEventSelectors" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_event_selectors_response_of_yojson
+      ~error_deserializer
 end
 
 module GetImport = struct
@@ -1428,6 +1575,12 @@ module GetImport = struct
     let input = Json_serializers.get_import_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GetImport" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_import_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_import_request) =
+    let input = Json_serializers.get_import_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.GetImport"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_import_response_of_yojson
       ~error_deserializer
 end
 
@@ -1486,6 +1639,13 @@ module GetInsightSelectors = struct
     let input = Json_serializers.get_insight_selectors_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GetInsightSelectors"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_insight_selectors_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_insight_selectors_request) =
+    let input = Json_serializers.get_insight_selectors_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.GetInsightSelectors" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_insight_selectors_response_of_yojson
       ~error_deserializer
 end
@@ -1555,6 +1715,13 @@ module GetQueryResults = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GetQueryResults" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_query_results_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_query_results_request) =
+    let input = Json_serializers.get_query_results_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.GetQueryResults" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_query_results_response_of_yojson
+      ~error_deserializer
 end
 
 module GetResourcePolicy = struct
@@ -1599,6 +1766,13 @@ module GetResourcePolicy = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GetResourcePolicy" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_resource_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_policy_request) =
+    let input = Json_serializers.get_resource_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.GetResourcePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module GetTrail = struct
@@ -1635,6 +1809,12 @@ module GetTrail = struct
     let input = Json_serializers.get_trail_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GetTrail" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_trail_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_trail_request) =
+    let input = Json_serializers.get_trail_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.GetTrail"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_trail_response_of_yojson
       ~error_deserializer
 end
 
@@ -1673,6 +1853,13 @@ module GetTrailStatus = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.GetTrailStatus" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_trail_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_trail_status_request) =
+    let input = Json_serializers.get_trail_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.GetTrailStatus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_trail_status_response_of_yojson
+      ~error_deserializer
 end
 
 module ListChannels = struct
@@ -1703,6 +1890,12 @@ module ListChannels = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.ListChannels" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_channels_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_channels_request) =
+    let input = Json_serializers.list_channels_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.ListChannels"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_channels_response_of_yojson ~error_deserializer
 end
 
 module ListDashboards = struct
@@ -1725,6 +1918,12 @@ module ListDashboards = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.ListDashboards" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_dashboards_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_dashboards_request) =
+    let input = Json_serializers.list_dashboards_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.ListDashboards" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_dashboards_response_of_yojson ~error_deserializer
 end
 
 module ListEventDataStores = struct
@@ -1765,6 +1964,13 @@ module ListEventDataStores = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_event_data_stores_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_event_data_stores_request) =
+    let input = Json_serializers.list_event_data_stores_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.ListEventDataStores" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_event_data_stores_response_of_yojson
+      ~error_deserializer
 end
 
 module ListImportFailures = struct
@@ -1798,6 +2004,13 @@ module ListImportFailures = struct
     let input = Json_serializers.list_import_failures_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.ListImportFailures"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_import_failures_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_import_failures_request) =
+    let input = Json_serializers.list_import_failures_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.ListImportFailures" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_import_failures_response_of_yojson
       ~error_deserializer
 end
@@ -1839,6 +2052,12 @@ module ListImports = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.ListImports" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_imports_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_imports_request) =
+    let input = Json_serializers.list_imports_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.ListImports"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_imports_response_of_yojson ~error_deserializer
 end
 
 module ListInsightsData = struct
@@ -1868,6 +2087,13 @@ module ListInsightsData = struct
     let input = Json_serializers.list_insights_data_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.ListInsightsData" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_insights_data_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_insights_data_request) =
+    let input = Json_serializers.list_insights_data_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.ListInsightsData" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_insights_data_response_of_yojson
       ~error_deserializer
 end
 
@@ -1904,6 +2130,13 @@ module ListInsightsMetricData = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_insights_metric_data_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_insights_metric_data_request) =
+    let input = Json_serializers.list_insights_metric_data_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.ListInsightsMetricData" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_insights_metric_data_response_of_yojson
+      ~error_deserializer
 end
 
 module ListPublicKeys = struct
@@ -1936,6 +2169,13 @@ module ListPublicKeys = struct
     let input = Json_serializers.list_public_keys_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.ListPublicKeys" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_public_keys_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_public_keys_request) =
+    let input = Json_serializers.list_public_keys_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.ListPublicKeys" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_public_keys_response_of_yojson
       ~error_deserializer
 end
 
@@ -2003,6 +2243,12 @@ module ListQueries = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.ListQueries" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_queries_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_queries_request) =
+    let input = Json_serializers.list_queries_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.ListQueries"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_queries_response_of_yojson ~error_deserializer
 end
 
 module ListTags = struct
@@ -2073,6 +2319,12 @@ module ListTags = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.ListTags" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_tags_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_request) =
+    let input = Json_serializers.list_tags_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.ListTags"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_tags_response_of_yojson
+      ~error_deserializer
 end
 
 module ListTrails = struct
@@ -2099,6 +2351,12 @@ module ListTrails = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.ListTrails" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_trails_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_trails_request) =
+    let input = Json_serializers.list_trails_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.ListTrails"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_trails_response_of_yojson ~error_deserializer
 end
 
 module LookupEvents = struct
@@ -2146,6 +2404,12 @@ module LookupEvents = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.LookupEvents" ~service
       ~context ~input ~output_deserializer:Json_deserializers.lookup_events_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : lookup_events_request) =
+    let input = Json_serializers.lookup_events_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.LookupEvents"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.lookup_events_response_of_yojson ~error_deserializer
 end
 
 module PutEventConfiguration = struct
@@ -2249,6 +2513,13 @@ module PutEventConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_event_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_event_configuration_request) =
+    let input = Json_serializers.put_event_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.PutEventConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_event_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module PutEventSelectors = struct
@@ -2315,6 +2586,13 @@ module PutEventSelectors = struct
     let input = Json_serializers.put_event_selectors_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.PutEventSelectors" ~service
       ~context ~input ~output_deserializer:Json_deserializers.put_event_selectors_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_event_selectors_request) =
+    let input = Json_serializers.put_event_selectors_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.PutEventSelectors" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_event_selectors_response_of_yojson
       ~error_deserializer
 end
 
@@ -2401,6 +2679,13 @@ module PutInsightSelectors = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_insight_selectors_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_insight_selectors_request) =
+    let input = Json_serializers.put_insight_selectors_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.PutInsightSelectors" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_insight_selectors_response_of_yojson
+      ~error_deserializer
 end
 
 module PutResourcePolicy = struct
@@ -2447,6 +2732,13 @@ module PutResourcePolicy = struct
     let input = Json_serializers.put_resource_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.PutResourcePolicy" ~service
       ~context ~input ~output_deserializer:Json_deserializers.put_resource_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_resource_policy_request) =
+    let input = Json_serializers.put_resource_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.PutResourcePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_resource_policy_response_of_yojson
       ~error_deserializer
 end
 
@@ -2527,6 +2819,14 @@ module RegisterOrganizationDelegatedAdmin = struct
   let request context (request : register_organization_delegated_admin_request) =
     let input = Json_serializers.register_organization_delegated_admin_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"CloudTrail_20131101.RegisterOrganizationDelegatedAdmin" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.register_organization_delegated_admin_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : register_organization_delegated_admin_request) =
+    let input = Json_serializers.register_organization_delegated_admin_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"CloudTrail_20131101.RegisterOrganizationDelegatedAdmin" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.register_organization_delegated_admin_response_of_yojson
@@ -2614,6 +2914,12 @@ module RemoveTags = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.RemoveTags" ~service
       ~context ~input ~output_deserializer:Json_deserializers.remove_tags_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : remove_tags_request) =
+    let input = Json_serializers.remove_tags_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.RemoveTags"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.remove_tags_response_of_yojson ~error_deserializer
 end
 
 module RestoreEventDataStore = struct
@@ -2695,6 +3001,13 @@ module RestoreEventDataStore = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.restore_event_data_store_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : restore_event_data_store_request) =
+    let input = Json_serializers.restore_event_data_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.RestoreEventDataStore" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.restore_event_data_store_response_of_yojson
+      ~error_deserializer
 end
 
 module SearchSampleQueries = struct
@@ -2724,6 +3037,13 @@ module SearchSampleQueries = struct
     let input = Json_serializers.search_sample_queries_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.SearchSampleQueries"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.search_sample_queries_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : search_sample_queries_request) =
+    let input = Json_serializers.search_sample_queries_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.SearchSampleQueries" ~service ~context ~input
       ~output_deserializer:Json_deserializers.search_sample_queries_response_of_yojson
       ~error_deserializer
 end
@@ -2765,6 +3085,13 @@ module StartDashboardRefresh = struct
     let input = Json_serializers.start_dashboard_refresh_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.StartDashboardRefresh"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_dashboard_refresh_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_dashboard_refresh_request) =
+    let input = Json_serializers.start_dashboard_refresh_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.StartDashboardRefresh" ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_dashboard_refresh_response_of_yojson
       ~error_deserializer
 end
@@ -2834,6 +3161,13 @@ module StartEventDataStoreIngestion = struct
   let request context (request : start_event_data_store_ingestion_request) =
     let input = Json_serializers.start_event_data_store_ingestion_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"CloudTrail_20131101.StartEventDataStoreIngestion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_event_data_store_ingestion_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_event_data_store_ingestion_request) =
+    let input = Json_serializers.start_event_data_store_ingestion_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"CloudTrail_20131101.StartEventDataStoreIngestion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_event_data_store_ingestion_response_of_yojson
       ~error_deserializer
@@ -2910,6 +3244,12 @@ module StartImport = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.StartImport" ~service
       ~context ~input ~output_deserializer:Json_deserializers.start_import_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_import_request) =
+    let input = Json_serializers.start_import_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.StartImport"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_import_response_of_yojson ~error_deserializer
 end
 
 module StartLogging = struct
@@ -2973,6 +3313,12 @@ module StartLogging = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.StartLogging" ~service
       ~context ~input ~output_deserializer:Json_deserializers.start_logging_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_logging_request) =
+    let input = Json_serializers.start_logging_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.StartLogging"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_logging_response_of_yojson ~error_deserializer
 end
 
 module StartQuery = struct
@@ -3053,6 +3399,12 @@ module StartQuery = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.StartQuery" ~service
       ~context ~input ~output_deserializer:Json_deserializers.start_query_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_query_request) =
+    let input = Json_serializers.start_query_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.StartQuery"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_query_response_of_yojson ~error_deserializer
 end
 
 module StopEventDataStoreIngestion = struct
@@ -3123,6 +3475,13 @@ module StopEventDataStoreIngestion = struct
       ~shape_name:"CloudTrail_20131101.StopEventDataStoreIngestion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.stop_event_data_store_ingestion_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : stop_event_data_store_ingestion_request) =
+    let input = Json_serializers.stop_event_data_store_ingestion_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.StopEventDataStoreIngestion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_event_data_store_ingestion_response_of_yojson
+      ~error_deserializer
 end
 
 module StopImport = struct
@@ -3157,6 +3516,12 @@ module StopImport = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.StopImport" ~service
       ~context ~input ~output_deserializer:Json_deserializers.stop_import_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : stop_import_request) =
+    let input = Json_serializers.stop_import_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.StopImport"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_import_response_of_yojson ~error_deserializer
 end
 
 module StopLogging = struct
@@ -3220,6 +3585,12 @@ module StopLogging = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.StopLogging" ~service
       ~context ~input ~output_deserializer:Json_deserializers.stop_logging_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : stop_logging_request) =
+    let input = Json_serializers.stop_logging_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.StopLogging"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_logging_response_of_yojson ~error_deserializer
 end
 
 module UpdateChannel = struct
@@ -3282,6 +3653,12 @@ module UpdateChannel = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.UpdateChannel" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_channel_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_channel_request) =
+    let input = Json_serializers.update_channel_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.UpdateChannel" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_channel_response_of_yojson ~error_deserializer
 end
 
 module UpdateDashboard = struct
@@ -3333,6 +3710,13 @@ module UpdateDashboard = struct
     let input = Json_serializers.update_dashboard_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.UpdateDashboard" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_dashboard_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_dashboard_request) =
+    let input = Json_serializers.update_dashboard_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.UpdateDashboard" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_dashboard_response_of_yojson
       ~error_deserializer
 end
 
@@ -3448,6 +3832,13 @@ module UpdateEventDataStore = struct
     let input = Json_serializers.update_event_data_store_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.UpdateEventDataStore"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_event_data_store_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_event_data_store_request) =
+    let input = Json_serializers.update_event_data_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CloudTrail_20131101.UpdateEventDataStore" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_event_data_store_response_of_yojson
       ~error_deserializer
 end
@@ -3609,4 +4000,10 @@ module UpdateTrail = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CloudTrail_20131101.UpdateTrail" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_trail_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_trail_request) =
+    let input = Json_serializers.update_trail_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CloudTrail_20131101.UpdateTrail"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_trail_response_of_yojson ~error_deserializer
 end

--- a/sdks/cloudtrail/operations.mli
+++ b/sdks/cloudtrail/operations.mli
@@ -64,7 +64,8 @@ module AddTags : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `TagsLimitExceededException of tags_limit_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -122,7 +123,8 @@ module CancelQuery : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `QueryIdNotFoundException of query_id_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -183,7 +185,8 @@ module CreateChannel : sig
       | `InvalidTagParameterException of invalid_tag_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TagsLimitExceededException of tags_limit_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -231,7 +234,8 @@ module CreateDashboard : sig
       | `InvalidQueryStatementException of invalid_query_statement_exception
       | `InvalidTagParameterException of invalid_tag_parameter_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -346,7 +350,8 @@ module CreateEventDataStore : sig
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `ThrottlingException of throttling_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a new event data store.\n"]
@@ -475,7 +480,8 @@ module CreateTrail : sig
       | `ThrottlingException of throttling_exception
       | `TrailAlreadyExistsException of trail_already_exists_exception
       | `TrailNotProvidedException of trail_not_provided_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -509,7 +515,8 @@ module DeleteChannel : sig
       | `ChannelARNInvalidException of channel_arn_invalid_exception
       | `ChannelNotFoundException of channel_not_found_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a channel.\n"]
@@ -539,7 +546,8 @@ module DeleteDashboard : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -610,7 +618,8 @@ module DeleteEventDataStore : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `NotOrganizationMasterAccountException of not_organization_master_account_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -663,7 +672,8 @@ module DeleteResourcePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyNotFoundException of resource_policy_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -722,7 +732,8 @@ module DeleteTrail : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -796,7 +807,8 @@ module DeregisterOrganizationDelegatedAdmin : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -842,7 +854,8 @@ module DescribeQuery : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `QueryIdNotFoundException of query_id_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -885,7 +898,8 @@ module DescribeTrails : sig
       | `InvalidTrailNameException of invalid_trail_name_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -954,7 +968,8 @@ module DisableFederation : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1031,7 +1046,8 @@ module EnableFederation : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1094,7 +1110,8 @@ module GenerateQuery : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1145,7 +1162,8 @@ module GetChannel : sig
       | `ChannelARNInvalidException of channel_arn_invalid_exception
       | `ChannelNotFoundException of channel_not_found_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns information about a specific channel. \n"]
@@ -1172,7 +1190,8 @@ module GetDashboard : sig
     ( get_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns the specified dashboard. \n"]
@@ -1229,7 +1248,8 @@ module GetEventConfiguration : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1271,7 +1291,8 @@ module GetEventDataStore : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1312,7 +1333,8 @@ module GetEventSelectors : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1385,7 +1407,8 @@ module GetImport : sig
       | `ImportNotFoundException of import_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns information about a specific import. \n"]
@@ -1436,7 +1459,8 @@ module GetInsightSelectors : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1503,7 +1527,8 @@ module GetQueryResults : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `QueryIdNotFoundException of query_id_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1544,7 +1569,8 @@ module GetResourcePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyNotFoundException of resource_policy_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1582,7 +1608,8 @@ module GetTrail : sig
       | `InvalidTrailNameException of invalid_trail_name_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns settings information for a specified trail.\n"]
@@ -1618,7 +1645,8 @@ module GetTrailStatus : sig
       | `InvalidTrailNameException of invalid_trail_name_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1652,7 +1680,8 @@ module ListChannels : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Lists the channels in the current account, and their source names. \n"]
@@ -1676,7 +1705,8 @@ module ListDashboards : sig
     list_dashboards_request ->
     ( list_dashboards_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns information about all dashboards in the account, in the current Region. \n"]
@@ -1712,7 +1742,8 @@ module ListEventDataStores : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1746,7 +1777,8 @@ module ListImportFailures : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns a list of failures for the specified import. \n"]
@@ -1782,7 +1814,8 @@ module ListImports : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1814,7 +1847,8 @@ module ListInsightsData : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1868,7 +1902,8 @@ module ListInsightsMetricData : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidTrailNameException of invalid_trail_name_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1937,7 +1972,8 @@ module ListPublicKeys : sig
       | `InvalidTimeRangeException of invalid_time_range_exception
       | `InvalidTokenException of invalid_token_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1999,7 +2035,8 @@ module ListQueries : sig
       | `InvalidQueryStatusException of invalid_query_status_exception
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2061,7 +2098,8 @@ module ListTags : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2090,7 +2128,8 @@ module ListTrails : sig
     ( list_trails_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists trails that are in the current account.\n"]
@@ -2132,7 +2171,8 @@ module LookupEvents : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidTimeRangeException of invalid_time_range_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2271,7 +2311,8 @@ module PutEventConfiguration : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2334,7 +2375,8 @@ module PutEventSelectors : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2479,7 +2521,8 @@ module PutInsightSelectors : sig
       | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2562,7 +2605,8 @@ module PutResourcePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyNotValidException of resource_policy_not_valid_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2637,7 +2681,8 @@ module RegisterOrganizationDelegatedAdmin : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2706,7 +2751,8 @@ module RemoveTags : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the specified tags from a trail, event data store, dashboard, or channel.\n"]
@@ -2771,7 +2817,8 @@ module RestoreEventDataStore : sig
       | `OrganizationNotInAllFeaturesModeException of
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2805,7 +2852,8 @@ module SearchSampleQueries : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2843,7 +2891,8 @@ module StartDashboardRefresh : sig
       | `InactiveEventDataStoreException of inactive_event_data_store_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2908,7 +2957,8 @@ module StartEventDataStoreIngestion : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `NotOrganizationMasterAccountException of not_organization_master_account_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2969,7 +3019,8 @@ module StartImport : sig
       | `InvalidImportSourceException of invalid_import_source_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3047,7 +3098,8 @@ module StartLogging : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3114,7 +3166,8 @@ module StartQuery : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3178,7 +3231,8 @@ module StopEventDataStoreIngestion : sig
       | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
       | `NotOrganizationMasterAccountException of not_organization_master_account_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3214,7 +3268,8 @@ module StopImport : sig
       | `ImportNotFoundException of import_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Stops a specified import. \n"]
@@ -3271,7 +3326,8 @@ module StopLogging : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3328,7 +3384,8 @@ module UpdateChannel : sig
       | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a channel specified by a required channel ARN or UUID.\n"]
@@ -3373,7 +3430,8 @@ module UpdateDashboard : sig
       | `InvalidQueryStatementException of invalid_query_statement_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3480,7 +3538,8 @@ module UpdateEventDataStore : sig
         organization_not_in_all_features_mode_exception
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `ThrottlingException of throttling_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3624,7 +3683,8 @@ module UpdateTrail : sig
       | `ThrottlingException of throttling_exception
       | `TrailNotFoundException of trail_not_found_exception
       | `TrailNotProvidedException of trail_not_provided_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/cloudtrail/operations.mli
+++ b/sdks/cloudtrail/operations.mli
@@ -43,6 +43,29 @@ module AddTags : sig
       | `TagsLimitExceededException of tags_limit_exceeded_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_request ->
+    ( add_tags_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `TagsLimitExceededException of tags_limit_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more tags to a trail, event data store, dashboard, or channel, up to a limit of 50. \
@@ -72,6 +95,23 @@ module CancelQuery : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_query_request ->
     ( cancel_query_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InactiveQueryException of inactive_query_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `QueryIdNotFoundException of query_id_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_query_request ->
+    ( cancel_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
@@ -126,6 +166,25 @@ module CreateChannel : sig
       | `TagsLimitExceededException of tags_limit_exceeded_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_channel_request ->
+    ( create_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelAlreadyExistsException of channel_already_exists_exception
+      | `ChannelMaxLimitExceededException of channel_max_limit_exceeded_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidSourceException of invalid_source_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TagsLimitExceededException of tags_limit_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a channel for CloudTrail to ingest events from a partner or external source. After you \
@@ -149,6 +208,21 @@ module CreateDashboard : sig
     'http_type Smaws_Lib.Context.t ->
     create_dashboard_request ->
     ( create_dashboard_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidQueryStatementException of invalid_query_statement_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_dashboard_request ->
+    ( create_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -223,6 +297,34 @@ module CreateEventDataStore : sig
     'http_type Smaws_Lib.Context.t ->
     create_event_data_store_request ->
     ( create_event_data_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreAlreadyExistsException of event_data_store_already_exists_exception
+      | `EventDataStoreMaxLimitExceededException of event_data_store_max_limit_exceeded_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidEventSelectorsException of invalid_event_selectors_exception
+      | `InvalidKmsKeyIdException of invalid_kms_key_id_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `KmsException of kms_exception
+      | `KmsKeyNotFoundException of kms_key_not_found_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `ThrottlingException of throttling_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_event_data_store_request ->
+    ( create_event_data_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
       | `ConflictException of conflict_exception
@@ -331,6 +433,50 @@ module CreateTrail : sig
       | `TrailNotProvidedException of trail_not_provided_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_trail_request ->
+    ( create_trail_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `CloudTrailInvalidClientTokenIdException of cloud_trail_invalid_client_token_id_exception
+      | `CloudWatchLogsDeliveryUnavailableException of
+        cloud_watch_logs_delivery_unavailable_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InsufficientS3BucketPolicyException of insufficient_s3_bucket_policy_exception
+      | `InsufficientSnsTopicPolicyException of insufficient_sns_topic_policy_exception
+      | `InvalidCloudWatchLogsLogGroupArnException of
+        invalid_cloud_watch_logs_log_group_arn_exception
+      | `InvalidCloudWatchLogsRoleArnException of invalid_cloud_watch_logs_role_arn_exception
+      | `InvalidKmsKeyIdException of invalid_kms_key_id_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidS3BucketNameException of invalid_s3_bucket_name_exception
+      | `InvalidS3PrefixException of invalid_s3_prefix_exception
+      | `InvalidSnsTopicNameException of invalid_sns_topic_name_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `KmsException of kms_exception
+      | `KmsKeyDisabledException of kms_key_disabled_exception
+      | `KmsKeyNotFoundException of kms_key_not_found_exception
+      | `MaximumNumberOfTrailsExceededException of maximum_number_of_trails_exceeded_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
+      | `TagsLimitExceededException of tags_limit_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailAlreadyExistsException of trail_already_exists_exception
+      | `TrailNotProvidedException of trail_not_provided_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a trail that specifies the settings for delivery of log data to an Amazon S3 bucket. \n"]
@@ -354,6 +500,17 @@ module DeleteChannel : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_channel_request ->
+    ( delete_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a channel.\n"]
 
@@ -369,6 +526,16 @@ module DeleteDashboard : sig
     'http_type Smaws_Lib.Context.t ->
     delete_dashboard_request ->
     ( delete_dashboard_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_dashboard_request ->
+    ( delete_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -404,6 +571,29 @@ module DeleteEventDataStore : sig
     'http_type Smaws_Lib.Context.t ->
     delete_event_data_store_request ->
     ( delete_event_data_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelExistsForEDSException of channel_exists_for_eds_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreFederationEnabledException of event_data_store_federation_enabled_exception
+      | `EventDataStoreHasOngoingImportException of event_data_store_has_ongoing_import_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `EventDataStoreTerminationProtectedException of
+        event_data_store_termination_protected_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_event_data_store_request ->
+    ( delete_event_data_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ChannelExistsForEDSException of channel_exists_for_eds_exception
       | `ConflictException of conflict_exception
@@ -461,6 +651,20 @@ module DeleteResourcePolicy : sig
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_policy_request ->
+    ( delete_resource_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceARNNotValidException of resource_arn_not_valid_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Deletes the resource-based policy attached to the CloudTrail event data store, dashboard, or \
@@ -487,6 +691,25 @@ module DeleteTrail : sig
     'http_type Smaws_Lib.Context.t ->
     delete_trail_request ->
     ( delete_trail_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_trail_request ->
+    ( delete_trail_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `ConflictException of conflict_exception
@@ -555,6 +778,26 @@ module DeregisterOrganizationDelegatedAdmin : sig
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_organization_delegated_admin_request ->
+    ( deregister_organization_delegated_admin_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccountNotFoundException of account_not_found_exception
+      | `AccountNotRegisteredException of account_not_registered_exception
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotOrganizationManagementAccountException of not_organization_management_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes CloudTrail delegated administrator permissions from a member account in an organization.\n"]
@@ -576,6 +819,21 @@ module DescribeQuery : sig
     'http_type Smaws_Lib.Context.t ->
     describe_query_request ->
     ( describe_query_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `QueryIdNotFoundException of query_id_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_query_request ->
+    ( describe_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -617,6 +875,18 @@ module DescribeTrails : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_trails_request ->
+    ( describe_trails_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves settings for one or more trails associated with the current Region for your account.\n"]
@@ -645,6 +915,29 @@ module DisableFederation : sig
     'http_type Smaws_Lib.Context.t ->
     disable_federation_request ->
     ( disable_federation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_federation_request ->
+    ( disable_federation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
@@ -716,6 +1009,30 @@ module EnableFederation : sig
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_federation_request ->
+    ( enable_federation_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreFederationEnabledException of event_data_store_federation_enabled_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Enables Lake query federation on the specified event data store. Federating an event data \
@@ -754,6 +1071,21 @@ module GenerateQuery : sig
     'http_type Smaws_Lib.Context.t ->
     generate_query_request ->
     ( generate_query_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `GenerateResponseException of generate_response_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_query_request ->
+    ( generate_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -804,6 +1136,17 @@ module GetChannel : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_channel_request ->
+    ( get_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc " Returns information about a specific channel. \n"]
 
@@ -818,6 +1161,15 @@ module GetDashboard : sig
     'http_type Smaws_Lib.Context.t ->
     get_dashboard_request ->
     ( get_dashboard_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_dashboard_request ->
+    ( get_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
@@ -846,6 +1198,25 @@ module GetEventConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     get_event_configuration_request ->
     ( get_event_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_event_configuration_request ->
+    ( get_event_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
@@ -889,6 +1260,19 @@ module GetEventDataStore : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_event_data_store_request ->
+    ( get_event_data_store_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about an event data store specified as either an ARN or the ID portion of \
@@ -909,6 +1293,19 @@ module GetEventSelectors : sig
     'http_type Smaws_Lib.Context.t ->
     get_event_selectors_request ->
     ( get_event_selectors_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_event_selectors_request ->
+    ( get_event_selectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `InvalidTrailNameException of invalid_trail_name_exception
@@ -979,6 +1376,17 @@ module GetImport : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_import_request ->
+    ( get_import_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ImportNotFoundException of import_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc " Returns information about a specific import. \n"]
 
@@ -1001,6 +1409,23 @@ module GetInsightSelectors : sig
     'http_type Smaws_Lib.Context.t ->
     get_insight_selectors_request ->
     ( get_insight_selectors_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InsightNotEnabledException of insight_not_enabled_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_insight_selectors_request ->
+    ( get_insight_selectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `InsightNotEnabledException of insight_not_enabled_exception
@@ -1062,6 +1487,24 @@ module GetQueryResults : sig
       | `QueryIdNotFoundException of query_id_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_query_results_request ->
+    ( get_query_results_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidMaxResultsException of invalid_max_results_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `QueryIdNotFoundException of query_id_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets event data results of a query. You must specify the [QueryID] value returned by the \
@@ -1082,6 +1525,19 @@ module GetResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_policy_request ->
     ( get_resource_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceARNNotValidException of resource_arn_not_valid_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_policy_request ->
+    ( get_resource_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `ResourceARNNotValidException of resource_arn_not_valid_exception
@@ -1116,6 +1572,18 @@ module GetTrail : sig
       | `TrailNotFoundException of trail_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_trail_request ->
+    ( get_trail_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns settings information for a specified trail.\n"]
 
@@ -1133,6 +1601,18 @@ module GetTrailStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_trail_status_request ->
     ( get_trail_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_trail_status_request ->
+    ( get_trail_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `InvalidTrailNameException of invalid_trail_name_exception
@@ -1164,6 +1644,16 @@ module ListChannels : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_channels_request ->
+    ( list_channels_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc " Lists the channels in the current account, and their source names. \n"]
 
@@ -1177,6 +1667,14 @@ module ListDashboards : sig
     'http_type Smaws_Lib.Context.t ->
     list_dashboards_request ->
     ( list_dashboards_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_dashboards_request ->
+    ( list_dashboards_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
@@ -1197,6 +1695,18 @@ module ListEventDataStores : sig
     'http_type Smaws_Lib.Context.t ->
     list_event_data_stores_request ->
     ( list_event_data_stores_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidMaxResultsException of invalid_max_results_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_event_data_stores_request ->
+    ( list_event_data_stores_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidMaxResultsException of invalid_max_results_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1227,6 +1737,17 @@ module ListImportFailures : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_import_failures_request ->
+    ( list_import_failures_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc " Returns a list of failures for the specified import. \n"]
 
@@ -1251,6 +1772,18 @@ module ListImports : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_imports_request ->
+    ( list_imports_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Returns information on all imports, or a select set of imports by [ImportStatus] or \
@@ -1268,6 +1801,16 @@ module ListInsightsData : sig
     'http_type Smaws_Lib.Context.t ->
     list_insights_data_request ->
     ( list_insights_data_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_insights_data_request ->
+    ( list_insights_data_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OperationNotPermittedException of operation_not_permitted_exception
@@ -1310,6 +1853,17 @@ module ListInsightsMetricData : sig
     'http_type Smaws_Lib.Context.t ->
     list_insights_metric_data_request ->
     ( list_insights_metric_data_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_insights_metric_data_request ->
+    ( list_insights_metric_data_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidTrailNameException of invalid_trail_name_exception
@@ -1374,6 +1928,17 @@ module ListPublicKeys : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_public_keys_request ->
+    ( list_public_keys_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidTimeRangeException of invalid_time_range_exception
+      | `InvalidTokenException of invalid_token_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns all public keys whose private keys were used to sign the digest files within the \
@@ -1405,6 +1970,24 @@ module ListQueries : sig
     'http_type Smaws_Lib.Context.t ->
     list_queries_request ->
     ( list_queries_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidDateRangeException of invalid_date_range_exception
+      | `InvalidMaxResultsException of invalid_max_results_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidQueryStatusException of invalid_query_status_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_queries_request ->
+    ( list_queries_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -1461,6 +2044,25 @@ module ListTags : sig
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_request ->
+    ( list_tags_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidTokenException of invalid_token_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the tags for the specified trails, event data stores, dashboards, or channels in the \
@@ -1477,6 +2079,15 @@ module ListTrails : sig
     'http_type Smaws_Lib.Context.t ->
     list_trails_request ->
     ( list_trails_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_trails_request ->
+    ( list_trails_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
@@ -1500,6 +2111,20 @@ module LookupEvents : sig
     'http_type Smaws_Lib.Context.t ->
     lookup_events_request ->
     ( lookup_events_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidEventCategoryException of invalid_event_category_exception
+      | `InvalidLookupAttributesException of invalid_lookup_attributes_exception
+      | `InvalidMaxResultsException of invalid_max_results_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidTimeRangeException of invalid_time_range_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    lookup_events_request ->
+    ( lookup_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidEventCategoryException of invalid_event_category_exception
       | `InvalidLookupAttributesException of invalid_lookup_attributes_exception
@@ -1621,6 +2246,33 @@ module PutEventConfiguration : sig
       | `TrailNotFoundException of trail_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_event_configuration_request ->
+    ( put_event_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientIAMAccessPermissionException of insufficient_iam_access_permission_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the event configuration settings for the specified event data store or trail. This \
@@ -1649,6 +2301,26 @@ module PutEventSelectors : sig
     'http_type Smaws_Lib.Context.t ->
     put_event_selectors_request ->
     ( put_event_selectors_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidEventSelectorsException of invalid_event_selectors_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_event_selectors_request ->
+    ( put_event_selectors_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `ConflictException of conflict_exception
@@ -1786,6 +2458,29 @@ module PutInsightSelectors : sig
       | `TrailNotFoundException of trail_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_insight_selectors_request ->
+    ( put_insight_selectors_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InsufficientS3BucketPolicyException of insufficient_s3_bucket_policy_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidInsightSelectorsException of invalid_insight_selectors_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `KmsException of kms_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lets you enable Insights event logging on specific event categories by specifying the Insights \
@@ -1855,6 +2550,20 @@ module PutResourcePolicy : sig
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_policy_request ->
+    ( put_resource_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceARNNotValidException of resource_arn_not_valid_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyNotValidException of resource_policy_not_valid_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Attaches a resource-based permission policy to a CloudTrail event data store, dashboard, or \
@@ -1887,6 +2596,30 @@ module RegisterOrganizationDelegatedAdmin : sig
     'http_type Smaws_Lib.Context.t ->
     register_organization_delegated_admin_request ->
     ( register_organization_delegated_admin_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccountNotFoundException of account_not_found_exception
+      | `AccountRegisteredException of account_registered_exception
+      | `CannotDelegateManagementAccountException of cannot_delegate_management_account_exception
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConflictException of conflict_exception
+      | `DelegatedAdminAccountLimitExceededException of
+        delegated_admin_account_limit_exceeded_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientIAMAccessPermissionException of insufficient_iam_access_permission_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotOrganizationManagementAccountException of not_organization_management_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_organization_delegated_admin_request ->
+    ( register_organization_delegated_admin_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccountNotFoundException of account_not_found_exception
       | `AccountRegisteredException of account_registered_exception
@@ -1953,6 +2686,28 @@ module RemoveTags : sig
       | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_request ->
+    ( remove_tags_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidTagParameterException of invalid_tag_parameter_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceTypeNotSupportedException of resource_type_not_supported_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Removes the specified tags from a trail, event data store, dashboard, or channel.\n"]
 
@@ -1996,6 +2751,28 @@ module RestoreEventDataStore : sig
       | `OrganizationsNotInUseException of organizations_not_in_use_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_event_data_store_request ->
+    ( restore_event_data_store_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreMaxLimitExceededException of event_data_store_max_limit_exceeded_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Restores a deleted event data store specified by [EventDataStore], which accepts an event data \
@@ -2020,6 +2797,16 @@ module SearchSampleQueries : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    search_sample_queries_request ->
+    ( search_sample_queries_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Searches sample queries and returns a list of sample queries that are sorted by relevance. To \
@@ -2039,6 +2826,18 @@ module StartDashboardRefresh : sig
     'http_type Smaws_Lib.Context.t ->
     start_dashboard_refresh_request ->
     ( start_dashboard_refresh_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_dashboard_refresh_request ->
+    ( start_dashboard_refresh_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
       | `InactiveEventDataStoreException of inactive_event_data_store_exception
@@ -2092,6 +2891,25 @@ module StartEventDataStoreIngestion : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_event_data_store_ingestion_request ->
+    ( start_event_data_store_ingestion_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the ingestion of live events on an event data store specified as either an ARN or the ID \
@@ -2120,6 +2938,25 @@ module StartImport : sig
     'http_type Smaws_Lib.Context.t ->
     start_import_request ->
     ( start_import_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccountHasOngoingImportException of account_has_ongoing_import_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `ImportNotFoundException of import_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidImportSourceException of invalid_import_source_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_import_request ->
+    ( start_import_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccountHasOngoingImportException of account_has_ongoing_import_exception
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
@@ -2193,6 +3030,25 @@ module StartLogging : sig
       | `TrailNotFoundException of trail_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_logging_request ->
+    ( start_logging_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the recording of Amazon Web Services API calls and log file delivery for a trail. For a \
@@ -2223,6 +3079,27 @@ module StartQuery : sig
     'http_type Smaws_Lib.Context.t ->
     start_query_request ->
     ( start_query_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InsufficientS3BucketPolicyException of insufficient_s3_bucket_policy_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidQueryStatementException of invalid_query_statement_exception
+      | `InvalidS3BucketNameException of invalid_s3_bucket_name_exception
+      | `InvalidS3PrefixException of invalid_s3_prefix_exception
+      | `MaxConcurrentQueriesException of max_concurrent_queries_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_query_request ->
+    ( start_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -2284,6 +3161,25 @@ module StopEventDataStoreIngestion : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_event_data_store_ingestion_request ->
+    ( stop_event_data_store_ingestion_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidEventDataStoreStatusException of invalid_event_data_store_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops the ingestion of live events on an event data store specified as either an ARN or the ID \
@@ -2303,6 +3199,17 @@ module StopImport : sig
     'http_type Smaws_Lib.Context.t ->
     stop_import_request ->
     ( stop_import_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ImportNotFoundException of import_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_import_request ->
+    ( stop_import_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ImportNotFoundException of import_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2333,6 +3240,25 @@ module StopLogging : sig
     'http_type Smaws_Lib.Context.t ->
     stop_logging_request ->
     ( stop_logging_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_logging_request ->
+    ( stop_logging_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
       | `ConflictException of conflict_exception
@@ -2387,6 +3313,23 @@ module UpdateChannel : sig
       | `OperationNotPermittedException of operation_not_permitted_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_channel_request ->
+    ( update_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ChannelAlreadyExistsException of channel_already_exists_exception
+      | `ChannelARNInvalidException of channel_arn_invalid_exception
+      | `ChannelNotFoundException of channel_not_found_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InvalidEventDataStoreCategoryException of invalid_event_data_store_category_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates a channel specified by a required channel ARN or UUID.\n"]
 
@@ -2407,6 +3350,21 @@ module UpdateDashboard : sig
     'http_type Smaws_Lib.Context.t ->
     update_dashboard_request ->
     ( update_dashboard_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidQueryStatementException of invalid_query_statement_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_dashboard_request ->
+    ( update_dashboard_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `EventDataStoreNotFoundException of event_data_store_not_found_exception
@@ -2467,6 +3425,37 @@ module UpdateEventDataStore : sig
     'http_type Smaws_Lib.Context.t ->
     update_event_data_store_request ->
     ( update_event_data_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `ConflictException of conflict_exception
+      | `EventDataStoreAlreadyExistsException of event_data_store_already_exists_exception
+      | `EventDataStoreARNInvalidException of event_data_store_arn_invalid_exception
+      | `EventDataStoreHasOngoingImportException of event_data_store_has_ongoing_import_exception
+      | `EventDataStoreNotFoundException of event_data_store_not_found_exception
+      | `InactiveEventDataStoreException of inactive_event_data_store_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InvalidEventSelectorsException of invalid_event_selectors_exception
+      | `InvalidInsightSelectorsException of invalid_insight_selectors_exception
+      | `InvalidKmsKeyIdException of invalid_kms_key_id_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `KmsException of kms_exception
+      | `KmsKeyNotFoundException of kms_key_not_found_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `ThrottlingException of throttling_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_event_data_store_request ->
+    ( update_event_data_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
       | `ConflictException of conflict_exception
@@ -2554,6 +3543,50 @@ module UpdateTrail : sig
     'http_type Smaws_Lib.Context.t ->
     update_trail_request ->
     ( update_trail_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
+      | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception
+      | `CloudTrailInvalidClientTokenIdException of cloud_trail_invalid_client_token_id_exception
+      | `CloudWatchLogsDeliveryUnavailableException of
+        cloud_watch_logs_delivery_unavailable_exception
+      | `ConflictException of conflict_exception
+      | `InsufficientDependencyServiceAccessPermissionException of
+        insufficient_dependency_service_access_permission_exception
+      | `InsufficientEncryptionPolicyException of insufficient_encryption_policy_exception
+      | `InsufficientS3BucketPolicyException of insufficient_s3_bucket_policy_exception
+      | `InsufficientSnsTopicPolicyException of insufficient_sns_topic_policy_exception
+      | `InvalidCloudWatchLogsLogGroupArnException of
+        invalid_cloud_watch_logs_log_group_arn_exception
+      | `InvalidCloudWatchLogsRoleArnException of invalid_cloud_watch_logs_role_arn_exception
+      | `InvalidEventSelectorsException of invalid_event_selectors_exception
+      | `InvalidHomeRegionException of invalid_home_region_exception
+      | `InvalidKmsKeyIdException of invalid_kms_key_id_exception
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidS3BucketNameException of invalid_s3_bucket_name_exception
+      | `InvalidS3PrefixException of invalid_s3_prefix_exception
+      | `InvalidSnsTopicNameException of invalid_sns_topic_name_exception
+      | `InvalidTrailNameException of invalid_trail_name_exception
+      | `KmsException of kms_exception
+      | `KmsKeyDisabledException of kms_key_disabled_exception
+      | `KmsKeyNotFoundException of kms_key_not_found_exception
+      | `NoManagementAccountSLRExistsException of no_management_account_slr_exists_exception
+      | `NotOrganizationMasterAccountException of not_organization_master_account_exception
+      | `OperationNotPermittedException of operation_not_permitted_exception
+      | `OrganizationNotInAllFeaturesModeException of
+        organization_not_in_all_features_mode_exception
+      | `OrganizationsNotInUseException of organizations_not_in_use_exception
+      | `S3BucketDoesNotExistException of s3_bucket_does_not_exist_exception
+      | `ThrottlingException of throttling_exception
+      | `TrailNotFoundException of trail_not_found_exception
+      | `TrailNotProvidedException of trail_not_provided_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_trail_request ->
+    ( update_trail_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudTrailAccessNotEnabledException of cloud_trail_access_not_enabled_exception
       | `CloudTrailARNInvalidException of cloud_trail_arn_invalid_exception

--- a/sdks/codeconnections/Smaws_Client_CodeConnections.mli
+++ b/sdks/codeconnections/Smaws_Client_CodeConnections.mli
@@ -407,7 +407,8 @@ module CreateConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ResourceUnavailableException of resource_unavailable_exception ] )
+      | `ResourceUnavailableException of resource_unavailable_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -433,7 +434,7 @@ module CreateHost : sig
     create_host_input ->
     ( create_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -483,7 +484,8 @@ module CreateRepositoryLink : sig
       | `InvalidInputException of invalid_input_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -527,7 +529,8 @@ module CreateSyncConfiguration : sig
       | `InvalidInputException of invalid_input_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -554,7 +557,8 @@ module DeleteConnection : sig
     delete_connection_input ->
     ( delete_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The connection to be deleted.\n"]
@@ -581,7 +585,8 @@ module DeleteHost : sig
     ( delete_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ResourceUnavailableException of resource_unavailable_exception ] )
+      | `ResourceUnavailableException of resource_unavailable_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -631,7 +636,8 @@ module DeleteRepositoryLink : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `SyncConfigurationStillExistsException of sync_configuration_still_exists_exception
       | `ThrottlingException of throttling_exception
-      | `UnsupportedProviderTypeException of unsupported_provider_type_exception ] )
+      | `UnsupportedProviderTypeException of unsupported_provider_type_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -671,7 +677,8 @@ module DeleteSyncConfiguration : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the sync configuration for a specified repository and connection.\n"]
@@ -698,7 +705,8 @@ module GetConnection : sig
     ( get_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ResourceUnavailableException of resource_unavailable_exception ] )
+      | `ResourceUnavailableException of resource_unavailable_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the connection ARN and details such as status, owner, and provider type.\n"]
@@ -725,7 +733,8 @@ module GetHost : sig
     ( get_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ResourceUnavailableException of resource_unavailable_exception ] )
+      | `ResourceUnavailableException of resource_unavailable_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -766,7 +775,8 @@ module GetRepositoryLink : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -804,7 +814,8 @@ module GetRepositorySyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -842,7 +853,8 @@ module GetResourceSyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -880,7 +892,8 @@ module GetSyncBlockerSummary : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of the most recent sync blockers.\n"]
@@ -916,7 +929,8 @@ module GetSyncConfiguration : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -943,7 +957,8 @@ module ListConnections : sig
     list_connections_input ->
     ( list_connections_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the connections associated with your account.\n"]
@@ -959,7 +974,9 @@ module ListHosts : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     list_hosts_input ->
-    (list_hosts_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( list_hosts_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "Lists the hosts associated with your account.\n"]
 
@@ -997,7 +1014,8 @@ module ListRepositoryLinks : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the repository links created for connections in your account.\n"]
@@ -1033,7 +1051,8 @@ module ListRepositorySyncDefinitions : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the repository sync definitions for repository links in your account.\n"]
@@ -1069,7 +1088,8 @@ module ListSyncConfigurations : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of sync configurations for a specified repository.\n"]
@@ -1093,7 +1113,8 @@ module ListTagsForResource : sig
     list_tags_for_resource_input ->
     ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the set of key-value pairs (metadata) that are used to manage the resource.\n"]
@@ -1120,7 +1141,8 @@ module TagResource : sig
     ( tag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1146,7 +1168,8 @@ module UntagResource : sig
     untag_resource_input ->
     ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tags from an Amazon Web Services resource.\n"]
@@ -1179,7 +1202,8 @@ module UpdateHost : sig
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a specified host with the provided configurations.\n"]
@@ -1221,7 +1245,8 @@ module UpdateRepositoryLink : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `UpdateOutOfSyncException of update_out_of_sync_exception ] )
+      | `UpdateOutOfSyncException of update_out_of_sync_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1266,7 +1291,8 @@ module UpdateSyncBlocker : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `RetryLatestCommitFailedException of retry_latest_commit_failed_exception
       | `SyncBlockerDoesNotExistException of sync_blocker_does_not_exist_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1311,7 +1337,8 @@ module UpdateSyncConfiguration : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `UpdateOutOfSyncException of update_out_of_sync_exception ] )
+      | `UpdateOutOfSyncException of update_out_of_sync_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/codeconnections/Smaws_Client_CodeConnections.mli
+++ b/sdks/codeconnections/Smaws_Client_CodeConnections.mli
@@ -399,6 +399,16 @@ module CreateConnection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_connection_input ->
+    ( create_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a connection that can then be given to other Amazon Web Services services like \
@@ -414,6 +424,14 @@ module CreateHost : sig
     'http_type Smaws_Lib.Context.t ->
     create_host_input ->
     ( create_host_output,
+      [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_host_input ->
+    ( create_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
     )
     result
@@ -453,6 +471,20 @@ module CreateRepositoryLink : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_repository_link_input ->
+    ( create_repository_link_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a link to a specified external Git repository. A repository link allows Git sync to \
@@ -483,6 +515,20 @@ module CreateSyncConfiguration : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_sync_configuration_input ->
+    ( create_sync_configuration_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a sync configuration which allows Amazon Web Services to sync content from a Git \
@@ -502,6 +548,14 @@ module DeleteConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_connection_input ->
+    ( delete_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "The connection to be deleted.\n"]
 
@@ -516,6 +570,15 @@ module DeleteHost : sig
     'http_type Smaws_Lib.Context.t ->
     delete_host_input ->
     ( delete_host_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_host_input ->
+    ( delete_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception ] )
@@ -555,6 +618,21 @@ module DeleteRepositoryLink : sig
       | `ThrottlingException of throttling_exception
       | `UnsupportedProviderTypeException of unsupported_provider_type_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_repository_link_input ->
+    ( delete_repository_link_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `SyncConfigurationStillExistsException of sync_configuration_still_exists_exception
+      | `ThrottlingException of throttling_exception
+      | `UnsupportedProviderTypeException of unsupported_provider_type_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the association between your connection and a specified external Git repository.\n"]
@@ -582,6 +660,19 @@ module DeleteSyncConfiguration : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_sync_configuration_input ->
+    ( delete_sync_configuration_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the sync configuration for a specified repository and connection.\n"]
 
@@ -600,6 +691,15 @@ module GetConnection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_connection_input ->
+    ( get_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the connection ARN and details such as status, owner, and provider type.\n"]
 
@@ -614,6 +714,15 @@ module GetHost : sig
     'http_type Smaws_Lib.Context.t ->
     get_host_input ->
     ( get_host_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_host_input ->
+    ( get_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception ] )
@@ -638,6 +747,19 @@ module GetRepositoryLink : sig
     'http_type Smaws_Lib.Context.t ->
     get_repository_link_input ->
     ( get_repository_link_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_repository_link_input ->
+    ( get_repository_link_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -672,6 +794,18 @@ module GetRepositorySyncStatus : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_repository_sync_status_input ->
+    ( get_repository_sync_status_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns details about the sync status for a repository. A repository sync uses Git sync to push \
@@ -691,6 +825,18 @@ module GetResourceSyncStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_sync_status_input ->
     ( get_resource_sync_status_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_sync_status_input ->
+    ( get_resource_sync_status_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -724,6 +870,18 @@ module GetSyncBlockerSummary : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sync_blocker_summary_input ->
+    ( get_sync_blocker_summary_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of the most recent sync blockers.\n"]
 
@@ -741,6 +899,18 @@ module GetSyncConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     get_sync_configuration_input ->
     ( get_sync_configuration_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sync_configuration_input ->
+    ( get_sync_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -767,6 +937,14 @@ module ListConnections : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_connections_input ->
+    ( list_connections_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the connections associated with your account.\n"]
 
@@ -777,6 +955,11 @@ module ListHosts : sig
     'http_type Smaws_Lib.Context.t ->
     list_hosts_input ->
     (list_hosts_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_hosts_input ->
+    (list_hosts_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc "Lists the hosts associated with your account.\n"]
 
@@ -795,6 +978,19 @@ module ListRepositoryLinks : sig
     'http_type Smaws_Lib.Context.t ->
     list_repository_links_input ->
     ( list_repository_links_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_repository_links_input ->
+    ( list_repository_links_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -827,6 +1023,18 @@ module ListRepositorySyncDefinitions : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_repository_sync_definitions_input ->
+    ( list_repository_sync_definitions_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the repository sync definitions for repository links in your account.\n"]
 
@@ -851,6 +1059,18 @@ module ListSyncConfigurations : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_sync_configurations_input ->
+    ( list_sync_configurations_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of sync configurations for a specified repository.\n"]
 
@@ -864,6 +1084,14 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_input ->
     ( list_tags_for_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -885,6 +1113,15 @@ module TagResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds to or modifies the tags of the given resource. Tags are metadata that can be used to \
@@ -900,6 +1137,14 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_input ->
     ( untag_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -925,6 +1170,17 @@ module UpdateHost : sig
       | `ResourceUnavailableException of resource_unavailable_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_host_input ->
+    ( update_host_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates a specified host with the provided configurations.\n"]
 
@@ -944,6 +1200,20 @@ module UpdateRepositoryLink : sig
     'http_type Smaws_Lib.Context.t ->
     update_repository_link_input ->
     ( update_repository_link_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `UpdateOutOfSyncException of update_out_of_sync_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_repository_link_input ->
+    ( update_repository_link_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConditionalCheckFailedException of conditional_check_failed_exception
@@ -984,6 +1254,20 @@ module UpdateSyncBlocker : sig
       | `SyncBlockerDoesNotExistException of sync_blocker_does_not_exist_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_sync_blocker_input ->
+    ( update_sync_blocker_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `RetryLatestCommitFailedException of retry_latest_commit_failed_exception
+      | `SyncBlockerDoesNotExistException of sync_blocker_does_not_exist_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows you to update the status of a sync blocker, resolving the blocker and allowing syncing \
@@ -1006,6 +1290,20 @@ module UpdateSyncConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     update_sync_configuration_input ->
     ( update_sync_configuration_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `UpdateOutOfSyncException of update_out_of_sync_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_sync_configuration_input ->
+    ( update_sync_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConcurrentModificationException of concurrent_modification_exception

--- a/sdks/codeconnections/operations.ml
+++ b/sdks/codeconnections/operations.ml
@@ -29,6 +29,12 @@ module CreateConnection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.CreateConnection"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_connection_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_connection_input) =
+    let input = Json_serializers.create_connection_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.CreateConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_connection_output_of_yojson ~error_deserializer
 end
 
 module CreateHost = struct
@@ -50,6 +56,12 @@ module CreateHost = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.CreateHost" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_host_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_host_input) =
+    let input = Json_serializers.create_host_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.CreateHost" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_host_output_of_yojson ~error_deserializer
 end
 
 module CreateRepositoryLink = struct
@@ -93,6 +105,13 @@ module CreateRepositoryLink = struct
     let input = Json_serializers.create_repository_link_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.CreateRepositoryLink"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_repository_link_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_repository_link_input) =
+    let input = Json_serializers.create_repository_link_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.CreateRepositoryLink" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_repository_link_output_of_yojson
       ~error_deserializer
 end
@@ -140,6 +159,13 @@ module CreateSyncConfiguration = struct
       ~shape_name:"CodeConnections_20231201.CreateSyncConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_sync_configuration_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_sync_configuration_input) =
+    let input = Json_serializers.create_sync_configuration_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.CreateSyncConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_sync_configuration_output_of_yojson
+      ~error_deserializer
 end
 
 module DeleteConnection = struct
@@ -161,6 +187,12 @@ module DeleteConnection = struct
     let input = Json_serializers.delete_connection_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.DeleteConnection"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_connection_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : delete_connection_input) =
+    let input = Json_serializers.delete_connection_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.DeleteConnection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_connection_output_of_yojson ~error_deserializer
 end
 
@@ -189,6 +221,12 @@ module DeleteHost = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.DeleteHost" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_host_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_host_input) =
+    let input = Json_serializers.delete_host_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.DeleteHost" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_host_output_of_yojson ~error_deserializer
 end
 
 module DeleteRepositoryLink = struct
@@ -240,6 +278,13 @@ module DeleteRepositoryLink = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_repository_link_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_repository_link_input) =
+    let input = Json_serializers.delete_repository_link_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.DeleteRepositoryLink" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_repository_link_output_of_yojson
+      ~error_deserializer
 end
 
 module DeleteSyncConfiguration = struct
@@ -280,6 +325,13 @@ module DeleteSyncConfiguration = struct
       ~shape_name:"CodeConnections_20231201.DeleteSyncConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_sync_configuration_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_sync_configuration_input) =
+    let input = Json_serializers.delete_sync_configuration_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.DeleteSyncConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_sync_configuration_output_of_yojson
+      ~error_deserializer
 end
 
 module GetConnection = struct
@@ -307,6 +359,12 @@ module GetConnection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.GetConnection"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_connection_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_connection_input) =
+    let input = Json_serializers.get_connection_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.GetConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_connection_output_of_yojson ~error_deserializer
 end
 
 module GetHost = struct
@@ -333,6 +391,12 @@ module GetHost = struct
     let input = Json_serializers.get_host_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.GetHost" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_host_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_host_input) =
+    let input = Json_serializers.get_host_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"CodeConnections_20231201.GetHost"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_host_output_of_yojson
       ~error_deserializer
 end
 
@@ -375,6 +439,13 @@ module GetRepositoryLink = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_repository_link_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_repository_link_input) =
+    let input = Json_serializers.get_repository_link_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.GetRepositoryLink" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_repository_link_output_of_yojson
+      ~error_deserializer
 end
 
 module GetRepositorySyncStatus = struct
@@ -408,6 +479,13 @@ module GetRepositorySyncStatus = struct
   let request context (request : get_repository_sync_status_input) =
     let input = Json_serializers.get_repository_sync_status_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"CodeConnections_20231201.GetRepositorySyncStatus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_repository_sync_status_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_repository_sync_status_input) =
+    let input = Json_serializers.get_repository_sync_status_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"CodeConnections_20231201.GetRepositorySyncStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_repository_sync_status_output_of_yojson
       ~error_deserializer
@@ -447,6 +525,13 @@ module GetResourceSyncStatus = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_resource_sync_status_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_sync_status_input) =
+    let input = Json_serializers.get_resource_sync_status_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.GetResourceSyncStatus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_sync_status_output_of_yojson
+      ~error_deserializer
 end
 
 module GetSyncBlockerSummary = struct
@@ -481,6 +566,13 @@ module GetSyncBlockerSummary = struct
     let input = Json_serializers.get_sync_blocker_summary_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.GetSyncBlockerSummary"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_sync_blocker_summary_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_sync_blocker_summary_input) =
+    let input = Json_serializers.get_sync_blocker_summary_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.GetSyncBlockerSummary" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_sync_blocker_summary_output_of_yojson
       ~error_deserializer
 end
@@ -519,6 +611,13 @@ module GetSyncConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_sync_configuration_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_sync_configuration_input) =
+    let input = Json_serializers.get_sync_configuration_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.GetSyncConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_sync_configuration_output_of_yojson
+      ~error_deserializer
 end
 
 module ListConnections = struct
@@ -541,6 +640,12 @@ module ListConnections = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.ListConnections"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_connections_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_connections_input) =
+    let input = Json_serializers.list_connections_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.ListConnections" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_connections_output_of_yojson ~error_deserializer
 end
 
 module ListHosts = struct
@@ -556,6 +661,12 @@ module ListHosts = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.ListHosts" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_hosts_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_hosts_input) =
+    let input = Json_serializers.list_hosts_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.ListHosts" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_hosts_output_of_yojson ~error_deserializer
 end
 
 module ListRepositoryLinks = struct
@@ -597,6 +708,13 @@ module ListRepositoryLinks = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_repository_links_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_repository_links_input) =
+    let input = Json_serializers.list_repository_links_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.ListRepositoryLinks" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_repository_links_output_of_yojson
+      ~error_deserializer
 end
 
 module ListRepositorySyncDefinitions = struct
@@ -630,6 +748,13 @@ module ListRepositorySyncDefinitions = struct
   let request context (request : list_repository_sync_definitions_input) =
     let input = Json_serializers.list_repository_sync_definitions_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"CodeConnections_20231201.ListRepositorySyncDefinitions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_repository_sync_definitions_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_repository_sync_definitions_input) =
+    let input = Json_serializers.list_repository_sync_definitions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"CodeConnections_20231201.ListRepositorySyncDefinitions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_repository_sync_definitions_output_of_yojson
       ~error_deserializer
@@ -669,6 +794,13 @@ module ListSyncConfigurations = struct
       ~shape_name:"CodeConnections_20231201.ListSyncConfigurations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_sync_configurations_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_sync_configurations_input) =
+    let input = Json_serializers.list_sync_configurations_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.ListSyncConfigurations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_sync_configurations_output_of_yojson
+      ~error_deserializer
 end
 
 module ListTagsForResource = struct
@@ -690,6 +822,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.ListTagsForResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_input) =
+    let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
       ~error_deserializer
 end
@@ -717,6 +856,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.TagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.tag_resource_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_input) =
+    let input = Json_serializers.tag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.TagResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_output_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -738,6 +883,12 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.UntagResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_input) =
+    let input = Json_serializers.untag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.UntagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.untag_resource_output_of_yojson ~error_deserializer
 end
 
@@ -774,6 +925,12 @@ module UpdateHost = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.UpdateHost" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_host_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_host_input) =
+    let input = Json_serializers.update_host_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.UpdateHost" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_host_output_of_yojson ~error_deserializer
 end
 
 module UpdateRepositoryLink = struct
@@ -817,6 +974,13 @@ module UpdateRepositoryLink = struct
     let input = Json_serializers.update_repository_link_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"CodeConnections_20231201.UpdateRepositoryLink"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_repository_link_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_repository_link_input) =
+    let input = Json_serializers.update_repository_link_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.UpdateRepositoryLink" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_repository_link_output_of_yojson
       ~error_deserializer
 end
@@ -865,6 +1029,13 @@ module UpdateSyncBlocker = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_sync_blocker_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_sync_blocker_input) =
+    let input = Json_serializers.update_sync_blocker_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"CodeConnections_20231201.UpdateSyncBlocker" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_sync_blocker_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateSyncConfiguration = struct
@@ -907,6 +1078,13 @@ module UpdateSyncConfiguration = struct
   let request context (request : update_sync_configuration_input) =
     let input = Json_serializers.update_sync_configuration_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"CodeConnections_20231201.UpdateSyncConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_sync_configuration_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_sync_configuration_input) =
+    let input = Json_serializers.update_sync_configuration_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"CodeConnections_20231201.UpdateSyncConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_sync_configuration_output_of_yojson
       ~error_deserializer

--- a/sdks/codeconnections/operations.mli
+++ b/sdks/codeconnections/operations.mli
@@ -25,7 +25,8 @@ module CreateConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ResourceUnavailableException of resource_unavailable_exception ] )
+      | `ResourceUnavailableException of resource_unavailable_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -51,7 +52,7 @@ module CreateHost : sig
     create_host_input ->
     ( create_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -101,7 +102,8 @@ module CreateRepositoryLink : sig
       | `InvalidInputException of invalid_input_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -145,7 +147,8 @@ module CreateSyncConfiguration : sig
       | `InvalidInputException of invalid_input_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -172,7 +175,8 @@ module DeleteConnection : sig
     delete_connection_input ->
     ( delete_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The connection to be deleted.\n"]
@@ -199,7 +203,8 @@ module DeleteHost : sig
     ( delete_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ResourceUnavailableException of resource_unavailable_exception ] )
+      | `ResourceUnavailableException of resource_unavailable_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -249,7 +254,8 @@ module DeleteRepositoryLink : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `SyncConfigurationStillExistsException of sync_configuration_still_exists_exception
       | `ThrottlingException of throttling_exception
-      | `UnsupportedProviderTypeException of unsupported_provider_type_exception ] )
+      | `UnsupportedProviderTypeException of unsupported_provider_type_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -289,7 +295,8 @@ module DeleteSyncConfiguration : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the sync configuration for a specified repository and connection.\n"]
@@ -316,7 +323,8 @@ module GetConnection : sig
     ( get_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ResourceUnavailableException of resource_unavailable_exception ] )
+      | `ResourceUnavailableException of resource_unavailable_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the connection ARN and details such as status, owner, and provider type.\n"]
@@ -343,7 +351,8 @@ module GetHost : sig
     ( get_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ResourceUnavailableException of resource_unavailable_exception ] )
+      | `ResourceUnavailableException of resource_unavailable_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -384,7 +393,8 @@ module GetRepositoryLink : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -422,7 +432,8 @@ module GetRepositorySyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -460,7 +471,8 @@ module GetResourceSyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -498,7 +510,8 @@ module GetSyncBlockerSummary : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of the most recent sync blockers.\n"]
@@ -534,7 +547,8 @@ module GetSyncConfiguration : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -561,7 +575,8 @@ module ListConnections : sig
     list_connections_input ->
     ( list_connections_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the connections associated with your account.\n"]
@@ -577,7 +592,9 @@ module ListHosts : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     list_hosts_input ->
-    (list_hosts_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( list_hosts_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc "Lists the hosts associated with your account.\n"]
 
@@ -615,7 +632,8 @@ module ListRepositoryLinks : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the repository links created for connections in your account.\n"]
@@ -651,7 +669,8 @@ module ListRepositorySyncDefinitions : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the repository sync definitions for repository links in your account.\n"]
@@ -687,7 +706,8 @@ module ListSyncConfigurations : sig
       | `InternalServerException of internal_server_exception
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of sync configurations for a specified repository.\n"]
@@ -711,7 +731,8 @@ module ListTagsForResource : sig
     list_tags_for_resource_input ->
     ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the set of key-value pairs (metadata) that are used to manage the resource.\n"]
@@ -738,7 +759,8 @@ module TagResource : sig
     ( tag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -764,7 +786,8 @@ module UntagResource : sig
     untag_resource_input ->
     ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tags from an Amazon Web Services resource.\n"]
@@ -797,7 +820,8 @@ module UpdateHost : sig
       | `ConflictException of conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a specified host with the provided configurations.\n"]
@@ -839,7 +863,8 @@ module UpdateRepositoryLink : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `UpdateOutOfSyncException of update_out_of_sync_exception ] )
+      | `UpdateOutOfSyncException of update_out_of_sync_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -884,7 +909,8 @@ module UpdateSyncBlocker : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `RetryLatestCommitFailedException of retry_latest_commit_failed_exception
       | `SyncBlockerDoesNotExistException of sync_blocker_does_not_exist_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -928,7 +954,8 @@ module UpdateSyncConfiguration : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `UpdateOutOfSyncException of update_out_of_sync_exception ] )
+      | `UpdateOutOfSyncException of update_out_of_sync_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/codeconnections/operations.mli
+++ b/sdks/codeconnections/operations.mli
@@ -17,6 +17,16 @@ module CreateConnection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_connection_input ->
+    ( create_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a connection that can then be given to other Amazon Web Services services like \
@@ -32,6 +42,14 @@ module CreateHost : sig
     'http_type Smaws_Lib.Context.t ->
     create_host_input ->
     ( create_host_output,
+      [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_host_input ->
+    ( create_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
     )
     result
@@ -71,6 +89,20 @@ module CreateRepositoryLink : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_repository_link_input ->
+    ( create_repository_link_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a link to a specified external Git repository. A repository link allows Git sync to \
@@ -101,6 +133,20 @@ module CreateSyncConfiguration : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_sync_configuration_input ->
+    ( create_sync_configuration_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a sync configuration which allows Amazon Web Services to sync content from a Git \
@@ -120,6 +166,14 @@ module DeleteConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_connection_input ->
+    ( delete_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "The connection to be deleted.\n"]
 
@@ -134,6 +188,15 @@ module DeleteHost : sig
     'http_type Smaws_Lib.Context.t ->
     delete_host_input ->
     ( delete_host_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_host_input ->
+    ( delete_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception ] )
@@ -173,6 +236,21 @@ module DeleteRepositoryLink : sig
       | `ThrottlingException of throttling_exception
       | `UnsupportedProviderTypeException of unsupported_provider_type_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_repository_link_input ->
+    ( delete_repository_link_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `SyncConfigurationStillExistsException of sync_configuration_still_exists_exception
+      | `ThrottlingException of throttling_exception
+      | `UnsupportedProviderTypeException of unsupported_provider_type_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the association between your connection and a specified external Git repository.\n"]
@@ -200,6 +278,19 @@ module DeleteSyncConfiguration : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_sync_configuration_input ->
+    ( delete_sync_configuration_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the sync configuration for a specified repository and connection.\n"]
 
@@ -218,6 +309,15 @@ module GetConnection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_connection_input ->
+    ( get_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the connection ARN and details such as status, owner, and provider type.\n"]
 
@@ -232,6 +332,15 @@ module GetHost : sig
     'http_type Smaws_Lib.Context.t ->
     get_host_input ->
     ( get_host_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_host_input ->
+    ( get_host_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception ] )
@@ -256,6 +365,19 @@ module GetRepositoryLink : sig
     'http_type Smaws_Lib.Context.t ->
     get_repository_link_input ->
     ( get_repository_link_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_repository_link_input ->
+    ( get_repository_link_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -290,6 +412,18 @@ module GetRepositorySyncStatus : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_repository_sync_status_input ->
+    ( get_repository_sync_status_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns details about the sync status for a repository. A repository sync uses Git sync to push \
@@ -309,6 +443,18 @@ module GetResourceSyncStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_sync_status_input ->
     ( get_resource_sync_status_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_sync_status_input ->
+    ( get_resource_sync_status_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -342,6 +488,18 @@ module GetSyncBlockerSummary : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sync_blocker_summary_input ->
+    ( get_sync_blocker_summary_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of the most recent sync blockers.\n"]
 
@@ -359,6 +517,18 @@ module GetSyncConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     get_sync_configuration_input ->
     ( get_sync_configuration_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sync_configuration_input ->
+    ( get_sync_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -385,6 +555,14 @@ module ListConnections : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_connections_input ->
+    ( list_connections_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the connections associated with your account.\n"]
 
@@ -395,6 +573,11 @@ module ListHosts : sig
     'http_type Smaws_Lib.Context.t ->
     list_hosts_input ->
     (list_hosts_output, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_hosts_input ->
+    (list_hosts_output Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc "Lists the hosts associated with your account.\n"]
 
@@ -413,6 +596,19 @@ module ListRepositoryLinks : sig
     'http_type Smaws_Lib.Context.t ->
     list_repository_links_input ->
     ( list_repository_links_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_repository_links_input ->
+    ( list_repository_links_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -445,6 +641,18 @@ module ListRepositorySyncDefinitions : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_repository_sync_definitions_input ->
+    ( list_repository_sync_definitions_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the repository sync definitions for repository links in your account.\n"]
 
@@ -469,6 +677,18 @@ module ListSyncConfigurations : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_sync_configurations_input ->
+    ( list_sync_configurations_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of sync configurations for a specified repository.\n"]
 
@@ -482,6 +702,14 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_input ->
     ( list_tags_for_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -503,6 +731,15 @@ module TagResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds to or modifies the tags of the given resource. Tags are metadata that can be used to \
@@ -518,6 +755,14 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_input ->
     ( untag_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -543,6 +788,17 @@ module UpdateHost : sig
       | `ResourceUnavailableException of resource_unavailable_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_host_input ->
+    ( update_host_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates a specified host with the provided configurations.\n"]
 
@@ -562,6 +818,20 @@ module UpdateRepositoryLink : sig
     'http_type Smaws_Lib.Context.t ->
     update_repository_link_input ->
     ( update_repository_link_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `UpdateOutOfSyncException of update_out_of_sync_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_repository_link_input ->
+    ( update_repository_link_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConditionalCheckFailedException of conditional_check_failed_exception
@@ -602,6 +872,20 @@ module UpdateSyncBlocker : sig
       | `SyncBlockerDoesNotExistException of sync_blocker_does_not_exist_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_sync_blocker_input ->
+    ( update_sync_blocker_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `RetryLatestCommitFailedException of retry_latest_commit_failed_exception
+      | `SyncBlockerDoesNotExistException of sync_blocker_does_not_exist_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows you to update the status of a sync blocker, resolving the blocker and allowing syncing \
@@ -623,6 +907,20 @@ module UpdateSyncConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     update_sync_configuration_input ->
     ( update_sync_configuration_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `UpdateOutOfSyncException of update_out_of_sync_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_sync_configuration_input ->
+    ( update_sync_configuration_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConcurrentModificationException of concurrent_modification_exception

--- a/sdks/cognito-identity/Smaws_Client_CognitoIdentity.mli
+++ b/sdks/cognito-identity/Smaws_Client_CognitoIdentity.mli
@@ -305,7 +305,8 @@ module CreateIdentityPool : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -362,7 +363,8 @@ module DeleteIdentities : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -402,7 +404,8 @@ module DeleteIdentityPool : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -442,7 +445,8 @@ module DescribeIdentity : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -482,7 +486,8 @@ module DescribeIdentityPool : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -531,7 +536,8 @@ module GetCredentialsForIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -581,7 +587,8 @@ module GetId : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -624,7 +631,8 @@ module GetIdentityPoolRoles : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -669,7 +677,8 @@ module GetOpenIdToken : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -718,7 +727,8 @@ module GetOpenIdTokenForDeveloperIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -768,7 +778,8 @@ module GetPrincipalTagAttributeMap : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -806,7 +817,8 @@ module ListIdentities : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -845,7 +857,8 @@ module ListIdentityPools : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -884,7 +897,8 @@ module ListTagsForResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -929,7 +943,8 @@ module LookupDeveloperIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -983,7 +998,8 @@ module MergeDeveloperIdentities : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1038,7 +1054,8 @@ module SetIdentityPoolRoles : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1078,7 +1095,8 @@ module SetPrincipalTagAttributeMap : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1116,7 +1134,8 @@ module TagResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1172,7 +1191,8 @@ module UnlinkDeveloperIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1220,7 +1240,8 @@ module UnlinkIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1261,7 +1282,8 @@ module UntagResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1309,7 +1331,8 @@ module UpdateIdentityPool : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/cognito-identity/Smaws_Client_CognitoIdentity.mli
+++ b/sdks/cognito-identity/Smaws_Client_CognitoIdentity.mli
@@ -294,6 +294,19 @@ module CreateIdentityPool : sig
       | `ResourceConflictException of resource_conflict_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_identity_pool_input ->
+    ( identity_pool Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new identity pool. The identity pool is a store of user identity information that is \
@@ -341,6 +354,16 @@ module DeleteIdentities : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_identities_input ->
+    ( delete_identities_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes identities from an identity pool. You can specify a list of 1-60 identities that you \
@@ -362,6 +385,18 @@ module DeleteIdentityPool : sig
     'http_type Smaws_Lib.Context.t ->
     delete_identity_pool_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_identity_pool_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -397,6 +432,18 @@ module DescribeIdentity : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_identity_input ->
+    ( identity_description Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns metadata related to the given identity, including when the identity was created and any \
@@ -418,6 +465,18 @@ module DescribeIdentityPool : sig
     'http_type Smaws_Lib.Context.t ->
     describe_identity_pool_input ->
     ( identity_pool,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_identity_pool_input ->
+    ( identity_pool Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -449,6 +508,21 @@ module GetCredentialsForIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     get_credentials_for_identity_input ->
     ( get_credentials_for_identity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExternalServiceException of external_service_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidIdentityPoolConfigurationException of invalid_identity_pool_configuration_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_credentials_for_identity_input ->
+    ( get_credentials_for_identity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExternalServiceException of external_service_exception
       | `InternalErrorException of internal_error_exception
@@ -494,6 +568,21 @@ module GetId : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_id_input ->
+    ( get_id_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExternalServiceException of external_service_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Generates (or retrieves) IdentityID. Supplying multiple logins will create an implicit linked \
@@ -516,6 +605,19 @@ module GetIdentityPoolRoles : sig
     'http_type Smaws_Lib.Context.t ->
     get_identity_pool_roles_input ->
     ( get_identity_pool_roles_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_identity_pool_roles_input ->
+    ( get_identity_pool_roles_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -555,6 +657,20 @@ module GetOpenIdToken : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_open_id_token_input ->
+    ( get_open_id_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExternalServiceException of external_service_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets an OpenID token, using a known Cognito ID. This known Cognito ID is returned by [GetId]. \
@@ -581,6 +697,20 @@ module GetOpenIdTokenForDeveloperIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     get_open_id_token_for_developer_identity_input ->
     ( get_open_id_token_for_developer_identity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DeveloperUserAlreadyRegisteredException of developer_user_already_registered_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_open_id_token_for_developer_identity_input ->
+    ( get_open_id_token_for_developer_identity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DeveloperUserAlreadyRegisteredException of developer_user_already_registered_exception
       | `InternalErrorException of internal_error_exception
@@ -628,6 +758,18 @@ module GetPrincipalTagAttributeMap : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_principal_tag_attribute_map_input ->
+    ( get_principal_tag_attribute_map_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Use [GetPrincipalTagAttributeMap] to list all mappings between [PrincipalTags] and user \
@@ -647,6 +789,18 @@ module ListIdentities : sig
     'http_type Smaws_Lib.Context.t ->
     list_identities_input ->
     ( list_identities_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_identities_input ->
+    ( list_identities_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -681,6 +835,18 @@ module ListIdentityPools : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_identity_pools_input ->
+    ( list_identity_pools_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all of the Cognito identity pools registered for your account.\n\n\
@@ -701,6 +867,18 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_input ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -732,6 +910,19 @@ module LookupDeveloperIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     lookup_developer_identity_input ->
     ( lookup_developer_identity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    lookup_developer_identity_input ->
+    ( lookup_developer_identity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -781,6 +972,19 @@ module MergeDeveloperIdentities : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    merge_developer_identities_input ->
+    ( merge_developer_identities_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Merges two users having different [IdentityId]s, existing in the same identity pool, and \
@@ -822,6 +1026,20 @@ module SetIdentityPoolRoles : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_identity_pool_roles_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the roles for an identity pool. These roles are used when making calls to \
@@ -850,6 +1068,18 @@ module SetPrincipalTagAttributeMap : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_principal_tag_attribute_map_input ->
+    ( set_principal_tag_attribute_map_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "You can use this operation to use default (username and clientID) attribute or custom attribute \
@@ -869,6 +1099,18 @@ module TagResource : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resource_input ->
     ( tag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -919,6 +1161,19 @@ module UnlinkDeveloperIdentity : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unlink_developer_identity_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Unlinks a [DeveloperUserIdentifier] from an existing identity. Unlinked developer users will be \
@@ -944,6 +1199,20 @@ module UnlinkIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     unlink_identity_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExternalServiceException of external_service_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unlink_identity_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExternalServiceException of external_service_exception
       | `InternalErrorException of internal_error_exception
@@ -982,6 +1251,18 @@ module UntagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the specified tags from the specified Amazon Cognito identity pool. You can use this \
@@ -1005,6 +1286,21 @@ module UpdateIdentityPool : sig
     'http_type Smaws_Lib.Context.t ->
     identity_pool ->
     ( identity_pool,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    identity_pool ->
+    ( identity_pool Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalErrorException of internal_error_exception

--- a/sdks/cognito-identity/operations.ml
+++ b/sdks/cognito-identity/operations.ml
@@ -38,6 +38,12 @@ module CreateIdentityPool = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.CreateIdentityPool"
       ~service ~context ~input ~output_deserializer:Json_deserializers.identity_pool_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_identity_pool_input) =
+    let input = Json_serializers.create_identity_pool_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.CreateIdentityPool" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.identity_pool_of_yojson ~error_deserializer
 end
 
 module DeleteIdentities = struct
@@ -66,6 +72,13 @@ module DeleteIdentities = struct
     let input = Json_serializers.delete_identities_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.DeleteIdentities"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_identities_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_identities_input) =
+    let input = Json_serializers.delete_identities_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.DeleteIdentities" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_identities_response_of_yojson
       ~error_deserializer
 end
@@ -105,6 +118,13 @@ module DeleteIdentityPool = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_identity_pool_input) =
+    let input = Json_serializers.delete_identity_pool_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.DeleteIdentityPool" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DescribeIdentity = struct
@@ -140,6 +160,12 @@ module DescribeIdentity = struct
     let input = Json_serializers.describe_identity_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.DescribeIdentity"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.identity_description_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_identity_input) =
+    let input = Json_serializers.describe_identity_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.DescribeIdentity" ~service ~context ~input
       ~output_deserializer:Json_deserializers.identity_description_of_yojson ~error_deserializer
 end
 
@@ -177,6 +203,12 @@ module DescribeIdentityPool = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.DescribeIdentityPool"
       ~service ~context ~input ~output_deserializer:Json_deserializers.identity_pool_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_identity_pool_input) =
+    let input = Json_serializers.describe_identity_pool_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.DescribeIdentityPool" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.identity_pool_of_yojson ~error_deserializer
 end
 
 module GetCredentialsForIdentity = struct
@@ -227,6 +259,13 @@ module GetCredentialsForIdentity = struct
       ~shape_name:"AWSCognitoIdentityService.GetCredentialsForIdentity" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_credentials_for_identity_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_credentials_for_identity_input) =
+    let input = Json_serializers.get_credentials_for_identity_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.GetCredentialsForIdentity" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_credentials_for_identity_response_of_yojson
+      ~error_deserializer
 end
 
 module GetId = struct
@@ -274,6 +313,12 @@ module GetId = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.GetId" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_id_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_id_input) =
+    let input = Json_serializers.get_id_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSCognitoIdentityService.GetId"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_id_response_of_yojson
+      ~error_deserializer
 end
 
 module GetIdentityPoolRoles = struct
@@ -313,6 +358,13 @@ module GetIdentityPoolRoles = struct
     let input = Json_serializers.get_identity_pool_roles_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.GetIdentityPoolRoles"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_identity_pool_roles_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_identity_pool_roles_input) =
+    let input = Json_serializers.get_identity_pool_roles_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.GetIdentityPoolRoles" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_identity_pool_roles_response_of_yojson
       ~error_deserializer
 end
@@ -358,6 +410,13 @@ module GetOpenIdToken = struct
     let input = Json_serializers.get_open_id_token_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.GetOpenIdToken"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_open_id_token_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_open_id_token_input) =
+    let input = Json_serializers.get_open_id_token_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.GetOpenIdToken" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_open_id_token_response_of_yojson
       ~error_deserializer
 end
@@ -408,6 +467,15 @@ module GetOpenIdTokenForDeveloperIdentity = struct
       ~output_deserializer:
         Json_deserializers.get_open_id_token_for_developer_identity_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_open_id_token_for_developer_identity_input) =
+    let input = Json_serializers.get_open_id_token_for_developer_identity_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.GetOpenIdTokenForDeveloperIdentity" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.get_open_id_token_for_developer_identity_response_of_yojson
+      ~error_deserializer
 end
 
 module GetPrincipalTagAttributeMap = struct
@@ -442,6 +510,13 @@ module GetPrincipalTagAttributeMap = struct
   let request context (request : get_principal_tag_attribute_map_input) =
     let input = Json_serializers.get_principal_tag_attribute_map_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSCognitoIdentityService.GetPrincipalTagAttributeMap" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_principal_tag_attribute_map_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_principal_tag_attribute_map_input) =
+    let input = Json_serializers.get_principal_tag_attribute_map_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSCognitoIdentityService.GetPrincipalTagAttributeMap" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_principal_tag_attribute_map_response_of_yojson
       ~error_deserializer
@@ -481,6 +556,12 @@ module ListIdentities = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.ListIdentities"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_identities_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_identities_input) =
+    let input = Json_serializers.list_identities_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.ListIdentities" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_identities_response_of_yojson ~error_deserializer
 end
 
 module ListIdentityPools = struct
@@ -518,6 +599,13 @@ module ListIdentityPools = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_identity_pools_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_identity_pools_input) =
+    let input = Json_serializers.list_identity_pools_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.ListIdentityPools" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_identity_pools_response_of_yojson
+      ~error_deserializer
 end
 
 module ListTagsForResource = struct
@@ -553,6 +641,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.ListTagsForResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_input) =
+    let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
 end
@@ -596,6 +691,13 @@ module LookupDeveloperIdentity = struct
       ~shape_name:"AWSCognitoIdentityService.LookupDeveloperIdentity" ~service ~context ~input
       ~output_deserializer:Json_deserializers.lookup_developer_identity_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : lookup_developer_identity_input) =
+    let input = Json_serializers.lookup_developer_identity_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.LookupDeveloperIdentity" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.lookup_developer_identity_response_of_yojson
+      ~error_deserializer
 end
 
 module MergeDeveloperIdentities = struct
@@ -634,6 +736,13 @@ module MergeDeveloperIdentities = struct
   let request context (request : merge_developer_identities_input) =
     let input = Json_serializers.merge_developer_identities_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSCognitoIdentityService.MergeDeveloperIdentities" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.merge_developer_identities_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : merge_developer_identities_input) =
+    let input = Json_serializers.merge_developer_identities_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSCognitoIdentityService.MergeDeveloperIdentities" ~service ~context ~input
       ~output_deserializer:Json_deserializers.merge_developer_identities_response_of_yojson
       ~error_deserializer
@@ -683,6 +792,13 @@ module SetIdentityPoolRoles = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : set_identity_pool_roles_input) =
+    let input = Json_serializers.set_identity_pool_roles_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.SetIdentityPoolRoles" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module SetPrincipalTagAttributeMap = struct
@@ -717,6 +833,13 @@ module SetPrincipalTagAttributeMap = struct
   let request context (request : set_principal_tag_attribute_map_input) =
     let input = Json_serializers.set_principal_tag_attribute_map_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSCognitoIdentityService.SetPrincipalTagAttributeMap" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.set_principal_tag_attribute_map_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : set_principal_tag_attribute_map_input) =
+    let input = Json_serializers.set_principal_tag_attribute_map_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSCognitoIdentityService.SetPrincipalTagAttributeMap" ~service ~context ~input
       ~output_deserializer:Json_deserializers.set_principal_tag_attribute_map_response_of_yojson
       ~error_deserializer
@@ -756,6 +879,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.TagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_input) =
+    let input = Json_serializers.tag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.TagResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UnlinkDeveloperIdentity = struct
@@ -794,6 +923,13 @@ module UnlinkDeveloperIdentity = struct
   let request context (request : unlink_developer_identity_input) =
     let input = Json_serializers.unlink_developer_identity_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSCognitoIdentityService.UnlinkDeveloperIdentity" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : unlink_developer_identity_input) =
+    let input = Json_serializers.unlink_developer_identity_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSCognitoIdentityService.UnlinkDeveloperIdentity" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -842,6 +978,13 @@ module UnlinkIdentity = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : unlink_identity_input) =
+    let input = Json_serializers.unlink_identity_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.UnlinkIdentity" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -877,6 +1020,12 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.UntagResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_input) =
+    let input = Json_serializers.untag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.UntagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
@@ -926,4 +1075,10 @@ module UpdateIdentityPool = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSCognitoIdentityService.UpdateIdentityPool"
       ~service ~context ~input ~output_deserializer:Json_deserializers.identity_pool_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : identity_pool) =
+    let input = Json_serializers.identity_pool_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSCognitoIdentityService.UpdateIdentityPool" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.identity_pool_of_yojson ~error_deserializer
 end

--- a/sdks/cognito-identity/operations.mli
+++ b/sdks/cognito-identity/operations.mli
@@ -23,6 +23,19 @@ module CreateIdentityPool : sig
       | `ResourceConflictException of resource_conflict_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_identity_pool_input ->
+    ( identity_pool Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new identity pool. The identity pool is a store of user identity information that is \
@@ -70,6 +83,16 @@ module DeleteIdentities : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_identities_input ->
+    ( delete_identities_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes identities from an identity pool. You can specify a list of 1-60 identities that you \
@@ -91,6 +114,18 @@ module DeleteIdentityPool : sig
     'http_type Smaws_Lib.Context.t ->
     delete_identity_pool_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_identity_pool_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -126,6 +161,18 @@ module DescribeIdentity : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_identity_input ->
+    ( identity_description Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns metadata related to the given identity, including when the identity was created and any \
@@ -147,6 +194,18 @@ module DescribeIdentityPool : sig
     'http_type Smaws_Lib.Context.t ->
     describe_identity_pool_input ->
     ( identity_pool,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_identity_pool_input ->
+    ( identity_pool Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -178,6 +237,21 @@ module GetCredentialsForIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     get_credentials_for_identity_input ->
     ( get_credentials_for_identity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExternalServiceException of external_service_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidIdentityPoolConfigurationException of invalid_identity_pool_configuration_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_credentials_for_identity_input ->
+    ( get_credentials_for_identity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExternalServiceException of external_service_exception
       | `InternalErrorException of internal_error_exception
@@ -223,6 +297,21 @@ module GetId : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_id_input ->
+    ( get_id_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExternalServiceException of external_service_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Generates (or retrieves) IdentityID. Supplying multiple logins will create an implicit linked \
@@ -245,6 +334,19 @@ module GetIdentityPoolRoles : sig
     'http_type Smaws_Lib.Context.t ->
     get_identity_pool_roles_input ->
     ( get_identity_pool_roles_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_identity_pool_roles_input ->
+    ( get_identity_pool_roles_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -284,6 +386,20 @@ module GetOpenIdToken : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_open_id_token_input ->
+    ( get_open_id_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExternalServiceException of external_service_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets an OpenID token, using a known Cognito ID. This known Cognito ID is returned by [GetId]. \
@@ -310,6 +426,20 @@ module GetOpenIdTokenForDeveloperIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     get_open_id_token_for_developer_identity_input ->
     ( get_open_id_token_for_developer_identity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DeveloperUserAlreadyRegisteredException of developer_user_already_registered_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_open_id_token_for_developer_identity_input ->
+    ( get_open_id_token_for_developer_identity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DeveloperUserAlreadyRegisteredException of developer_user_already_registered_exception
       | `InternalErrorException of internal_error_exception
@@ -357,6 +487,18 @@ module GetPrincipalTagAttributeMap : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_principal_tag_attribute_map_input ->
+    ( get_principal_tag_attribute_map_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Use [GetPrincipalTagAttributeMap] to list all mappings between [PrincipalTags] and user \
@@ -376,6 +518,18 @@ module ListIdentities : sig
     'http_type Smaws_Lib.Context.t ->
     list_identities_input ->
     ( list_identities_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_identities_input ->
+    ( list_identities_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -410,6 +564,18 @@ module ListIdentityPools : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_identity_pools_input ->
+    ( list_identity_pools_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all of the Cognito identity pools registered for your account.\n\n\
@@ -430,6 +596,18 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_input ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -461,6 +639,19 @@ module LookupDeveloperIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     lookup_developer_identity_input ->
     ( lookup_developer_identity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    lookup_developer_identity_input ->
+    ( lookup_developer_identity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -510,6 +701,19 @@ module MergeDeveloperIdentities : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    merge_developer_identities_input ->
+    ( merge_developer_identities_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Merges two users having different [IdentityId]s, existing in the same identity pool, and \
@@ -551,6 +755,20 @@ module SetIdentityPoolRoles : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_identity_pool_roles_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the roles for an identity pool. These roles are used when making calls to \
@@ -579,6 +797,18 @@ module SetPrincipalTagAttributeMap : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_principal_tag_attribute_map_input ->
+    ( set_principal_tag_attribute_map_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "You can use this operation to use default (username and clientID) attribute or custom attribute \
@@ -598,6 +828,18 @@ module TagResource : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resource_input ->
     ( tag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -648,6 +890,19 @@ module UnlinkDeveloperIdentity : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unlink_developer_identity_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Unlinks a [DeveloperUserIdentifier] from an existing identity. Unlinked developer users will be \
@@ -673,6 +928,20 @@ module UnlinkIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     unlink_identity_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExternalServiceException of external_service_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unlink_identity_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExternalServiceException of external_service_exception
       | `InternalErrorException of internal_error_exception
@@ -711,6 +980,18 @@ module UntagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyRequestsException of too_many_requests_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the specified tags from the specified Amazon Cognito identity pool. You can use this \
@@ -733,6 +1014,21 @@ module UpdateIdentityPool : sig
     'http_type Smaws_Lib.Context.t ->
     identity_pool ->
     ( identity_pool,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotAuthorizedException of not_authorized_exception
+      | `ResourceConflictException of resource_conflict_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyRequestsException of too_many_requests_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    identity_pool ->
+    ( identity_pool Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalErrorException of internal_error_exception

--- a/sdks/cognito-identity/operations.mli
+++ b/sdks/cognito-identity/operations.mli
@@ -34,7 +34,8 @@ module CreateIdentityPool : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -91,7 +92,8 @@ module DeleteIdentities : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -131,7 +133,8 @@ module DeleteIdentityPool : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -171,7 +174,8 @@ module DescribeIdentity : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -211,7 +215,8 @@ module DescribeIdentityPool : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -260,7 +265,8 @@ module GetCredentialsForIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -310,7 +316,8 @@ module GetId : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -353,7 +360,8 @@ module GetIdentityPoolRoles : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -398,7 +406,8 @@ module GetOpenIdToken : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -447,7 +456,8 @@ module GetOpenIdTokenForDeveloperIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -497,7 +507,8 @@ module GetPrincipalTagAttributeMap : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -535,7 +546,8 @@ module ListIdentities : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -574,7 +586,8 @@ module ListIdentityPools : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -613,7 +626,8 @@ module ListTagsForResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -658,7 +672,8 @@ module LookupDeveloperIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -712,7 +727,8 @@ module MergeDeveloperIdentities : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -767,7 +783,8 @@ module SetIdentityPoolRoles : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -807,7 +824,8 @@ module SetPrincipalTagAttributeMap : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -845,7 +863,8 @@ module TagResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -901,7 +920,8 @@ module UnlinkDeveloperIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -949,7 +969,8 @@ module UnlinkIdentity : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -990,7 +1011,8 @@ module UntagResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1037,7 +1059,8 @@ module UpdateIdentityPool : sig
       | `NotAuthorizedException of not_authorized_exception
       | `ResourceConflictException of resource_conflict_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyRequestsException of too_many_requests_exception ] )
+      | `TooManyRequestsException of too_many_requests_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/config-service/Smaws_Client_ConfigService.mli
+++ b/sdks/config-service/Smaws_Client_ConfigService.mli
@@ -1852,7 +1852,8 @@ module AssociateResourceTypes : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1886,7 +1887,8 @@ module BatchGetAggregateResourceConfig : sig
     ( batch_get_aggregate_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1926,7 +1928,8 @@ module BatchGetResourceConfig : sig
     ( batch_get_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1963,7 +1966,8 @@ module DeleteAggregationAuthorization : sig
     delete_aggregation_authorization_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1992,7 +1996,8 @@ module DeleteConfigRule : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigRuleException of no_such_config_rule_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2040,7 +2045,8 @@ module DeleteConfigurationAggregator : sig
     delete_configuration_aggregator_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2069,7 +2075,8 @@ module DeleteConfigurationRecorder : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2103,7 +2110,8 @@ module DeleteConformancePack : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConformancePackException of no_such_conformance_pack_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2151,7 +2159,8 @@ module DeleteDeliveryChannel : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LastDeliveryChannelDeleteFailedException of last_delivery_channel_delete_failed_exception
-      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2183,7 +2192,8 @@ module DeleteEvaluationResults : sig
     ( delete_evaluation_results_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigRuleException of no_such_config_rule_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2217,7 +2227,8 @@ module DeleteOrganizationConfigRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2275,7 +2286,8 @@ module DeleteOrganizationConformancePack : sig
       | `NoSuchOrganizationConformancePackException of
         no_such_organization_conformance_pack_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2325,7 +2337,8 @@ module DeletePendingAggregationRequest : sig
     delete_pending_aggregation_request_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2359,7 +2372,8 @@ module DeleteRemediationConfiguration : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception
-      | `RemediationInProgressException of remediation_in_progress_exception ] )
+      | `RemediationInProgressException of remediation_in_progress_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the remediation configuration.\n"]
@@ -2383,7 +2397,8 @@ module DeleteRemediationExceptions : sig
     delete_remediation_exceptions_request ->
     ( delete_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchRemediationExceptionException of no_such_remediation_exception_exception ] )
+      | `NoSuchRemediationExceptionException of no_such_remediation_exception_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2416,7 +2431,8 @@ module DeleteResourceConfig : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2446,7 +2462,8 @@ module DeleteRetentionConfiguration : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
+      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the retention configuration.\n"]
@@ -2476,7 +2493,8 @@ module DeleteServiceLinkedConfigurationRecorder : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2517,7 +2535,8 @@ module DeleteStoredQuery : sig
     ( delete_stored_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2549,7 +2568,8 @@ module DeliverConfigSnapshot : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
-      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2598,7 +2618,8 @@ module DescribeAggregateComplianceByConfigRules : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2637,7 +2658,8 @@ module DescribeAggregateComplianceByConformancePacks : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2675,7 +2697,8 @@ module DescribeAggregationAuthorizations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2706,7 +2729,8 @@ module DescribeComplianceByConfigRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2760,7 +2784,8 @@ module DescribeComplianceByResource : sig
     ( describe_compliance_by_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2818,7 +2843,8 @@ module DescribeConfigRuleEvaluationStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2851,7 +2877,8 @@ module DescribeConfigRules : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns details about your Config rules.\n"]
@@ -2884,7 +2911,8 @@ module DescribeConfigurationAggregators : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2920,7 +2948,8 @@ module DescribeConfigurationAggregatorSourcesStatus : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2950,7 +2979,8 @@ module DescribeConfigurationRecorders : sig
     ( describe_configuration_recorders_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2984,7 +3014,8 @@ module DescribeConfigurationRecorderStatus : sig
     ( describe_configuration_recorder_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3034,7 +3065,8 @@ module DescribeConformancePackCompliance : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleInConformancePackException of
         no_such_config_rule_in_conformance_pack_exception
-      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3071,7 +3103,8 @@ module DescribeConformancePacks : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of one or more conformance packs.\n"]
@@ -3101,7 +3134,8 @@ module DescribeConformancePackStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3129,7 +3163,8 @@ module DescribeDeliveryChannels : sig
     describe_delivery_channels_request ->
     ( describe_delivery_channels_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3158,7 +3193,8 @@ module DescribeDeliveryChannelStatus : sig
     describe_delivery_channel_status_request ->
     ( describe_delivery_channel_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3197,7 +3233,8 @@ module DescribeOrganizationConfigRules : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3249,7 +3286,8 @@ module DescribeOrganizationConfigRuleStatuses : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3293,7 +3331,8 @@ module DescribeOrganizationConformancePacks : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConformancePackException of
         no_such_organization_conformance_pack_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3347,7 +3386,8 @@ module DescribeOrganizationConformancePackStatuses : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConformancePackException of
         no_such_organization_conformance_pack_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3386,7 +3426,8 @@ module DescribePendingAggregationRequests : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of all pending aggregation requests.\n"]
@@ -3403,7 +3444,7 @@ module DescribeRemediationConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_remediation_configurations_request ->
     ( describe_remediation_configurations_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the details of one or more remediation configurations.\n"]
@@ -3430,7 +3471,8 @@ module DescribeRemediationExceptions : sig
     ( describe_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3476,7 +3518,7 @@ module DescribeRemediationExecutionStatus : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3510,7 +3552,8 @@ module DescribeRetentionConfigurations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
+      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3546,7 +3589,8 @@ module DisassociateResourceTypes : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3586,7 +3630,8 @@ module GetAggregateComplianceDetailsByConfigRule : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3626,7 +3671,8 @@ module GetAggregateConfigRuleComplianceSummary : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3665,7 +3711,8 @@ module GetAggregateConformancePackComplianceSummary : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3705,7 +3752,8 @@ module GetAggregateDiscoveredResourceCounts : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3745,7 +3793,8 @@ module GetAggregateResourceConfig : sig
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `OversizedConfigurationItemException of oversized_configuration_item_exception
       | `ResourceNotDiscoveredException of resource_not_discovered_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3780,7 +3829,8 @@ module GetComplianceDetailsByConfigRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3807,7 +3857,8 @@ module GetComplianceDetailsByResource : sig
     get_compliance_details_by_resource_request ->
     ( get_compliance_details_by_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3827,7 +3878,7 @@ module GetComplianceSummaryByConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( get_compliance_summary_by_config_rule_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3853,7 +3904,8 @@ module GetComplianceSummaryByResourceType : sig
     get_compliance_summary_by_resource_type_request ->
     ( get_compliance_summary_by_resource_type_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3895,7 +3947,8 @@ module GetConformancePackComplianceDetails : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleInConformancePackException of
         no_such_config_rule_in_conformance_pack_exception
-      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3927,7 +3980,8 @@ module GetConformancePackComplianceSummary : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3953,7 +4007,8 @@ module GetCustomRulePolicy : sig
     get_custom_rule_policy_request ->
     ( get_custom_rule_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3984,7 +4039,8 @@ module GetDiscoveredResourceCounts : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4066,7 +4122,8 @@ module GetOrganizationConfigRuleDetailedStatus : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4103,7 +4160,8 @@ module GetOrganizationConformancePackDetailedStatus : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConformancePackException of
         no_such_organization_conformance_pack_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4132,7 +4190,8 @@ module GetOrganizationCustomRulePolicy : sig
     ( get_organization_custom_rule_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4173,7 +4232,8 @@ module GetResourceConfigHistory : sig
       | `InvalidTimeRangeException of invalid_time_range_exception
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `ResourceNotDiscoveredException of resource_not_discovered_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4225,7 +4285,8 @@ module GetResourceEvaluationSummary : sig
     get_resource_evaluation_summary_request ->
     ( get_resource_evaluation_summary_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4264,7 +4325,8 @@ module GetStoredQuery : sig
     ( get_stored_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the details of a specific stored query.\n"]
@@ -4297,7 +4359,8 @@ module ListAggregateDiscoveredResources : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4326,7 +4389,8 @@ module ListConfigurationRecorders : sig
     'http_type Smaws_Lib.Context.t ->
     list_configuration_recorders_request ->
     ( list_configuration_recorders_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of configuration recorders depending on the filters you specify.\n"]
@@ -4356,7 +4420,8 @@ module ListConformancePackComplianceScores : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4398,7 +4463,8 @@ module ListDiscoveredResources : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4468,7 +4534,8 @@ module ListResourceEvaluations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `InvalidTimeRangeException of invalid_time_range_exception ] )
+      | `InvalidTimeRangeException of invalid_time_range_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of proactive resource evaluations.\n"]
@@ -4495,7 +4562,8 @@ module ListStoredQueries : sig
     ( list_stored_queries_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4530,7 +4598,8 @@ module ListTagsForResource : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List the tags for Config resource.\n"]
@@ -4554,7 +4623,8 @@ module PutAggregationAuthorization : sig
     put_aggregation_authorization_request ->
     ( put_aggregation_authorization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4605,7 +4675,8 @@ module PutConfigRule : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `MaxNumberOfConfigRulesExceededException of max_number_of_config_rules_exceeded_exception
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4700,7 +4771,8 @@ module PutConfigurationAggregator : sig
       | `NoAvailableOrganizationException of no_available_organization_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception
       | `OrganizationAllFeaturesNotEnabledException of
-        organization_all_features_not_enabled_exception ] )
+        organization_all_features_not_enabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4774,7 +4846,8 @@ module PutConfigurationRecorder : sig
       | `MaxNumberOfConfigurationRecordersExceededException of
         max_number_of_configuration_recorders_exceeded_exception
       | `UnmodifiableEntityException of unmodifiable_entity_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4855,7 +4928,8 @@ module PutConformancePack : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `MaxNumberOfConformancePacksExceededException of
         max_number_of_conformance_packs_exceeded_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4936,7 +5010,8 @@ module PutDeliveryChannel : sig
       | `MaxNumberOfDeliveryChannelsExceededException of
         max_number_of_delivery_channels_exceeded_exception
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
-      | `NoSuchBucketException of no_such_bucket_exception ] )
+      | `NoSuchBucketException of no_such_bucket_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4980,7 +5055,8 @@ module PutEvaluations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `InvalidResultTokenException of invalid_result_token_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5009,7 +5085,8 @@ module PutExternalEvaluation : sig
     ( put_external_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5061,7 +5138,8 @@ module PutOrganizationConfigRule : sig
       | `OrganizationAllFeaturesNotEnabledException of
         organization_all_features_not_enabled_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5167,7 +5245,8 @@ module PutOrganizationConformancePack : sig
       | `OrganizationConformancePackTemplateValidationException of
         organization_conformance_pack_template_validation_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5232,7 +5311,8 @@ module PutRemediationConfigurations : sig
     ( put_remediation_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5297,7 +5377,8 @@ module PutRemediationExceptions : sig
     ( put_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5377,7 +5458,8 @@ module PutResourceConfig : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `MaxActiveResourcesExceededException of max_active_resources_exceeded_exception
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5420,7 +5502,8 @@ module PutRetentionConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `MaxNumberOfRetentionConfigurationsExceededException of
-        max_number_of_retention_configurations_exceeded_exception ] )
+        max_number_of_retention_configurations_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5461,7 +5544,8 @@ module PutServiceLinkedConfigurationRecorder : sig
       | `ConflictException of conflict_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5517,7 +5601,8 @@ module PutStoredQuery : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceConcurrentModificationException of resource_concurrent_modification_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5561,7 +5646,8 @@ module SelectAggregateResourceConfig : sig
       | `InvalidExpressionException of invalid_expression_exception
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5609,7 +5695,8 @@ module SelectResourceConfig : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidExpressionException of invalid_expression_exception
       | `InvalidLimitException of invalid_limit_exception
-      | `InvalidNextTokenException of invalid_next_token_exception ] )
+      | `InvalidNextTokenException of invalid_next_token_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5648,7 +5735,8 @@ module StartConfigRulesEvaluation : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `LimitExceededException of limit_exceeded_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5714,7 +5802,8 @@ module StartConfigurationRecorder : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoAvailableDeliveryChannelException of no_available_delivery_channel_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5753,7 +5842,7 @@ module StartRemediationExecution : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5786,7 +5875,8 @@ module StartResourceEvaluation : sig
     ( start_resource_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5834,7 +5924,8 @@ module StopConfigurationRecorder : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5866,7 +5957,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5898,7 +5990,8 @@ module UntagResource : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes specified tags from a resource.\n"]

--- a/sdks/config-service/Smaws_Client_ConfigService.mli
+++ b/sdks/config-service/Smaws_Client_ConfigService.mli
@@ -1844,6 +1844,16 @@ module AssociateResourceTypes : sig
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_resource_types_request ->
+    ( associate_resource_types_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds all resource types specified in the [ResourceTypes] list to the \
@@ -1865,6 +1875,15 @@ module BatchGetAggregateResourceConfig : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_aggregate_resource_config_request ->
     ( batch_get_aggregate_resource_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_aggregate_resource_config_request ->
+    ( batch_get_aggregate_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `ValidationException of validation_exception ] )
@@ -1900,6 +1919,15 @@ module BatchGetResourceConfig : sig
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_resource_config_request ->
+    ( batch_get_resource_config_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the [BaseConfigurationItem] for one or more requested resources. The operation also \
@@ -1929,6 +1957,14 @@ module DeleteAggregationAuthorization : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_aggregation_authorization_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the authorization granted to the specified configuration aggregator account in a \
@@ -1945,6 +1981,15 @@ module DeleteConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_config_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigRuleException of no_such_config_rule_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_config_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigRuleException of no_such_config_rule_exception
       | `ResourceInUseException of resource_in_use_exception ] )
@@ -1989,6 +2034,14 @@ module DeleteConfigurationAggregator : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_configuration_aggregator_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified configuration aggregator and the aggregated data associated with the \
@@ -2005,6 +2058,15 @@ module DeleteConfigurationRecorder : sig
     'http_type Smaws_Lib.Context.t ->
     delete_configuration_recorder_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_configuration_recorder_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
@@ -2030,6 +2092,15 @@ module DeleteConformancePack : sig
     'http_type Smaws_Lib.Context.t ->
     delete_conformance_pack_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_conformance_pack_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConformancePackException of no_such_conformance_pack_exception
       | `ResourceInUseException of resource_in_use_exception ] )
@@ -2073,6 +2144,15 @@ module DeleteDeliveryChannel : sig
       | `LastDeliveryChannelDeleteFailedException of last_delivery_channel_delete_failed_exception
       | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_delivery_channel_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LastDeliveryChannelDeleteFailedException of last_delivery_channel_delete_failed_exception
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the delivery channel.\n\n\
@@ -2096,6 +2176,15 @@ module DeleteEvaluationResults : sig
       | `NoSuchConfigRuleException of no_such_config_rule_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_evaluation_results_request ->
+    ( delete_evaluation_results_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigRuleException of no_such_config_rule_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the evaluation results for the specified Config rule. You can specify one Config rule \
@@ -2115,6 +2204,16 @@ module DeleteOrganizationConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_organization_config_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_organization_config_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception
@@ -2167,6 +2266,17 @@ module DeleteOrganizationConformancePack : sig
       | `OrganizationAccessDeniedException of organization_access_denied_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_organization_conformance_pack_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchOrganizationConformancePackException of
+        no_such_organization_conformance_pack_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified organization conformance pack and all of the Config rules and remediation \
@@ -2209,6 +2319,14 @@ module DeletePendingAggregationRequest : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_pending_aggregation_request_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes pending authorization requests for a specified aggregator account in a specified region.\n"]
@@ -2232,6 +2350,17 @@ module DeleteRemediationConfiguration : sig
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception
       | `RemediationInProgressException of remediation_in_progress_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_remediation_configuration_request ->
+    ( delete_remediation_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception
+      | `RemediationInProgressException of remediation_in_progress_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the remediation configuration.\n"]
 
@@ -2245,6 +2374,14 @@ module DeleteRemediationExceptions : sig
     'http_type Smaws_Lib.Context.t ->
     delete_remediation_exceptions_request ->
     ( delete_remediation_exceptions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchRemediationExceptionException of no_such_remediation_exception_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_remediation_exceptions_request ->
+    ( delete_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchRemediationExceptionException of no_such_remediation_exception_exception ] )
     result
@@ -2272,6 +2409,15 @@ module DeleteResourceConfig : sig
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_config_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Records the configuration state for a custom resource that has been deleted. This API records a \
@@ -2293,6 +2439,15 @@ module DeleteRetentionConfiguration : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_retention_configuration_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the retention configuration.\n"]
 
@@ -2308,6 +2463,16 @@ module DeleteServiceLinkedConfigurationRecorder : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_linked_configuration_recorder_request ->
     ( delete_service_linked_configuration_recorder_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_linked_configuration_recorder_request ->
+    ( delete_service_linked_configuration_recorder_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
@@ -2345,6 +2510,15 @@ module DeleteStoredQuery : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_stored_query_request ->
+    ( delete_stored_query_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the stored query for a single Amazon Web Services account and a single Amazon Web \
@@ -2362,6 +2536,16 @@ module DeliverConfigSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     deliver_config_snapshot_request ->
     ( deliver_config_snapshot_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deliver_config_snapshot_request ->
+    ( deliver_config_snapshot_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
@@ -2405,6 +2589,17 @@ module DescribeAggregateComplianceByConfigRules : sig
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_aggregate_compliance_by_config_rules_request ->
+    ( describe_aggregate_compliance_by_config_rules_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of compliant and noncompliant rules with the number of resources for compliant \
@@ -2427,6 +2622,17 @@ module DescribeAggregateComplianceByConformancePacks : sig
     'http_type Smaws_Lib.Context.t ->
     describe_aggregate_compliance_by_conformance_packs_request ->
     ( describe_aggregate_compliance_by_conformance_packs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_aggregate_compliance_by_conformance_packs_request ->
+    ( describe_aggregate_compliance_by_conformance_packs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -2461,6 +2667,16 @@ module DescribeAggregationAuthorizations : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_aggregation_authorizations_request ->
+    ( describe_aggregation_authorizations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of authorizations granted to various aggregator accounts and regions.\n"]
@@ -2477,6 +2693,16 @@ module DescribeComplianceByConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     describe_compliance_by_config_rule_request ->
     ( describe_compliance_by_config_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_compliance_by_config_rule_request ->
+    ( describe_compliance_by_config_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -2523,6 +2749,15 @@ module DescribeComplianceByResource : sig
     'http_type Smaws_Lib.Context.t ->
     describe_compliance_by_resource_request ->
     ( describe_compliance_by_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_compliance_by_resource_request ->
+    ( describe_compliance_by_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
@@ -2575,6 +2810,16 @@ module DescribeConfigRuleEvaluationStatus : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_config_rule_evaluation_status_request ->
+    ( describe_config_rule_evaluation_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns status information for each of your Config managed rules. The status includes \
@@ -2598,6 +2843,16 @@ module DescribeConfigRules : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_config_rules_request ->
+    ( describe_config_rules_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc "Returns details about your Config rules.\n"]
 
@@ -2614,6 +2869,17 @@ module DescribeConfigurationAggregators : sig
     'http_type Smaws_Lib.Context.t ->
     describe_configuration_aggregators_request ->
     ( describe_configuration_aggregators_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_configuration_aggregators_request ->
+    ( describe_configuration_aggregators_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -2645,6 +2911,17 @@ module DescribeConfigurationAggregatorSourcesStatus : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_configuration_aggregator_sources_status_request ->
+    ( describe_configuration_aggregator_sources_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns status information for sources within an aggregator. The status includes information \
@@ -2662,6 +2939,15 @@ module DescribeConfigurationRecorders : sig
     'http_type Smaws_Lib.Context.t ->
     describe_configuration_recorders_request ->
     ( describe_configuration_recorders_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_configuration_recorders_request ->
+    ( describe_configuration_recorders_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
@@ -2687,6 +2973,15 @@ module DescribeConfigurationRecorderStatus : sig
     'http_type Smaws_Lib.Context.t ->
     describe_configuration_recorder_status_request ->
     ( describe_configuration_recorder_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_configuration_recorder_status_request ->
+    ( describe_configuration_recorder_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
@@ -2728,6 +3023,19 @@ module DescribeConformancePackCompliance : sig
         no_such_config_rule_in_conformance_pack_exception
       | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_conformance_pack_compliance_request ->
+    ( describe_conformance_pack_compliance_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleInConformancePackException of
+        no_such_config_rule_in_conformance_pack_exception
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns compliance details for each rule in that conformance pack.\n\n\
@@ -2754,6 +3062,17 @@ module DescribeConformancePacks : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_conformance_packs_request ->
+    ( describe_conformance_packs_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of one or more conformance packs.\n"]
 
@@ -2769,6 +3088,16 @@ module DescribeConformancePackStatus : sig
     'http_type Smaws_Lib.Context.t ->
     describe_conformance_pack_status_request ->
     ( describe_conformance_pack_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_conformance_pack_status_request ->
+    ( describe_conformance_pack_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -2794,6 +3123,14 @@ module DescribeDeliveryChannels : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_delivery_channels_request ->
+    ( describe_delivery_channels_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns details about the specified delivery channel. If a delivery channel is not specified, \
@@ -2812,6 +3149,14 @@ module DescribeDeliveryChannelStatus : sig
     'http_type Smaws_Lib.Context.t ->
     describe_delivery_channel_status_request ->
     ( describe_delivery_channel_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_delivery_channel_status_request ->
+    ( describe_delivery_channel_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
     result
@@ -2837,6 +3182,17 @@ module DescribeOrganizationConfigRules : sig
     'http_type Smaws_Lib.Context.t ->
     describe_organization_config_rules_request ->
     ( describe_organization_config_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_config_rules_request ->
+    ( describe_organization_config_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -2884,6 +3240,17 @@ module DescribeOrganizationConfigRuleStatuses : sig
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_config_rule_statuses_request ->
+    ( describe_organization_config_rule_statuses_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides organization Config rule deployment status for an organization.\n\n\
@@ -2909,6 +3276,18 @@ module DescribeOrganizationConformancePacks : sig
     'http_type Smaws_Lib.Context.t ->
     describe_organization_conformance_packs_request ->
     ( describe_organization_conformance_packs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConformancePackException of
+        no_such_organization_conformance_pack_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_conformance_packs_request ->
+    ( describe_organization_conformance_packs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -2958,6 +3337,18 @@ module DescribeOrganizationConformancePackStatuses : sig
         no_such_organization_conformance_pack_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_conformance_pack_statuses_request ->
+    ( describe_organization_conformance_pack_statuses_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConformancePackException of
+        no_such_organization_conformance_pack_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides organization conformance pack deployment status for an organization. \n\n\
@@ -2987,6 +3378,16 @@ module DescribePendingAggregationRequests : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_pending_aggregation_requests_request ->
+    ( describe_pending_aggregation_requests_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of all pending aggregation requests.\n"]
 
@@ -2997,6 +3398,13 @@ module DescribeRemediationConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_remediation_configurations_request ->
     (describe_remediation_configurations_response, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_remediation_configurations_request ->
+    ( describe_remediation_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc "Returns the details of one or more remediation configurations.\n"]
 
@@ -3011,6 +3419,15 @@ module DescribeRemediationExceptions : sig
     'http_type Smaws_Lib.Context.t ->
     describe_remediation_exceptions_request ->
     ( describe_remediation_exceptions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_remediation_exceptions_request ->
+    ( describe_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
@@ -3050,6 +3467,17 @@ module DescribeRemediationExecutionStatus : sig
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_remediation_execution_status_request ->
+    ( describe_remediation_execution_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Provides a detailed view of a Remediation Execution for a set of resources including state, \
@@ -3069,6 +3497,16 @@ module DescribeRetentionConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_retention_configurations_request ->
     ( describe_retention_configurations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_retention_configurations_request ->
+    ( describe_retention_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -3100,6 +3538,16 @@ module DisassociateResourceTypes : sig
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_resource_types_request ->
+    ( disassociate_resource_types_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes all resource types specified in the [ResourceTypes] list from the \
@@ -3123,6 +3571,17 @@ module GetAggregateComplianceDetailsByConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     get_aggregate_compliance_details_by_config_rule_request ->
     ( get_aggregate_compliance_details_by_config_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_compliance_details_by_config_rule_request ->
+    ( get_aggregate_compliance_details_by_config_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -3158,6 +3617,17 @@ module GetAggregateConfigRuleComplianceSummary : sig
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_config_rule_compliance_summary_request ->
+    ( get_aggregate_config_rule_compliance_summary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the number of compliant and noncompliant rules for one or more accounts and regions in \
@@ -3180,6 +3650,17 @@ module GetAggregateConformancePackComplianceSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_aggregate_conformance_pack_compliance_summary_request ->
     ( get_aggregate_conformance_pack_compliance_summary_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_conformance_pack_compliance_summary_request ->
+    ( get_aggregate_conformance_pack_compliance_summary_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -3215,6 +3696,17 @@ module GetAggregateDiscoveredResourceCounts : sig
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_discovered_resource_counts_request ->
+    ( get_aggregate_discovered_resource_counts_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the resource counts across accounts and regions that are present in your Config \
@@ -3238,6 +3730,17 @@ module GetAggregateResourceConfig : sig
     'http_type Smaws_Lib.Context.t ->
     get_aggregate_resource_config_request ->
     ( get_aggregate_resource_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `OversizedConfigurationItemException of oversized_configuration_item_exception
+      | `ResourceNotDiscoveredException of resource_not_discovered_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_resource_config_request ->
+    ( get_aggregate_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `OversizedConfigurationItemException of oversized_configuration_item_exception
@@ -3269,6 +3772,16 @@ module GetComplianceDetailsByConfigRule : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_details_by_config_rule_request ->
+    ( get_compliance_details_by_config_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the evaluation results for the specified Config rule. The results indicate which Amazon \
@@ -3288,6 +3801,14 @@ module GetComplianceDetailsByResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_details_by_resource_request ->
+    ( get_compliance_details_by_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the evaluation results for the specified Amazon Web Services resource. The results \
@@ -3301,6 +3822,13 @@ module GetComplianceSummaryByConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (get_compliance_summary_by_config_rule_response, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( get_compliance_summary_by_config_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc
   "Returns the number of Config rules that are compliant and noncompliant, up to a maximum of 25 \
@@ -3316,6 +3844,14 @@ module GetComplianceSummaryByResourceType : sig
     'http_type Smaws_Lib.Context.t ->
     get_compliance_summary_by_resource_type_request ->
     ( get_compliance_summary_by_resource_type_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_summary_by_resource_type_request ->
+    ( get_compliance_summary_by_resource_type_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
@@ -3348,6 +3884,19 @@ module GetConformancePackComplianceDetails : sig
         no_such_config_rule_in_conformance_pack_exception
       | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_conformance_pack_compliance_details_request ->
+    ( get_conformance_pack_compliance_details_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleInConformancePackException of
+        no_such_config_rule_in_conformance_pack_exception
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns compliance details of a conformance pack for all Amazon Web Services resources that are \
@@ -3365,6 +3914,16 @@ module GetConformancePackComplianceSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_conformance_pack_compliance_summary_request ->
     ( get_conformance_pack_compliance_summary_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_conformance_pack_compliance_summary_request ->
+    ( get_conformance_pack_compliance_summary_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -3388,6 +3947,14 @@ module GetCustomRulePolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_custom_rule_policy_request ->
+    ( get_custom_rule_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the policy definition containing the logic for your Config Custom Policy rule.\n"]
@@ -3404,6 +3971,16 @@ module GetDiscoveredResourceCounts : sig
     'http_type Smaws_Lib.Context.t ->
     get_discovered_resource_counts_request ->
     ( get_discovered_resource_counts_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_discovered_resource_counts_request ->
+    ( get_discovered_resource_counts_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -3480,6 +4057,17 @@ module GetOrganizationConfigRuleDetailedStatus : sig
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_organization_config_rule_detailed_status_request ->
+    ( get_organization_config_rule_detailed_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed status for each member account within an organization for a given organization \
@@ -3498,6 +4086,18 @@ module GetOrganizationConformancePackDetailedStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_organization_conformance_pack_detailed_status_request ->
     ( get_organization_conformance_pack_detailed_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConformancePackException of
+        no_such_organization_conformance_pack_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_organization_conformance_pack_detailed_status_request ->
+    ( get_organization_conformance_pack_detailed_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -3525,6 +4125,15 @@ module GetOrganizationCustomRulePolicy : sig
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_organization_custom_rule_policy_request ->
+    ( get_organization_custom_rule_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the policy definition containing the logic for your organization Config Custom Policy \
@@ -3545,6 +4154,19 @@ module GetResourceConfigHistory : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_config_history_request ->
     ( get_resource_config_history_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidTimeRangeException of invalid_time_range_exception
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `ResourceNotDiscoveredException of resource_not_discovered_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_config_history_request ->
+    ( get_resource_config_history_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -3597,6 +4219,14 @@ module GetResourceEvaluationSummary : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_evaluation_summary_request ->
+    ( get_resource_evaluation_summary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a summary of resource evaluation for the specified resource evaluation ID from the \
@@ -3627,6 +4257,15 @@ module GetStoredQuery : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_stored_query_request ->
+    ( get_stored_query_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the details of a specific stored query.\n"]
 
@@ -3643,6 +4282,17 @@ module ListAggregateDiscoveredResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_aggregate_discovered_resources_request ->
     ( list_aggregate_discovered_resources_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_aggregate_discovered_resources_request ->
+    ( list_aggregate_discovered_resources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -3671,6 +4321,13 @@ module ListConfigurationRecorders : sig
     ( list_configuration_recorders_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_configuration_recorders_request ->
+    ( list_configuration_recorders_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of configuration recorders depending on the filters you specify.\n"]
 
@@ -3686,6 +4343,16 @@ module ListConformancePackComplianceScores : sig
     'http_type Smaws_Lib.Context.t ->
     list_conformance_pack_compliance_scores_request ->
     ( list_conformance_pack_compliance_scores_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_conformance_pack_compliance_scores_request ->
+    ( list_conformance_pack_compliance_scores_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -3716,6 +4383,17 @@ module ListDiscoveredResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_discovered_resources_request ->
     ( list_discovered_resources_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_discovered_resources_request ->
+    ( list_discovered_resources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -3782,6 +4460,16 @@ module ListResourceEvaluations : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `InvalidTimeRangeException of invalid_time_range_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_evaluations_request ->
+    ( list_resource_evaluations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidTimeRangeException of invalid_time_range_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of proactive resource evaluations.\n"]
 
@@ -3796,6 +4484,15 @@ module ListStoredQueries : sig
     'http_type Smaws_Lib.Context.t ->
     list_stored_queries_request ->
     ( list_stored_queries_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_stored_queries_request ->
+    ( list_stored_queries_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `ValidationException of validation_exception ] )
@@ -3824,6 +4521,17 @@ module ListTagsForResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List the tags for Config resource.\n"]
 
@@ -3837,6 +4545,14 @@ module PutAggregationAuthorization : sig
     'http_type Smaws_Lib.Context.t ->
     put_aggregation_authorization_request ->
     ( put_aggregation_authorization_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_aggregation_authorization_request ->
+    ( put_aggregation_authorization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
@@ -3872,6 +4588,18 @@ module PutConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     put_config_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `MaxNumberOfConfigRulesExceededException of max_number_of_config_rules_exceeded_exception
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_config_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -3960,6 +4688,20 @@ module PutConfigurationAggregator : sig
       | `OrganizationAllFeaturesNotEnabledException of
         organization_all_features_not_enabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_configuration_aggregator_request ->
+    ( put_configuration_aggregator_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidRoleException of invalid_role_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NoAvailableOrganizationException of no_available_organization_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `OrganizationAllFeaturesNotEnabledException of
+        organization_all_features_not_enabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates and updates the configuration aggregator with the selected source accounts and regions. \
@@ -4011,6 +4753,20 @@ module PutConfigurationRecorder : sig
     'http_type Smaws_Lib.Context.t ->
     put_configuration_recorder_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidConfigurationRecorderNameException of invalid_configuration_recorder_name_exception
+      | `InvalidRecordingGroupException of invalid_recording_group_exception
+      | `InvalidRoleException of invalid_role_exception
+      | `MaxNumberOfConfigurationRecordersExceededException of
+        max_number_of_configuration_recorders_exceeded_exception
+      | `UnmodifiableEntityException of unmodifiable_entity_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_configuration_recorder_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidConfigurationRecorderNameException of invalid_configuration_recorder_name_exception
       | `InvalidRecordingGroupException of invalid_recording_group_exception
@@ -4087,6 +4843,20 @@ module PutConformancePack : sig
         max_number_of_conformance_packs_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_conformance_pack_request ->
+    ( put_conformance_pack_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConformancePackTemplateValidationException of
+        conformance_pack_template_validation_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `MaxNumberOfConformancePacksExceededException of
+        max_number_of_conformance_packs_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates or updates a conformance pack. A conformance pack is a collection of Config rules that \
@@ -4152,6 +4922,22 @@ module PutDeliveryChannel : sig
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `NoSuchBucketException of no_such_bucket_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_delivery_channel_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientDeliveryPolicyException of insufficient_delivery_policy_exception
+      | `InvalidDeliveryChannelNameException of invalid_delivery_channel_name_exception
+      | `InvalidS3KeyPrefixException of invalid_s3_key_prefix_exception
+      | `InvalidS3KmsKeyArnException of invalid_s3_kms_key_arn_exception
+      | `InvalidSNSTopicARNException of invalid_sns_topic_arn_exception
+      | `MaxNumberOfDeliveryChannelsExceededException of
+        max_number_of_delivery_channels_exceeded_exception
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `NoSuchBucketException of no_such_bucket_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates or updates a delivery channel to deliver configuration information and other compliance \
@@ -4186,6 +4972,16 @@ module PutEvaluations : sig
       | `InvalidResultTokenException of invalid_result_token_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_evaluations_request ->
+    ( put_evaluations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidResultTokenException of invalid_result_token_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc
   "Used by an Lambda function to deliver evaluation results to Config. This operation is required \
@@ -4202,6 +4998,15 @@ module PutExternalEvaluation : sig
     'http_type Smaws_Lib.Context.t ->
     put_external_evaluation_request ->
     ( put_external_evaluation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_external_evaluation_request ->
+    ( put_external_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
@@ -4229,6 +5034,23 @@ module PutOrganizationConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     put_organization_config_rule_request ->
     ( put_organization_config_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `MaxNumberOfOrganizationConfigRulesExceededException of
+        max_number_of_organization_config_rules_exceeded_exception
+      | `NoAvailableOrganizationException of no_available_organization_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `OrganizationAllFeaturesNotEnabledException of
+        organization_all_features_not_enabled_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_organization_config_rule_request ->
+    ( put_organization_config_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -4329,6 +5151,24 @@ module PutOrganizationConformancePack : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_organization_conformance_pack_request ->
+    ( put_organization_conformance_pack_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `MaxNumberOfOrganizationConformancePacksExceededException of
+        max_number_of_organization_conformance_packs_exceeded_exception
+      | `NoAvailableOrganizationException of no_available_organization_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `OrganizationAllFeaturesNotEnabledException of
+        organization_all_features_not_enabled_exception
+      | `OrganizationConformancePackTemplateValidationException of
+        organization_conformance_pack_template_validation_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deploys conformance packs across member accounts in an Amazon Web Services Organization. For \
@@ -4385,6 +5225,15 @@ module PutRemediationConfigurations : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_remediation_configurations_request ->
+    ( put_remediation_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or updates the remediation configuration with a specific Config rule with the selected \
@@ -4437,6 +5286,15 @@ module PutRemediationExceptions : sig
     'http_type Smaws_Lib.Context.t ->
     put_remediation_exceptions_request ->
     ( put_remediation_exceptions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_remediation_exceptions_request ->
+    ( put_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
@@ -4510,6 +5368,17 @@ module PutResourceConfig : sig
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_config_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `MaxActiveResourcesExceededException of max_active_resources_exceeded_exception
+      | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Records the configuration state for the resource provided in the request. The configuration \
@@ -4543,6 +5412,16 @@ module PutRetentionConfiguration : sig
       | `MaxNumberOfRetentionConfigurationsExceededException of
         max_number_of_retention_configurations_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_retention_configuration_request ->
+    ( put_retention_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `MaxNumberOfRetentionConfigurationsExceededException of
+        max_number_of_retention_configurations_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates and updates the retention configuration with details about retention period (number of \
@@ -4567,6 +5446,17 @@ module PutServiceLinkedConfigurationRecorder : sig
     'http_type Smaws_Lib.Context.t ->
     put_service_linked_configuration_recorder_request ->
     ( put_service_linked_configuration_recorder_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_service_linked_configuration_recorder_request ->
+    ( put_service_linked_configuration_recorder_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
@@ -4619,6 +5509,16 @@ module PutStoredQuery : sig
       | `TooManyTagsException of too_many_tags_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_stored_query_request ->
+    ( put_stored_query_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceConcurrentModificationException of resource_concurrent_modification_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Saves a new query or updates an existing saved query. The [QueryName] must be unique for a \
@@ -4646,6 +5546,17 @@ module SelectAggregateResourceConfig : sig
     'http_type Smaws_Lib.Context.t ->
     select_aggregate_resource_config_request ->
     ( select_aggregate_resource_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidExpressionException of invalid_expression_exception
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    select_aggregate_resource_config_request ->
+    ( select_aggregate_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidExpressionException of invalid_expression_exception
       | `InvalidLimitException of invalid_limit_exception
@@ -4690,6 +5601,16 @@ module SelectResourceConfig : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    select_resource_config_request ->
+    ( select_resource_config_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidExpressionException of invalid_expression_exception
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception ] )
+    result
 end
 [@@ocaml.doc
   "Accepts a structured query language (SQL) [SELECT] command, performs the corresponding search, \
@@ -4712,6 +5633,17 @@ module StartConfigRulesEvaluation : sig
     'http_type Smaws_Lib.Context.t ->
     start_config_rules_evaluation_request ->
     ( start_config_rules_evaluation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_config_rules_evaluation_request ->
+    ( start_config_rules_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -4774,6 +5706,16 @@ module StartConfigurationRecorder : sig
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_configuration_recorder_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoAvailableDeliveryChannelException of no_available_delivery_channel_exception
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the customer managed configuration recorder. The customer managed configuration recorder \
@@ -4802,6 +5744,17 @@ module StartRemediationExecution : sig
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_remediation_execution_request ->
+    ( start_remediation_execution_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Runs an on-demand remediation for the specified Config rules against the last known remediation \
@@ -4822,6 +5775,15 @@ module StartResourceEvaluation : sig
     'http_type Smaws_Lib.Context.t ->
     start_resource_evaluation_request ->
     ( start_resource_evaluation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_resource_evaluation_request ->
+    ( start_resource_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
@@ -4865,6 +5827,15 @@ module StopConfigurationRecorder : sig
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_configuration_recorder_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops the customer managed configuration recorder. The customer managed configuration recorder \
@@ -4882,6 +5853,16 @@ module TagResource : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resource_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception
@@ -4906,6 +5887,15 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )

--- a/sdks/config-service/operations.ml
+++ b/sdks/config-service/operations.ml
@@ -29,6 +29,13 @@ module AssociateResourceTypes = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_resource_types_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_resource_types_request) =
+    let input = Json_serializers.associate_resource_types_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.AssociateResourceTypes" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_resource_types_response_of_yojson
+      ~error_deserializer
 end
 
 module BatchGetAggregateResourceConfig = struct
@@ -53,6 +60,13 @@ module BatchGetAggregateResourceConfig = struct
   let request context (request : batch_get_aggregate_resource_config_request) =
     let input = Json_serializers.batch_get_aggregate_resource_config_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.BatchGetAggregateResourceConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_get_aggregate_resource_config_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : batch_get_aggregate_resource_config_request) =
+    let input = Json_serializers.batch_get_aggregate_resource_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.BatchGetAggregateResourceConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_get_aggregate_resource_config_response_of_yojson
       ~error_deserializer
@@ -83,6 +97,13 @@ module BatchGetResourceConfig = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_get_resource_config_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_get_resource_config_request) =
+    let input = Json_serializers.batch_get_resource_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.BatchGetResourceConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_get_resource_config_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteAggregationAuthorization = struct
@@ -104,6 +125,13 @@ module DeleteAggregationAuthorization = struct
   let request context (request : delete_aggregation_authorization_request) =
     let input = Json_serializers.delete_aggregation_authorization_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DeleteAggregationAuthorization" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_aggregation_authorization_request) =
+    let input = Json_serializers.delete_aggregation_authorization_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DeleteAggregationAuthorization" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -132,6 +160,13 @@ module DeleteConfigRule = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.DeleteConfigRule" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_config_rule_request) =
+    let input = Json_serializers.delete_config_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteConfigRule" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteConfigurationAggregator = struct
@@ -153,6 +188,13 @@ module DeleteConfigurationAggregator = struct
   let request context (request : delete_configuration_aggregator_request) =
     let input = Json_serializers.delete_configuration_aggregator_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DeleteConfigurationAggregator" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_configuration_aggregator_request) =
+    let input = Json_serializers.delete_configuration_aggregator_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DeleteConfigurationAggregator" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -184,6 +226,13 @@ module DeleteConfigurationRecorder = struct
       ~shape_name:"StarlingDoveService.DeleteConfigurationRecorder" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_configuration_recorder_request) =
+    let input = Json_serializers.delete_configuration_recorder_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteConfigurationRecorder" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteConformancePack = struct
@@ -209,6 +258,13 @@ module DeleteConformancePack = struct
     let input = Json_serializers.delete_conformance_pack_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.DeleteConformancePack"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_conformance_pack_request) =
+    let input = Json_serializers.delete_conformance_pack_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteConformancePack" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -240,6 +296,13 @@ module DeleteDeliveryChannel = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_delivery_channel_request) =
+    let input = Json_serializers.delete_delivery_channel_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteDeliveryChannel" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteEvaluationResults = struct
@@ -264,6 +327,13 @@ module DeleteEvaluationResults = struct
     let input = Json_serializers.delete_evaluation_results_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.DeleteEvaluationResults"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_evaluation_results_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_evaluation_results_request) =
+    let input = Json_serializers.delete_evaluation_results_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteEvaluationResults" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_evaluation_results_response_of_yojson
       ~error_deserializer
 end
@@ -295,6 +365,13 @@ module DeleteOrganizationConfigRule = struct
   let request context (request : delete_organization_config_rule_request) =
     let input = Json_serializers.delete_organization_config_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DeleteOrganizationConfigRule" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_organization_config_rule_request) =
+    let input = Json_serializers.delete_organization_config_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DeleteOrganizationConfigRule" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -330,6 +407,13 @@ module DeleteOrganizationConformancePack = struct
       ~shape_name:"StarlingDoveService.DeleteOrganizationConformancePack" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_organization_conformance_pack_request) =
+    let input = Json_serializers.delete_organization_conformance_pack_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteOrganizationConformancePack" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeletePendingAggregationRequest = struct
@@ -351,6 +435,13 @@ module DeletePendingAggregationRequest = struct
   let request context (request : delete_pending_aggregation_request_request) =
     let input = Json_serializers.delete_pending_aggregation_request_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DeletePendingAggregationRequest" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_pending_aggregation_request_request) =
+    let input = Json_serializers.delete_pending_aggregation_request_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DeletePendingAggregationRequest" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -393,6 +484,13 @@ module DeleteRemediationConfiguration = struct
       ~shape_name:"StarlingDoveService.DeleteRemediationConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_remediation_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_remediation_configuration_request) =
+    let input = Json_serializers.delete_remediation_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteRemediationConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_remediation_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteRemediationExceptions = struct
@@ -414,6 +512,13 @@ module DeleteRemediationExceptions = struct
   let request context (request : delete_remediation_exceptions_request) =
     let input = Json_serializers.delete_remediation_exceptions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DeleteRemediationExceptions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_remediation_exceptions_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_remediation_exceptions_request) =
+    let input = Json_serializers.delete_remediation_exceptions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DeleteRemediationExceptions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_remediation_exceptions_response_of_yojson
       ~error_deserializer
@@ -444,6 +549,13 @@ module DeleteResourceConfig = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_resource_config_request) =
+    let input = Json_serializers.delete_resource_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteResourceConfig" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteRetentionConfiguration = struct
@@ -470,6 +582,13 @@ module DeleteRetentionConfiguration = struct
   let request context (request : delete_retention_configuration_request) =
     let input = Json_serializers.delete_retention_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DeleteRetentionConfiguration" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_retention_configuration_request) =
+    let input = Json_serializers.delete_retention_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DeleteRetentionConfiguration" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -507,6 +626,18 @@ module DeleteServiceLinkedConfigurationRecorder = struct
       ~output_deserializer:
         Json_deserializers.delete_service_linked_configuration_recorder_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_service_linked_configuration_recorder_request)
+      =
+    let input =
+      Json_serializers.delete_service_linked_configuration_recorder_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteServiceLinkedConfigurationRecorder" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.delete_service_linked_configuration_recorder_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteStoredQuery = struct
@@ -531,6 +662,13 @@ module DeleteStoredQuery = struct
     let input = Json_serializers.delete_stored_query_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.DeleteStoredQuery" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_stored_query_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_stored_query_request) =
+    let input = Json_serializers.delete_stored_query_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeleteStoredQuery" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_stored_query_response_of_yojson
       ~error_deserializer
 end
 
@@ -566,6 +704,13 @@ module DeliverConfigSnapshot = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.deliver_config_snapshot_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deliver_config_snapshot_request) =
+    let input = Json_serializers.deliver_config_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DeliverConfigSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.deliver_config_snapshot_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAggregateComplianceByConfigRules = struct
@@ -599,6 +744,18 @@ module DescribeAggregateComplianceByConfigRules = struct
       Json_serializers.describe_aggregate_compliance_by_config_rules_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DescribeAggregateComplianceByConfigRules" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.describe_aggregate_compliance_by_config_rules_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context
+      (request : describe_aggregate_compliance_by_config_rules_request) =
+    let input =
+      Json_serializers.describe_aggregate_compliance_by_config_rules_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DescribeAggregateComplianceByConfigRules" ~service ~context
       ~input
       ~output_deserializer:
@@ -642,6 +799,18 @@ module DescribeAggregateComplianceByConformancePacks = struct
       ~output_deserializer:
         Json_deserializers.describe_aggregate_compliance_by_conformance_packs_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : describe_aggregate_compliance_by_conformance_packs_request) =
+    let input =
+      Json_serializers.describe_aggregate_compliance_by_conformance_packs_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeAggregateComplianceByConformancePacks" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_aggregate_compliance_by_conformance_packs_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAggregationAuthorizations = struct
@@ -670,6 +839,13 @@ module DescribeAggregationAuthorizations = struct
   let request context (request : describe_aggregation_authorizations_request) =
     let input = Json_serializers.describe_aggregation_authorizations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DescribeAggregationAuthorizations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_aggregation_authorizations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_aggregation_authorizations_request) =
+    let input = Json_serializers.describe_aggregation_authorizations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DescribeAggregationAuthorizations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_aggregation_authorizations_response_of_yojson
       ~error_deserializer
@@ -705,6 +881,13 @@ module DescribeComplianceByConfigRule = struct
       ~shape_name:"StarlingDoveService.DescribeComplianceByConfigRule" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_compliance_by_config_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_compliance_by_config_rule_request) =
+    let input = Json_serializers.describe_compliance_by_config_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeComplianceByConfigRule" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_compliance_by_config_rule_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeComplianceByResource = struct
@@ -730,6 +913,13 @@ module DescribeComplianceByResource = struct
   let request context (request : describe_compliance_by_resource_request) =
     let input = Json_serializers.describe_compliance_by_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DescribeComplianceByResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_compliance_by_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_compliance_by_resource_request) =
+    let input = Json_serializers.describe_compliance_by_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DescribeComplianceByResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_compliance_by_resource_response_of_yojson
       ~error_deserializer
@@ -766,6 +956,14 @@ module DescribeConfigRuleEvaluationStatus = struct
       ~output_deserializer:
         Json_deserializers.describe_config_rule_evaluation_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_config_rule_evaluation_status_request) =
+    let input = Json_serializers.describe_config_rule_evaluation_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeConfigRuleEvaluationStatus" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_config_rule_evaluation_status_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeConfigRules = struct
@@ -796,6 +994,13 @@ module DescribeConfigRules = struct
     let input = Json_serializers.describe_config_rules_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.DescribeConfigRules"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_config_rules_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_config_rules_request) =
+    let input = Json_serializers.describe_config_rules_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeConfigRules" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_config_rules_response_of_yojson
       ~error_deserializer
 end
@@ -831,6 +1036,13 @@ module DescribeConfigurationAggregators = struct
   let request context (request : describe_configuration_aggregators_request) =
     let input = Json_serializers.describe_configuration_aggregators_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DescribeConfigurationAggregators" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_configuration_aggregators_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_configuration_aggregators_request) =
+    let input = Json_serializers.describe_configuration_aggregators_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DescribeConfigurationAggregators" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_configuration_aggregators_response_of_yojson
       ~error_deserializer
@@ -874,6 +1086,18 @@ module DescribeConfigurationAggregatorSourcesStatus = struct
       ~output_deserializer:
         Json_deserializers.describe_configuration_aggregator_sources_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : describe_configuration_aggregator_sources_status_request) =
+    let input =
+      Json_serializers.describe_configuration_aggregator_sources_status_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeConfigurationAggregatorSourcesStatus" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_configuration_aggregator_sources_status_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeConfigurationRecorders = struct
@@ -901,6 +1125,13 @@ module DescribeConfigurationRecorders = struct
       ~shape_name:"StarlingDoveService.DescribeConfigurationRecorders" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_configuration_recorders_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_configuration_recorders_request) =
+    let input = Json_serializers.describe_configuration_recorders_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeConfigurationRecorders" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_configuration_recorders_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeConfigurationRecorderStatus = struct
@@ -925,6 +1156,14 @@ module DescribeConfigurationRecorderStatus = struct
   let request context (request : describe_configuration_recorder_status_request) =
     let input = Json_serializers.describe_configuration_recorder_status_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DescribeConfigurationRecorderStatus" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_configuration_recorder_status_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_configuration_recorder_status_request) =
+    let input = Json_serializers.describe_configuration_recorder_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DescribeConfigurationRecorderStatus" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.describe_configuration_recorder_status_response_of_yojson
@@ -972,6 +1211,14 @@ module DescribeConformancePackCompliance = struct
       ~output_deserializer:
         Json_deserializers.describe_conformance_pack_compliance_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_conformance_pack_compliance_request) =
+    let input = Json_serializers.describe_conformance_pack_compliance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeConformancePackCompliance" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_conformance_pack_compliance_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeConformancePacks = struct
@@ -1008,6 +1255,13 @@ module DescribeConformancePacks = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_conformance_packs_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_conformance_packs_request) =
+    let input = Json_serializers.describe_conformance_packs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeConformancePacks" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_conformance_packs_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeConformancePackStatus = struct
@@ -1039,6 +1293,13 @@ module DescribeConformancePackStatus = struct
       ~shape_name:"StarlingDoveService.DescribeConformancePackStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_conformance_pack_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_conformance_pack_status_request) =
+    let input = Json_serializers.describe_conformance_pack_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeConformancePackStatus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_conformance_pack_status_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeDeliveryChannels = struct
@@ -1063,6 +1324,13 @@ module DescribeDeliveryChannels = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_delivery_channels_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_delivery_channels_request) =
+    let input = Json_serializers.describe_delivery_channels_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeDeliveryChannels" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_delivery_channels_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeDeliveryChannelStatus = struct
@@ -1084,6 +1352,13 @@ module DescribeDeliveryChannelStatus = struct
   let request context (request : describe_delivery_channel_status_request) =
     let input = Json_serializers.describe_delivery_channel_status_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DescribeDeliveryChannelStatus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_delivery_channel_status_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_delivery_channel_status_request) =
+    let input = Json_serializers.describe_delivery_channel_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DescribeDeliveryChannelStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_delivery_channel_status_response_of_yojson
       ~error_deserializer
@@ -1123,6 +1398,13 @@ module DescribeOrganizationConfigRules = struct
       ~shape_name:"StarlingDoveService.DescribeOrganizationConfigRules" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_organization_config_rules_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_organization_config_rules_request) =
+    let input = Json_serializers.describe_organization_config_rules_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeOrganizationConfigRules" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_organization_config_rules_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeOrganizationConfigRuleStatuses = struct
@@ -1158,6 +1440,17 @@ module DescribeOrganizationConfigRuleStatuses = struct
       Json_serializers.describe_organization_config_rule_statuses_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DescribeOrganizationConfigRuleStatuses" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.describe_organization_config_rule_statuses_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_organization_config_rule_statuses_request) =
+    let input =
+      Json_serializers.describe_organization_config_rule_statuses_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DescribeOrganizationConfigRuleStatuses" ~service ~context
       ~input
       ~output_deserializer:
@@ -1203,6 +1496,17 @@ module DescribeOrganizationConformancePacks = struct
       ~output_deserializer:
         Json_deserializers.describe_organization_conformance_packs_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_organization_conformance_packs_request) =
+    let input =
+      Json_serializers.describe_organization_conformance_packs_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeOrganizationConformancePacks" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.describe_organization_conformance_packs_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeOrganizationConformancePackStatuses = struct
@@ -1243,6 +1547,18 @@ module DescribeOrganizationConformancePackStatuses = struct
       ~output_deserializer:
         Json_deserializers.describe_organization_conformance_pack_statuses_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : describe_organization_conformance_pack_statuses_request) =
+    let input =
+      Json_serializers.describe_organization_conformance_pack_statuses_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeOrganizationConformancePackStatuses" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_organization_conformance_pack_statuses_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribePendingAggregationRequests = struct
@@ -1275,6 +1591,14 @@ module DescribePendingAggregationRequests = struct
       ~output_deserializer:
         Json_deserializers.describe_pending_aggregation_requests_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_pending_aggregation_requests_request) =
+    let input = Json_serializers.describe_pending_aggregation_requests_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribePendingAggregationRequests" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_pending_aggregation_requests_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeRemediationConfigurations = struct
@@ -1288,6 +1612,13 @@ module DescribeRemediationConfigurations = struct
   let request context (request : describe_remediation_configurations_request) =
     let input = Json_serializers.describe_remediation_configurations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DescribeRemediationConfigurations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_remediation_configurations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_remediation_configurations_request) =
+    let input = Json_serializers.describe_remediation_configurations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DescribeRemediationConfigurations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_remediation_configurations_response_of_yojson
       ~error_deserializer
@@ -1316,6 +1647,13 @@ module DescribeRemediationExceptions = struct
   let request context (request : describe_remediation_exceptions_request) =
     let input = Json_serializers.describe_remediation_exceptions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.DescribeRemediationExceptions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_remediation_exceptions_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_remediation_exceptions_request) =
+    let input = Json_serializers.describe_remediation_exceptions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.DescribeRemediationExceptions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_remediation_exceptions_response_of_yojson
       ~error_deserializer
@@ -1353,6 +1691,14 @@ module DescribeRemediationExecutionStatus = struct
       ~output_deserializer:
         Json_deserializers.describe_remediation_execution_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_remediation_execution_status_request) =
+    let input = Json_serializers.describe_remediation_execution_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeRemediationExecutionStatus" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_remediation_execution_status_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeRetentionConfigurations = struct
@@ -1386,6 +1732,13 @@ module DescribeRetentionConfigurations = struct
       ~shape_name:"StarlingDoveService.DescribeRetentionConfigurations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_retention_configurations_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_retention_configurations_request) =
+    let input = Json_serializers.describe_retention_configurations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DescribeRetentionConfigurations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_retention_configurations_response_of_yojson
+      ~error_deserializer
 end
 
 module DisassociateResourceTypes = struct
@@ -1414,6 +1767,13 @@ module DisassociateResourceTypes = struct
     let input = Json_serializers.disassociate_resource_types_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.DisassociateResourceTypes"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_resource_types_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_resource_types_request) =
+    let input = Json_serializers.disassociate_resource_types_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.DisassociateResourceTypes" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_resource_types_response_of_yojson
       ~error_deserializer
 end
@@ -1449,6 +1809,18 @@ module GetAggregateComplianceDetailsByConfigRule = struct
       Json_serializers.get_aggregate_compliance_details_by_config_rule_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.GetAggregateComplianceDetailsByConfigRule" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.get_aggregate_compliance_details_by_config_rule_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context
+      (request : get_aggregate_compliance_details_by_config_rule_request) =
+    let input =
+      Json_serializers.get_aggregate_compliance_details_by_config_rule_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.GetAggregateComplianceDetailsByConfigRule" ~service ~context
       ~input
       ~output_deserializer:
@@ -1492,6 +1864,18 @@ module GetAggregateConfigRuleComplianceSummary = struct
       ~output_deserializer:
         Json_deserializers.get_aggregate_config_rule_compliance_summary_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_aggregate_config_rule_compliance_summary_request)
+      =
+    let input =
+      Json_serializers.get_aggregate_config_rule_compliance_summary_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetAggregateConfigRuleComplianceSummary" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.get_aggregate_config_rule_compliance_summary_response_of_yojson
+      ~error_deserializer
 end
 
 module GetAggregateConformancePackComplianceSummary = struct
@@ -1525,6 +1909,18 @@ module GetAggregateConformancePackComplianceSummary = struct
       Json_serializers.get_aggregate_conformance_pack_compliance_summary_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.GetAggregateConformancePackComplianceSummary" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_aggregate_conformance_pack_compliance_summary_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context
+      (request : get_aggregate_conformance_pack_compliance_summary_request) =
+    let input =
+      Json_serializers.get_aggregate_conformance_pack_compliance_summary_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.GetAggregateConformancePackComplianceSummary" ~service
       ~context ~input
       ~output_deserializer:
@@ -1568,6 +1964,17 @@ module GetAggregateDiscoveredResourceCounts = struct
       ~output_deserializer:
         Json_deserializers.get_aggregate_discovered_resource_counts_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_aggregate_discovered_resource_counts_request) =
+    let input =
+      Json_serializers.get_aggregate_discovered_resource_counts_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetAggregateDiscoveredResourceCounts" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.get_aggregate_discovered_resource_counts_response_of_yojson
+      ~error_deserializer
 end
 
 module GetAggregateResourceConfig = struct
@@ -1605,6 +2012,13 @@ module GetAggregateResourceConfig = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_aggregate_resource_config_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_aggregate_resource_config_request) =
+    let input = Json_serializers.get_aggregate_resource_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetAggregateResourceConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_aggregate_resource_config_response_of_yojson
+      ~error_deserializer
 end
 
 module GetComplianceDetailsByConfigRule = struct
@@ -1638,6 +2052,14 @@ module GetComplianceDetailsByConfigRule = struct
       ~output_deserializer:
         Json_deserializers.get_compliance_details_by_config_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_compliance_details_by_config_rule_request) =
+    let input = Json_serializers.get_compliance_details_by_config_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetComplianceDetailsByConfigRule" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_compliance_details_by_config_rule_response_of_yojson
+      ~error_deserializer
 end
 
 module GetComplianceDetailsByResource = struct
@@ -1662,6 +2084,13 @@ module GetComplianceDetailsByResource = struct
       ~shape_name:"StarlingDoveService.GetComplianceDetailsByResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_compliance_details_by_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_compliance_details_by_resource_request) =
+    let input = Json_serializers.get_compliance_details_by_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetComplianceDetailsByResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_compliance_details_by_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module GetComplianceSummaryByConfigRule = struct
@@ -1675,6 +2104,14 @@ module GetComplianceSummaryByConfigRule = struct
   let request context (request : Smaws_Lib.Smithy_api.Types.unit_) =
     let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.GetComplianceSummaryByConfigRule" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_compliance_summary_by_config_rule_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : Smaws_Lib.Smithy_api.Types.unit_) =
+    let input = Smaws_Lib.Smithy_api.Json_serializers.unit__to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.GetComplianceSummaryByConfigRule" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.get_compliance_summary_by_config_rule_response_of_yojson
@@ -1702,6 +2139,16 @@ module GetComplianceSummaryByResourceType = struct
       Json_serializers.get_compliance_summary_by_resource_type_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.GetComplianceSummaryByResourceType" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_compliance_summary_by_resource_type_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_compliance_summary_by_resource_type_request) =
+    let input =
+      Json_serializers.get_compliance_summary_by_resource_type_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.GetComplianceSummaryByResourceType" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.get_compliance_summary_by_resource_type_response_of_yojson
@@ -1751,6 +2198,16 @@ module GetConformancePackComplianceDetails = struct
       ~output_deserializer:
         Json_deserializers.get_conformance_pack_compliance_details_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_conformance_pack_compliance_details_request) =
+    let input =
+      Json_serializers.get_conformance_pack_compliance_details_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetConformancePackComplianceDetails" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_conformance_pack_compliance_details_response_of_yojson
+      ~error_deserializer
 end
 
 module GetConformancePackComplianceSummary = struct
@@ -1785,6 +2242,16 @@ module GetConformancePackComplianceSummary = struct
       ~output_deserializer:
         Json_deserializers.get_conformance_pack_compliance_summary_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_conformance_pack_compliance_summary_request) =
+    let input =
+      Json_serializers.get_conformance_pack_compliance_summary_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetConformancePackComplianceSummary" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_conformance_pack_compliance_summary_response_of_yojson
+      ~error_deserializer
 end
 
 module GetCustomRulePolicy = struct
@@ -1806,6 +2273,13 @@ module GetCustomRulePolicy = struct
     let input = Json_serializers.get_custom_rule_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.GetCustomRulePolicy"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_custom_rule_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_custom_rule_policy_request) =
+    let input = Json_serializers.get_custom_rule_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetCustomRulePolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_custom_rule_policy_response_of_yojson
       ~error_deserializer
 end
@@ -1834,6 +2308,13 @@ module GetDiscoveredResourceCounts = struct
   let request context (request : get_discovered_resource_counts_request) =
     let input = Json_serializers.get_discovered_resource_counts_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.GetDiscoveredResourceCounts" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_discovered_resource_counts_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_discovered_resource_counts_request) =
+    let input = Json_serializers.get_discovered_resource_counts_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.GetDiscoveredResourceCounts" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_discovered_resource_counts_response_of_yojson
       ~error_deserializer
@@ -1872,6 +2353,18 @@ module GetOrganizationConfigRuleDetailedStatus = struct
       Json_serializers.get_organization_config_rule_detailed_status_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.GetOrganizationConfigRuleDetailedStatus" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.get_organization_config_rule_detailed_status_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_organization_config_rule_detailed_status_request)
+      =
+    let input =
+      Json_serializers.get_organization_config_rule_detailed_status_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.GetOrganizationConfigRuleDetailedStatus" ~service ~context
       ~input
       ~output_deserializer:
@@ -1917,6 +2410,18 @@ module GetOrganizationConformancePackDetailedStatus = struct
       ~output_deserializer:
         Json_deserializers.get_organization_conformance_pack_detailed_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : get_organization_conformance_pack_detailed_status_request) =
+    let input =
+      Json_serializers.get_organization_conformance_pack_detailed_status_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetOrganizationConformancePackDetailedStatus" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_organization_conformance_pack_detailed_status_response_of_yojson
+      ~error_deserializer
 end
 
 module GetOrganizationCustomRulePolicy = struct
@@ -1943,6 +2448,13 @@ module GetOrganizationCustomRulePolicy = struct
   let request context (request : get_organization_custom_rule_policy_request) =
     let input = Json_serializers.get_organization_custom_rule_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.GetOrganizationCustomRulePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_organization_custom_rule_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_organization_custom_rule_policy_request) =
+    let input = Json_serializers.get_organization_custom_rule_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.GetOrganizationCustomRulePolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_organization_custom_rule_policy_response_of_yojson
       ~error_deserializer
@@ -1989,6 +2501,13 @@ module GetResourceConfigHistory = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_resource_config_history_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_config_history_request) =
+    let input = Json_serializers.get_resource_config_history_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetResourceConfigHistory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_config_history_response_of_yojson
+      ~error_deserializer
 end
 
 module GetResourceEvaluationSummary = struct
@@ -2009,6 +2528,13 @@ module GetResourceEvaluationSummary = struct
   let request context (request : get_resource_evaluation_summary_request) =
     let input = Json_serializers.get_resource_evaluation_summary_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.GetResourceEvaluationSummary" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_evaluation_summary_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_evaluation_summary_request) =
+    let input = Json_serializers.get_resource_evaluation_summary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.GetResourceEvaluationSummary" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_resource_evaluation_summary_response_of_yojson
       ~error_deserializer
@@ -2036,6 +2562,13 @@ module GetStoredQuery = struct
     let input = Json_serializers.get_stored_query_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.GetStoredQuery" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_stored_query_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_stored_query_request) =
+    let input = Json_serializers.get_stored_query_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.GetStoredQuery" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_stored_query_response_of_yojson
       ~error_deserializer
 end
 
@@ -2071,6 +2604,13 @@ module ListAggregateDiscoveredResources = struct
       ~shape_name:"StarlingDoveService.ListAggregateDiscoveredResources" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_aggregate_discovered_resources_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_aggregate_discovered_resources_request) =
+    let input = Json_serializers.list_aggregate_discovered_resources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.ListAggregateDiscoveredResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_aggregate_discovered_resources_response_of_yojson
+      ~error_deserializer
 end
 
 module ListConfigurationRecorders = struct
@@ -2091,6 +2631,13 @@ module ListConfigurationRecorders = struct
     let input = Json_serializers.list_configuration_recorders_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.ListConfigurationRecorders"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_configuration_recorders_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_configuration_recorders_request) =
+    let input = Json_serializers.list_configuration_recorders_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.ListConfigurationRecorders" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_configuration_recorders_response_of_yojson
       ~error_deserializer
 end
@@ -2123,6 +2670,16 @@ module ListConformancePackComplianceScores = struct
       Json_serializers.list_conformance_pack_compliance_scores_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.ListConformancePackComplianceScores" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.list_conformance_pack_compliance_scores_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_conformance_pack_compliance_scores_request) =
+    let input =
+      Json_serializers.list_conformance_pack_compliance_scores_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.ListConformancePackComplianceScores" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.list_conformance_pack_compliance_scores_response_of_yojson
@@ -2161,6 +2718,13 @@ module ListDiscoveredResources = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_discovered_resources_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_discovered_resources_request) =
+    let input = Json_serializers.list_discovered_resources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.ListDiscoveredResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_discovered_resources_response_of_yojson
+      ~error_deserializer
 end
 
 module ListResourceEvaluations = struct
@@ -2193,6 +2757,13 @@ module ListResourceEvaluations = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_resource_evaluations_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_resource_evaluations_request) =
+    let input = Json_serializers.list_resource_evaluations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.ListResourceEvaluations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resource_evaluations_response_of_yojson
+      ~error_deserializer
 end
 
 module ListStoredQueries = struct
@@ -2217,6 +2788,13 @@ module ListStoredQueries = struct
     let input = Json_serializers.list_stored_queries_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.ListStoredQueries" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_stored_queries_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_stored_queries_request) =
+    let input = Json_serializers.list_stored_queries_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.ListStoredQueries" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_stored_queries_response_of_yojson
       ~error_deserializer
 end
 
@@ -2251,6 +2829,13 @@ module ListTagsForResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module PutAggregationAuthorization = struct
@@ -2272,6 +2857,13 @@ module PutAggregationAuthorization = struct
   let request context (request : put_aggregation_authorization_request) =
     let input = Json_serializers.put_aggregation_authorization_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.PutAggregationAuthorization" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_aggregation_authorization_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_aggregation_authorization_request) =
+    let input = Json_serializers.put_aggregation_authorization_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.PutAggregationAuthorization" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_aggregation_authorization_response_of_yojson
       ~error_deserializer
@@ -2316,6 +2908,13 @@ module PutConfigRule = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutConfigRule" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_config_rule_request) =
+    let input = Json_serializers.put_config_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutConfigRule" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module PutConfigurationAggregator = struct
@@ -2359,6 +2958,13 @@ module PutConfigurationAggregator = struct
     let input = Json_serializers.put_configuration_aggregator_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutConfigurationAggregator"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_configuration_aggregator_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_configuration_aggregator_request) =
+    let input = Json_serializers.put_configuration_aggregator_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutConfigurationAggregator" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_configuration_aggregator_response_of_yojson
       ~error_deserializer
 end
@@ -2406,6 +3012,13 @@ module PutConfigurationRecorder = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_configuration_recorder_request) =
+    let input = Json_serializers.put_configuration_recorder_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutConfigurationRecorder" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module PutConformancePack = struct
@@ -2447,6 +3060,13 @@ module PutConformancePack = struct
     let input = Json_serializers.put_conformance_pack_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutConformancePack"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_conformance_pack_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_conformance_pack_request) =
+    let input = Json_serializers.put_conformance_pack_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutConformancePack" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_conformance_pack_response_of_yojson
       ~error_deserializer
 end
@@ -2504,6 +3124,13 @@ module PutDeliveryChannel = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_delivery_channel_request) =
+    let input = Json_serializers.put_delivery_channel_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutDeliveryChannel" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module PutEvaluations = struct
@@ -2535,6 +3162,12 @@ module PutEvaluations = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutEvaluations" ~service
       ~context ~input ~output_deserializer:Json_deserializers.put_evaluations_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_evaluations_request) =
+    let input = Json_serializers.put_evaluations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutEvaluations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_evaluations_response_of_yojson ~error_deserializer
 end
 
 module PutExternalEvaluation = struct
@@ -2561,6 +3194,13 @@ module PutExternalEvaluation = struct
     let input = Json_serializers.put_external_evaluation_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutExternalEvaluation"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_external_evaluation_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_external_evaluation_request) =
+    let input = Json_serializers.put_external_evaluation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutExternalEvaluation" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_external_evaluation_response_of_yojson
       ~error_deserializer
 end
@@ -2617,6 +3257,13 @@ module PutOrganizationConfigRule = struct
     let input = Json_serializers.put_organization_config_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutOrganizationConfigRule"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_organization_config_rule_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_organization_config_rule_request) =
+    let input = Json_serializers.put_organization_config_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutOrganizationConfigRule" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_organization_config_rule_response_of_yojson
       ~error_deserializer
 end
@@ -2676,6 +3323,13 @@ module PutOrganizationConformancePack = struct
       ~shape_name:"StarlingDoveService.PutOrganizationConformancePack" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_organization_conformance_pack_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_organization_conformance_pack_request) =
+    let input = Json_serializers.put_organization_conformance_pack_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutOrganizationConformancePack" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_organization_conformance_pack_response_of_yojson
+      ~error_deserializer
 end
 
 module PutRemediationConfigurations = struct
@@ -2702,6 +3356,13 @@ module PutRemediationConfigurations = struct
   let request context (request : put_remediation_configurations_request) =
     let input = Json_serializers.put_remediation_configurations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"StarlingDoveService.PutRemediationConfigurations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_remediation_configurations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_remediation_configurations_request) =
+    let input = Json_serializers.put_remediation_configurations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"StarlingDoveService.PutRemediationConfigurations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_remediation_configurations_response_of_yojson
       ~error_deserializer
@@ -2732,6 +3393,13 @@ module PutRemediationExceptions = struct
     let input = Json_serializers.put_remediation_exceptions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutRemediationExceptions"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_remediation_exceptions_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_remediation_exceptions_request) =
+    let input = Json_serializers.put_remediation_exceptions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutRemediationExceptions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_remediation_exceptions_response_of_yojson
       ~error_deserializer
 end
@@ -2770,6 +3438,13 @@ module PutResourceConfig = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutResourceConfig" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_resource_config_request) =
+    let input = Json_serializers.put_resource_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutResourceConfig" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module PutRetentionConfiguration = struct
@@ -2798,6 +3473,13 @@ module PutRetentionConfiguration = struct
     let input = Json_serializers.put_retention_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutRetentionConfiguration"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_retention_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_retention_configuration_request) =
+    let input = Json_serializers.put_retention_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutRetentionConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_retention_configuration_response_of_yojson
       ~error_deserializer
 end
@@ -2837,6 +3519,17 @@ module PutServiceLinkedConfigurationRecorder = struct
       ~output_deserializer:
         Json_deserializers.put_service_linked_configuration_recorder_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_service_linked_configuration_recorder_request) =
+    let input =
+      Json_serializers.put_service_linked_configuration_recorder_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutServiceLinkedConfigurationRecorder" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.put_service_linked_configuration_recorder_response_of_yojson
+      ~error_deserializer
 end
 
 module PutStoredQuery = struct
@@ -2865,6 +3558,13 @@ module PutStoredQuery = struct
     let input = Json_serializers.put_stored_query_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.PutStoredQuery" ~service
       ~context ~input ~output_deserializer:Json_deserializers.put_stored_query_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_stored_query_request) =
+    let input = Json_serializers.put_stored_query_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.PutStoredQuery" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_stored_query_response_of_yojson
       ~error_deserializer
 end
 
@@ -2901,6 +3601,13 @@ module SelectAggregateResourceConfig = struct
       ~shape_name:"StarlingDoveService.SelectAggregateResourceConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.select_aggregate_resource_config_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : select_aggregate_resource_config_request) =
+    let input = Json_serializers.select_aggregate_resource_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.SelectAggregateResourceConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.select_aggregate_resource_config_response_of_yojson
+      ~error_deserializer
 end
 
 module SelectResourceConfig = struct
@@ -2929,6 +3636,13 @@ module SelectResourceConfig = struct
     let input = Json_serializers.select_resource_config_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.SelectResourceConfig"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.select_resource_config_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : select_resource_config_request) =
+    let input = Json_serializers.select_resource_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.SelectResourceConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.select_resource_config_response_of_yojson
       ~error_deserializer
 end
@@ -2965,6 +3679,13 @@ module StartConfigRulesEvaluation = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_config_rules_evaluation_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_config_rules_evaluation_request) =
+    let input = Json_serializers.start_config_rules_evaluation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.StartConfigRulesEvaluation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_config_rules_evaluation_response_of_yojson
+      ~error_deserializer
 end
 
 module StartConfigurationRecorder = struct
@@ -2996,6 +3717,13 @@ module StartConfigurationRecorder = struct
     let input = Json_serializers.start_configuration_recorder_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.StartConfigurationRecorder"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_configuration_recorder_request) =
+    let input = Json_serializers.start_configuration_recorder_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.StartConfigurationRecorder" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -3032,6 +3760,13 @@ module StartRemediationExecution = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_remediation_execution_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_remediation_execution_request) =
+    let input = Json_serializers.start_remediation_execution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.StartRemediationExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_remediation_execution_response_of_yojson
+      ~error_deserializer
 end
 
 module StartResourceEvaluation = struct
@@ -3058,6 +3793,13 @@ module StartResourceEvaluation = struct
     let input = Json_serializers.start_resource_evaluation_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.StartResourceEvaluation"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_resource_evaluation_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_resource_evaluation_request) =
+    let input = Json_serializers.start_resource_evaluation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.StartResourceEvaluation" ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_resource_evaluation_response_of_yojson
       ~error_deserializer
 end
@@ -3088,6 +3830,13 @@ module StopConfigurationRecorder = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : stop_configuration_recorder_request) =
+    let input = Json_serializers.stop_configuration_recorder_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.StopConfigurationRecorder" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -3116,6 +3865,13 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.TagResource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"StarlingDoveService.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -3140,5 +3896,12 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"StarlingDoveService.UntagResource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"StarlingDoveService.UntagResource" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end

--- a/sdks/config-service/operations.mli
+++ b/sdks/config-service/operations.mli
@@ -25,7 +25,8 @@ module AssociateResourceTypes : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -59,7 +60,8 @@ module BatchGetAggregateResourceConfig : sig
     ( batch_get_aggregate_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -99,7 +101,8 @@ module BatchGetResourceConfig : sig
     ( batch_get_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -136,7 +139,8 @@ module DeleteAggregationAuthorization : sig
     delete_aggregation_authorization_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -165,7 +169,8 @@ module DeleteConfigRule : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigRuleException of no_such_config_rule_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -213,7 +218,8 @@ module DeleteConfigurationAggregator : sig
     delete_configuration_aggregator_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -242,7 +248,8 @@ module DeleteConfigurationRecorder : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -276,7 +283,8 @@ module DeleteConformancePack : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConformancePackException of no_such_conformance_pack_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -324,7 +332,8 @@ module DeleteDeliveryChannel : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LastDeliveryChannelDeleteFailedException of last_delivery_channel_delete_failed_exception
-      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -356,7 +365,8 @@ module DeleteEvaluationResults : sig
     ( delete_evaluation_results_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigRuleException of no_such_config_rule_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -390,7 +400,8 @@ module DeleteOrganizationConfigRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -448,7 +459,8 @@ module DeleteOrganizationConformancePack : sig
       | `NoSuchOrganizationConformancePackException of
         no_such_organization_conformance_pack_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -498,7 +510,8 @@ module DeletePendingAggregationRequest : sig
     delete_pending_aggregation_request_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -532,7 +545,8 @@ module DeleteRemediationConfiguration : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception
-      | `RemediationInProgressException of remediation_in_progress_exception ] )
+      | `RemediationInProgressException of remediation_in_progress_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the remediation configuration.\n"]
@@ -556,7 +570,8 @@ module DeleteRemediationExceptions : sig
     delete_remediation_exceptions_request ->
     ( delete_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchRemediationExceptionException of no_such_remediation_exception_exception ] )
+      | `NoSuchRemediationExceptionException of no_such_remediation_exception_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -589,7 +604,8 @@ module DeleteResourceConfig : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -619,7 +635,8 @@ module DeleteRetentionConfiguration : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
+      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the retention configuration.\n"]
@@ -649,7 +666,8 @@ module DeleteServiceLinkedConfigurationRecorder : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -690,7 +708,8 @@ module DeleteStoredQuery : sig
     ( delete_stored_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -722,7 +741,8 @@ module DeliverConfigSnapshot : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
-      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -771,7 +791,8 @@ module DescribeAggregateComplianceByConfigRules : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -810,7 +831,8 @@ module DescribeAggregateComplianceByConformancePacks : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -848,7 +870,8 @@ module DescribeAggregationAuthorizations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -879,7 +902,8 @@ module DescribeComplianceByConfigRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -933,7 +957,8 @@ module DescribeComplianceByResource : sig
     ( describe_compliance_by_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -991,7 +1016,8 @@ module DescribeConfigRuleEvaluationStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1024,7 +1050,8 @@ module DescribeConfigRules : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns details about your Config rules.\n"]
@@ -1057,7 +1084,8 @@ module DescribeConfigurationAggregators : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1093,7 +1121,8 @@ module DescribeConfigurationAggregatorSourcesStatus : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1123,7 +1152,8 @@ module DescribeConfigurationRecorders : sig
     ( describe_configuration_recorders_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1157,7 +1187,8 @@ module DescribeConfigurationRecorderStatus : sig
     ( describe_configuration_recorder_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1207,7 +1238,8 @@ module DescribeConformancePackCompliance : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleInConformancePackException of
         no_such_config_rule_in_conformance_pack_exception
-      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1244,7 +1276,8 @@ module DescribeConformancePacks : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of one or more conformance packs.\n"]
@@ -1274,7 +1307,8 @@ module DescribeConformancePackStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1302,7 +1336,8 @@ module DescribeDeliveryChannels : sig
     describe_delivery_channels_request ->
     ( describe_delivery_channels_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1331,7 +1366,8 @@ module DescribeDeliveryChannelStatus : sig
     describe_delivery_channel_status_request ->
     ( describe_delivery_channel_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1370,7 +1406,8 @@ module DescribeOrganizationConfigRules : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1422,7 +1459,8 @@ module DescribeOrganizationConfigRuleStatuses : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1466,7 +1504,8 @@ module DescribeOrganizationConformancePacks : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConformancePackException of
         no_such_organization_conformance_pack_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1520,7 +1559,8 @@ module DescribeOrganizationConformancePackStatuses : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConformancePackException of
         no_such_organization_conformance_pack_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1559,7 +1599,8 @@ module DescribePendingAggregationRequests : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of all pending aggregation requests.\n"]
@@ -1576,7 +1617,7 @@ module DescribeRemediationConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_remediation_configurations_request ->
     ( describe_remediation_configurations_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the details of one or more remediation configurations.\n"]
@@ -1603,7 +1644,8 @@ module DescribeRemediationExceptions : sig
     ( describe_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1649,7 +1691,7 @@ module DescribeRemediationExecutionStatus : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1683,7 +1725,8 @@ module DescribeRetentionConfigurations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
+      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1719,7 +1762,8 @@ module DisassociateResourceTypes : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1759,7 +1803,8 @@ module GetAggregateComplianceDetailsByConfigRule : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1799,7 +1844,8 @@ module GetAggregateConfigRuleComplianceSummary : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1838,7 +1884,8 @@ module GetAggregateConformancePackComplianceSummary : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1878,7 +1925,8 @@ module GetAggregateDiscoveredResourceCounts : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1918,7 +1966,8 @@ module GetAggregateResourceConfig : sig
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `OversizedConfigurationItemException of oversized_configuration_item_exception
       | `ResourceNotDiscoveredException of resource_not_discovered_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1953,7 +2002,8 @@ module GetComplianceDetailsByConfigRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1980,7 +2030,8 @@ module GetComplianceDetailsByResource : sig
     get_compliance_details_by_resource_request ->
     ( get_compliance_details_by_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2000,7 +2051,7 @@ module GetComplianceSummaryByConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     ( get_compliance_summary_by_config_rule_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2026,7 +2077,8 @@ module GetComplianceSummaryByResourceType : sig
     get_compliance_summary_by_resource_type_request ->
     ( get_compliance_summary_by_resource_type_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2068,7 +2120,8 @@ module GetConformancePackComplianceDetails : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleInConformancePackException of
         no_such_config_rule_in_conformance_pack_exception
-      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2100,7 +2153,8 @@ module GetConformancePackComplianceSummary : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2126,7 +2180,8 @@ module GetCustomRulePolicy : sig
     get_custom_rule_policy_request ->
     ( get_custom_rule_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2157,7 +2212,8 @@ module GetDiscoveredResourceCounts : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2239,7 +2295,8 @@ module GetOrganizationConfigRuleDetailedStatus : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2276,7 +2333,8 @@ module GetOrganizationConformancePackDetailedStatus : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchOrganizationConformancePackException of
         no_such_organization_conformance_pack_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2305,7 +2363,8 @@ module GetOrganizationCustomRulePolicy : sig
     ( get_organization_custom_rule_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
-      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2346,7 +2405,8 @@ module GetResourceConfigHistory : sig
       | `InvalidTimeRangeException of invalid_time_range_exception
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `ResourceNotDiscoveredException of resource_not_discovered_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2398,7 +2458,8 @@ module GetResourceEvaluationSummary : sig
     get_resource_evaluation_summary_request ->
     ( get_resource_evaluation_summary_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2437,7 +2498,8 @@ module GetStoredQuery : sig
     ( get_stored_query_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the details of a specific stored query.\n"]
@@ -2470,7 +2532,8 @@ module ListAggregateDiscoveredResources : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2499,7 +2562,8 @@ module ListConfigurationRecorders : sig
     'http_type Smaws_Lib.Context.t ->
     list_configuration_recorders_request ->
     ( list_configuration_recorders_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of configuration recorders depending on the filters you specify.\n"]
@@ -2529,7 +2593,8 @@ module ListConformancePackComplianceScores : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2571,7 +2636,8 @@ module ListDiscoveredResources : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2641,7 +2707,8 @@ module ListResourceEvaluations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `InvalidTimeRangeException of invalid_time_range_exception ] )
+      | `InvalidTimeRangeException of invalid_time_range_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of proactive resource evaluations.\n"]
@@ -2668,7 +2735,8 @@ module ListStoredQueries : sig
     ( list_stored_queries_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2703,7 +2771,8 @@ module ListTagsForResource : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List the tags for Config resource.\n"]
@@ -2727,7 +2796,8 @@ module PutAggregationAuthorization : sig
     put_aggregation_authorization_request ->
     ( put_aggregation_authorization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2778,7 +2848,8 @@ module PutConfigRule : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `MaxNumberOfConfigRulesExceededException of max_number_of_config_rules_exceeded_exception
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2873,7 +2944,8 @@ module PutConfigurationAggregator : sig
       | `NoAvailableOrganizationException of no_available_organization_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception
       | `OrganizationAllFeaturesNotEnabledException of
-        organization_all_features_not_enabled_exception ] )
+        organization_all_features_not_enabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2947,7 +3019,8 @@ module PutConfigurationRecorder : sig
       | `MaxNumberOfConfigurationRecordersExceededException of
         max_number_of_configuration_recorders_exceeded_exception
       | `UnmodifiableEntityException of unmodifiable_entity_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3028,7 +3101,8 @@ module PutConformancePack : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `MaxNumberOfConformancePacksExceededException of
         max_number_of_conformance_packs_exceeded_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3109,7 +3183,8 @@ module PutDeliveryChannel : sig
       | `MaxNumberOfDeliveryChannelsExceededException of
         max_number_of_delivery_channels_exceeded_exception
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
-      | `NoSuchBucketException of no_such_bucket_exception ] )
+      | `NoSuchBucketException of no_such_bucket_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3153,7 +3228,8 @@ module PutEvaluations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `InvalidResultTokenException of invalid_result_token_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3182,7 +3258,8 @@ module PutExternalEvaluation : sig
     ( put_external_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3234,7 +3311,8 @@ module PutOrganizationConfigRule : sig
       | `OrganizationAllFeaturesNotEnabledException of
         organization_all_features_not_enabled_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3340,7 +3418,8 @@ module PutOrganizationConformancePack : sig
       | `OrganizationConformancePackTemplateValidationException of
         organization_conformance_pack_template_validation_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3405,7 +3484,8 @@ module PutRemediationConfigurations : sig
     ( put_remediation_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3470,7 +3550,8 @@ module PutRemediationExceptions : sig
     ( put_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3550,7 +3631,8 @@ module PutResourceConfig : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `MaxActiveResourcesExceededException of max_active_resources_exceeded_exception
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3593,7 +3675,8 @@ module PutRetentionConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `MaxNumberOfRetentionConfigurationsExceededException of
-        max_number_of_retention_configurations_exceeded_exception ] )
+        max_number_of_retention_configurations_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3634,7 +3717,8 @@ module PutServiceLinkedConfigurationRecorder : sig
       | `ConflictException of conflict_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3690,7 +3774,8 @@ module PutStoredQuery : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceConcurrentModificationException of resource_concurrent_modification_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3734,7 +3819,8 @@ module SelectAggregateResourceConfig : sig
       | `InvalidExpressionException of invalid_expression_exception
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3782,7 +3868,8 @@ module SelectResourceConfig : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidExpressionException of invalid_expression_exception
       | `InvalidLimitException of invalid_limit_exception
-      | `InvalidNextTokenException of invalid_next_token_exception ] )
+      | `InvalidNextTokenException of invalid_next_token_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3821,7 +3908,8 @@ module StartConfigRulesEvaluation : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `LimitExceededException of limit_exceeded_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3887,7 +3975,8 @@ module StartConfigurationRecorder : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoAvailableDeliveryChannelException of no_available_delivery_channel_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3926,7 +4015,7 @@ module StartRemediationExecution : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3959,7 +4048,8 @@ module StartResourceEvaluation : sig
     ( start_resource_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
-      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+      | `InvalidParameterValueException of invalid_parameter_value_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4007,7 +4097,8 @@ module StopConfigurationRecorder : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
-      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4039,7 +4130,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4070,7 +4162,8 @@ module UntagResource : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes specified tags from a resource.\n"]

--- a/sdks/config-service/operations.mli
+++ b/sdks/config-service/operations.mli
@@ -17,6 +17,16 @@ module AssociateResourceTypes : sig
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_resource_types_request ->
+    ( associate_resource_types_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds all resource types specified in the [ResourceTypes] list to the \
@@ -38,6 +48,15 @@ module BatchGetAggregateResourceConfig : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_aggregate_resource_config_request ->
     ( batch_get_aggregate_resource_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_aggregate_resource_config_request ->
+    ( batch_get_aggregate_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `ValidationException of validation_exception ] )
@@ -73,6 +92,15 @@ module BatchGetResourceConfig : sig
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_resource_config_request ->
+    ( batch_get_resource_config_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the [BaseConfigurationItem] for one or more requested resources. The operation also \
@@ -102,6 +130,14 @@ module DeleteAggregationAuthorization : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_aggregation_authorization_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the authorization granted to the specified configuration aggregator account in a \
@@ -118,6 +154,15 @@ module DeleteConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_config_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigRuleException of no_such_config_rule_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_config_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigRuleException of no_such_config_rule_exception
       | `ResourceInUseException of resource_in_use_exception ] )
@@ -162,6 +207,14 @@ module DeleteConfigurationAggregator : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_configuration_aggregator_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified configuration aggregator and the aggregated data associated with the \
@@ -178,6 +231,15 @@ module DeleteConfigurationRecorder : sig
     'http_type Smaws_Lib.Context.t ->
     delete_configuration_recorder_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_configuration_recorder_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
@@ -203,6 +265,15 @@ module DeleteConformancePack : sig
     'http_type Smaws_Lib.Context.t ->
     delete_conformance_pack_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_conformance_pack_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConformancePackException of no_such_conformance_pack_exception
       | `ResourceInUseException of resource_in_use_exception ] )
@@ -246,6 +317,15 @@ module DeleteDeliveryChannel : sig
       | `LastDeliveryChannelDeleteFailedException of last_delivery_channel_delete_failed_exception
       | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_delivery_channel_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LastDeliveryChannelDeleteFailedException of last_delivery_channel_delete_failed_exception
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the delivery channel.\n\n\
@@ -269,6 +349,15 @@ module DeleteEvaluationResults : sig
       | `NoSuchConfigRuleException of no_such_config_rule_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_evaluation_results_request ->
+    ( delete_evaluation_results_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigRuleException of no_such_config_rule_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the evaluation results for the specified Config rule. You can specify one Config rule \
@@ -288,6 +377,16 @@ module DeleteOrganizationConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_organization_config_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_organization_config_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception
@@ -340,6 +439,17 @@ module DeleteOrganizationConformancePack : sig
       | `OrganizationAccessDeniedException of organization_access_denied_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_organization_conformance_pack_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchOrganizationConformancePackException of
+        no_such_organization_conformance_pack_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified organization conformance pack and all of the Config rules and remediation \
@@ -382,6 +492,14 @@ module DeletePendingAggregationRequest : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_pending_aggregation_request_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes pending authorization requests for a specified aggregator account in a specified region.\n"]
@@ -405,6 +523,17 @@ module DeleteRemediationConfiguration : sig
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception
       | `RemediationInProgressException of remediation_in_progress_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_remediation_configuration_request ->
+    ( delete_remediation_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception
+      | `RemediationInProgressException of remediation_in_progress_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the remediation configuration.\n"]
 
@@ -418,6 +547,14 @@ module DeleteRemediationExceptions : sig
     'http_type Smaws_Lib.Context.t ->
     delete_remediation_exceptions_request ->
     ( delete_remediation_exceptions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchRemediationExceptionException of no_such_remediation_exception_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_remediation_exceptions_request ->
+    ( delete_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchRemediationExceptionException of no_such_remediation_exception_exception ] )
     result
@@ -445,6 +582,15 @@ module DeleteResourceConfig : sig
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_config_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Records the configuration state for a custom resource that has been deleted. This API records a \
@@ -466,6 +612,15 @@ module DeleteRetentionConfiguration : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_retention_configuration_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the retention configuration.\n"]
 
@@ -481,6 +636,16 @@ module DeleteServiceLinkedConfigurationRecorder : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_linked_configuration_recorder_request ->
     ( delete_service_linked_configuration_recorder_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_linked_configuration_recorder_request ->
+    ( delete_service_linked_configuration_recorder_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
@@ -518,6 +683,15 @@ module DeleteStoredQuery : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_stored_query_request ->
+    ( delete_stored_query_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the stored query for a single Amazon Web Services account and a single Amazon Web \
@@ -535,6 +709,16 @@ module DeliverConfigSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     deliver_config_snapshot_request ->
     ( deliver_config_snapshot_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deliver_config_snapshot_request ->
+    ( deliver_config_snapshot_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
@@ -578,6 +762,17 @@ module DescribeAggregateComplianceByConfigRules : sig
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_aggregate_compliance_by_config_rules_request ->
+    ( describe_aggregate_compliance_by_config_rules_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of compliant and noncompliant rules with the number of resources for compliant \
@@ -600,6 +795,17 @@ module DescribeAggregateComplianceByConformancePacks : sig
     'http_type Smaws_Lib.Context.t ->
     describe_aggregate_compliance_by_conformance_packs_request ->
     ( describe_aggregate_compliance_by_conformance_packs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_aggregate_compliance_by_conformance_packs_request ->
+    ( describe_aggregate_compliance_by_conformance_packs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -634,6 +840,16 @@ module DescribeAggregationAuthorizations : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_aggregation_authorizations_request ->
+    ( describe_aggregation_authorizations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of authorizations granted to various aggregator accounts and regions.\n"]
@@ -650,6 +866,16 @@ module DescribeComplianceByConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     describe_compliance_by_config_rule_request ->
     ( describe_compliance_by_config_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_compliance_by_config_rule_request ->
+    ( describe_compliance_by_config_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -696,6 +922,15 @@ module DescribeComplianceByResource : sig
     'http_type Smaws_Lib.Context.t ->
     describe_compliance_by_resource_request ->
     ( describe_compliance_by_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_compliance_by_resource_request ->
+    ( describe_compliance_by_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
@@ -748,6 +983,16 @@ module DescribeConfigRuleEvaluationStatus : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_config_rule_evaluation_status_request ->
+    ( describe_config_rule_evaluation_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns status information for each of your Config managed rules. The status includes \
@@ -771,6 +1016,16 @@ module DescribeConfigRules : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_config_rules_request ->
+    ( describe_config_rules_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc "Returns details about your Config rules.\n"]
 
@@ -787,6 +1042,17 @@ module DescribeConfigurationAggregators : sig
     'http_type Smaws_Lib.Context.t ->
     describe_configuration_aggregators_request ->
     ( describe_configuration_aggregators_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_configuration_aggregators_request ->
+    ( describe_configuration_aggregators_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -818,6 +1084,17 @@ module DescribeConfigurationAggregatorSourcesStatus : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_configuration_aggregator_sources_status_request ->
+    ( describe_configuration_aggregator_sources_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns status information for sources within an aggregator. The status includes information \
@@ -835,6 +1112,15 @@ module DescribeConfigurationRecorders : sig
     'http_type Smaws_Lib.Context.t ->
     describe_configuration_recorders_request ->
     ( describe_configuration_recorders_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_configuration_recorders_request ->
+    ( describe_configuration_recorders_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
@@ -860,6 +1146,15 @@ module DescribeConfigurationRecorderStatus : sig
     'http_type Smaws_Lib.Context.t ->
     describe_configuration_recorder_status_request ->
     ( describe_configuration_recorder_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_configuration_recorder_status_request ->
+    ( describe_configuration_recorder_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
@@ -901,6 +1196,19 @@ module DescribeConformancePackCompliance : sig
         no_such_config_rule_in_conformance_pack_exception
       | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_conformance_pack_compliance_request ->
+    ( describe_conformance_pack_compliance_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleInConformancePackException of
+        no_such_config_rule_in_conformance_pack_exception
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns compliance details for each rule in that conformance pack.\n\n\
@@ -927,6 +1235,17 @@ module DescribeConformancePacks : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_conformance_packs_request ->
+    ( describe_conformance_packs_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of one or more conformance packs.\n"]
 
@@ -942,6 +1261,16 @@ module DescribeConformancePackStatus : sig
     'http_type Smaws_Lib.Context.t ->
     describe_conformance_pack_status_request ->
     ( describe_conformance_pack_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_conformance_pack_status_request ->
+    ( describe_conformance_pack_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -967,6 +1296,14 @@ module DescribeDeliveryChannels : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_delivery_channels_request ->
+    ( describe_delivery_channels_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns details about the specified delivery channel. If a delivery channel is not specified, \
@@ -985,6 +1322,14 @@ module DescribeDeliveryChannelStatus : sig
     'http_type Smaws_Lib.Context.t ->
     describe_delivery_channel_status_request ->
     ( describe_delivery_channel_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_delivery_channel_status_request ->
+    ( describe_delivery_channel_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchDeliveryChannelException of no_such_delivery_channel_exception ] )
     result
@@ -1010,6 +1355,17 @@ module DescribeOrganizationConfigRules : sig
     'http_type Smaws_Lib.Context.t ->
     describe_organization_config_rules_request ->
     ( describe_organization_config_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_config_rules_request ->
+    ( describe_organization_config_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1057,6 +1413,17 @@ module DescribeOrganizationConfigRuleStatuses : sig
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_config_rule_statuses_request ->
+    ( describe_organization_config_rule_statuses_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides organization Config rule deployment status for an organization.\n\n\
@@ -1082,6 +1449,18 @@ module DescribeOrganizationConformancePacks : sig
     'http_type Smaws_Lib.Context.t ->
     describe_organization_conformance_packs_request ->
     ( describe_organization_conformance_packs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConformancePackException of
+        no_such_organization_conformance_pack_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_conformance_packs_request ->
+    ( describe_organization_conformance_packs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1131,6 +1510,18 @@ module DescribeOrganizationConformancePackStatuses : sig
         no_such_organization_conformance_pack_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_conformance_pack_statuses_request ->
+    ( describe_organization_conformance_pack_statuses_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConformancePackException of
+        no_such_organization_conformance_pack_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides organization conformance pack deployment status for an organization. \n\n\
@@ -1160,6 +1551,16 @@ module DescribePendingAggregationRequests : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_pending_aggregation_requests_request ->
+    ( describe_pending_aggregation_requests_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of all pending aggregation requests.\n"]
 
@@ -1170,6 +1571,13 @@ module DescribeRemediationConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_remediation_configurations_request ->
     (describe_remediation_configurations_response, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_remediation_configurations_request ->
+    ( describe_remediation_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc "Returns the details of one or more remediation configurations.\n"]
 
@@ -1184,6 +1592,15 @@ module DescribeRemediationExceptions : sig
     'http_type Smaws_Lib.Context.t ->
     describe_remediation_exceptions_request ->
     ( describe_remediation_exceptions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_remediation_exceptions_request ->
+    ( describe_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
@@ -1223,6 +1640,17 @@ module DescribeRemediationExecutionStatus : sig
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_remediation_execution_status_request ->
+    ( describe_remediation_execution_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Provides a detailed view of a Remediation Execution for a set of resources including state, \
@@ -1242,6 +1670,16 @@ module DescribeRetentionConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_retention_configurations_request ->
     ( describe_retention_configurations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRetentionConfigurationException of no_such_retention_configuration_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_retention_configurations_request ->
+    ( describe_retention_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -1273,6 +1711,16 @@ module DisassociateResourceTypes : sig
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_resource_types_request ->
+    ( disassociate_resource_types_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes all resource types specified in the [ResourceTypes] list from the \
@@ -1296,6 +1744,17 @@ module GetAggregateComplianceDetailsByConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     get_aggregate_compliance_details_by_config_rule_request ->
     ( get_aggregate_compliance_details_by_config_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_compliance_details_by_config_rule_request ->
+    ( get_aggregate_compliance_details_by_config_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1331,6 +1790,17 @@ module GetAggregateConfigRuleComplianceSummary : sig
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_config_rule_compliance_summary_request ->
+    ( get_aggregate_config_rule_compliance_summary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the number of compliant and noncompliant rules for one or more accounts and regions in \
@@ -1353,6 +1823,17 @@ module GetAggregateConformancePackComplianceSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_aggregate_conformance_pack_compliance_summary_request ->
     ( get_aggregate_conformance_pack_compliance_summary_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_conformance_pack_compliance_summary_request ->
+    ( get_aggregate_conformance_pack_compliance_summary_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1388,6 +1869,17 @@ module GetAggregateDiscoveredResourceCounts : sig
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_discovered_resource_counts_request ->
+    ( get_aggregate_discovered_resource_counts_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the resource counts across accounts and regions that are present in your Config \
@@ -1411,6 +1903,17 @@ module GetAggregateResourceConfig : sig
     'http_type Smaws_Lib.Context.t ->
     get_aggregate_resource_config_request ->
     ( get_aggregate_resource_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `OversizedConfigurationItemException of oversized_configuration_item_exception
+      | `ResourceNotDiscoveredException of resource_not_discovered_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_aggregate_resource_config_request ->
+    ( get_aggregate_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
       | `OversizedConfigurationItemException of oversized_configuration_item_exception
@@ -1442,6 +1945,16 @@ module GetComplianceDetailsByConfigRule : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_details_by_config_rule_request ->
+    ( get_compliance_details_by_config_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the evaluation results for the specified Config rule. The results indicate which Amazon \
@@ -1461,6 +1974,14 @@ module GetComplianceDetailsByResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_details_by_resource_request ->
+    ( get_compliance_details_by_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the evaluation results for the specified Amazon Web Services resource. The results \
@@ -1474,6 +1995,13 @@ module GetComplianceSummaryByConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     Smaws_Lib.Smithy_api.Types.unit_ ->
     (get_compliance_summary_by_config_rule_response, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    Smaws_Lib.Smithy_api.Types.unit_ ->
+    ( get_compliance_summary_by_config_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc
   "Returns the number of Config rules that are compliant and noncompliant, up to a maximum of 25 \
@@ -1489,6 +2017,14 @@ module GetComplianceSummaryByResourceType : sig
     'http_type Smaws_Lib.Context.t ->
     get_compliance_summary_by_resource_type_request ->
     ( get_compliance_summary_by_resource_type_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_summary_by_resource_type_request ->
+    ( get_compliance_summary_by_resource_type_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
@@ -1521,6 +2057,19 @@ module GetConformancePackComplianceDetails : sig
         no_such_config_rule_in_conformance_pack_exception
       | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_conformance_pack_compliance_details_request ->
+    ( get_conformance_pack_compliance_details_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleInConformancePackException of
+        no_such_config_rule_in_conformance_pack_exception
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns compliance details of a conformance pack for all Amazon Web Services resources that are \
@@ -1538,6 +2087,16 @@ module GetConformancePackComplianceSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_conformance_pack_compliance_summary_request ->
     ( get_conformance_pack_compliance_summary_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConformancePackException of no_such_conformance_pack_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_conformance_pack_compliance_summary_request ->
+    ( get_conformance_pack_compliance_summary_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1561,6 +2120,14 @@ module GetCustomRulePolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_custom_rule_policy_request ->
+    ( get_custom_rule_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the policy definition containing the logic for your Config Custom Policy rule.\n"]
@@ -1577,6 +2144,16 @@ module GetDiscoveredResourceCounts : sig
     'http_type Smaws_Lib.Context.t ->
     get_discovered_resource_counts_request ->
     ( get_discovered_resource_counts_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_discovered_resource_counts_request ->
+    ( get_discovered_resource_counts_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1653,6 +2230,17 @@ module GetOrganizationConfigRuleDetailedStatus : sig
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_organization_config_rule_detailed_status_request ->
+    ( get_organization_config_rule_detailed_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed status for each member account within an organization for a given organization \
@@ -1671,6 +2259,18 @@ module GetOrganizationConformancePackDetailedStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_organization_conformance_pack_detailed_status_request ->
     ( get_organization_conformance_pack_detailed_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchOrganizationConformancePackException of
+        no_such_organization_conformance_pack_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_organization_conformance_pack_detailed_status_request ->
+    ( get_organization_conformance_pack_detailed_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1698,6 +2298,15 @@ module GetOrganizationCustomRulePolicy : sig
       | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
       | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_organization_custom_rule_policy_request ->
+    ( get_organization_custom_rule_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchOrganizationConfigRuleException of no_such_organization_config_rule_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the policy definition containing the logic for your organization Config Custom Policy \
@@ -1718,6 +2327,19 @@ module GetResourceConfigHistory : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_config_history_request ->
     ( get_resource_config_history_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidTimeRangeException of invalid_time_range_exception
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `ResourceNotDiscoveredException of resource_not_discovered_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_config_history_request ->
+    ( get_resource_config_history_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1770,6 +2392,14 @@ module GetResourceEvaluationSummary : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_evaluation_summary_request ->
+    ( get_resource_evaluation_summary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a summary of resource evaluation for the specified resource evaluation ID from the \
@@ -1800,6 +2430,15 @@ module GetStoredQuery : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_stored_query_request ->
+    ( get_stored_query_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the details of a specific stored query.\n"]
 
@@ -1816,6 +2455,17 @@ module ListAggregateDiscoveredResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_aggregate_discovered_resources_request ->
     ( list_aggregate_discovered_resources_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_aggregate_discovered_resources_request ->
+    ( list_aggregate_discovered_resources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1844,6 +2494,13 @@ module ListConfigurationRecorders : sig
     ( list_configuration_recorders_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_configuration_recorders_request ->
+    ( list_configuration_recorders_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of configuration recorders depending on the filters you specify.\n"]
 
@@ -1859,6 +2516,16 @@ module ListConformancePackComplianceScores : sig
     'http_type Smaws_Lib.Context.t ->
     list_conformance_pack_compliance_scores_request ->
     ( list_conformance_pack_compliance_scores_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_conformance_pack_compliance_scores_request ->
+    ( list_conformance_pack_compliance_scores_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1889,6 +2556,17 @@ module ListDiscoveredResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_discovered_resources_request ->
     ( list_discovered_resources_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_discovered_resources_request ->
+    ( list_discovered_resources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception
@@ -1955,6 +2633,16 @@ module ListResourceEvaluations : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `InvalidTimeRangeException of invalid_time_range_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_evaluations_request ->
+    ( list_resource_evaluations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidTimeRangeException of invalid_time_range_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of proactive resource evaluations.\n"]
 
@@ -1969,6 +2657,15 @@ module ListStoredQueries : sig
     'http_type Smaws_Lib.Context.t ->
     list_stored_queries_request ->
     ( list_stored_queries_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_stored_queries_request ->
+    ( list_stored_queries_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `ValidationException of validation_exception ] )
@@ -1997,6 +2694,17 @@ module ListTagsForResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List the tags for Config resource.\n"]
 
@@ -2010,6 +2718,14 @@ module PutAggregationAuthorization : sig
     'http_type Smaws_Lib.Context.t ->
     put_aggregation_authorization_request ->
     ( put_aggregation_authorization_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_aggregation_authorization_request ->
+    ( put_aggregation_authorization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
@@ -2045,6 +2761,18 @@ module PutConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     put_config_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `MaxNumberOfConfigRulesExceededException of max_number_of_config_rules_exceeded_exception
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_config_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -2133,6 +2861,20 @@ module PutConfigurationAggregator : sig
       | `OrganizationAllFeaturesNotEnabledException of
         organization_all_features_not_enabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_configuration_aggregator_request ->
+    ( put_configuration_aggregator_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidRoleException of invalid_role_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NoAvailableOrganizationException of no_available_organization_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `OrganizationAllFeaturesNotEnabledException of
+        organization_all_features_not_enabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates and updates the configuration aggregator with the selected source accounts and regions. \
@@ -2184,6 +2926,20 @@ module PutConfigurationRecorder : sig
     'http_type Smaws_Lib.Context.t ->
     put_configuration_recorder_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidConfigurationRecorderNameException of invalid_configuration_recorder_name_exception
+      | `InvalidRecordingGroupException of invalid_recording_group_exception
+      | `InvalidRoleException of invalid_role_exception
+      | `MaxNumberOfConfigurationRecordersExceededException of
+        max_number_of_configuration_recorders_exceeded_exception
+      | `UnmodifiableEntityException of unmodifiable_entity_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_configuration_recorder_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidConfigurationRecorderNameException of invalid_configuration_recorder_name_exception
       | `InvalidRecordingGroupException of invalid_recording_group_exception
@@ -2260,6 +3016,20 @@ module PutConformancePack : sig
         max_number_of_conformance_packs_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_conformance_pack_request ->
+    ( put_conformance_pack_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConformancePackTemplateValidationException of
+        conformance_pack_template_validation_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `MaxNumberOfConformancePacksExceededException of
+        max_number_of_conformance_packs_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates or updates a conformance pack. A conformance pack is a collection of Config rules that \
@@ -2325,6 +3095,22 @@ module PutDeliveryChannel : sig
       | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
       | `NoSuchBucketException of no_such_bucket_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_delivery_channel_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientDeliveryPolicyException of insufficient_delivery_policy_exception
+      | `InvalidDeliveryChannelNameException of invalid_delivery_channel_name_exception
+      | `InvalidS3KeyPrefixException of invalid_s3_key_prefix_exception
+      | `InvalidS3KmsKeyArnException of invalid_s3_kms_key_arn_exception
+      | `InvalidSNSTopicARNException of invalid_sns_topic_arn_exception
+      | `MaxNumberOfDeliveryChannelsExceededException of
+        max_number_of_delivery_channels_exceeded_exception
+      | `NoAvailableConfigurationRecorderException of no_available_configuration_recorder_exception
+      | `NoSuchBucketException of no_such_bucket_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates or updates a delivery channel to deliver configuration information and other compliance \
@@ -2359,6 +3145,16 @@ module PutEvaluations : sig
       | `InvalidResultTokenException of invalid_result_token_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_evaluations_request ->
+    ( put_evaluations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidResultTokenException of invalid_result_token_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
 end
 [@@ocaml.doc
   "Used by an Lambda function to deliver evaluation results to Config. This operation is required \
@@ -2375,6 +3171,15 @@ module PutExternalEvaluation : sig
     'http_type Smaws_Lib.Context.t ->
     put_external_evaluation_request ->
     ( put_external_evaluation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_external_evaluation_request ->
+    ( put_external_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NoSuchConfigRuleException of no_such_config_rule_exception ] )
@@ -2402,6 +3207,23 @@ module PutOrganizationConfigRule : sig
     'http_type Smaws_Lib.Context.t ->
     put_organization_config_rule_request ->
     ( put_organization_config_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `MaxNumberOfOrganizationConfigRulesExceededException of
+        max_number_of_organization_config_rules_exceeded_exception
+      | `NoAvailableOrganizationException of no_available_organization_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `OrganizationAllFeaturesNotEnabledException of
+        organization_all_features_not_enabled_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_organization_config_rule_request ->
+    ( put_organization_config_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -2502,6 +3324,24 @@ module PutOrganizationConformancePack : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_organization_conformance_pack_request ->
+    ( put_organization_conformance_pack_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `MaxNumberOfOrganizationConformancePacksExceededException of
+        max_number_of_organization_conformance_packs_exceeded_exception
+      | `NoAvailableOrganizationException of no_available_organization_exception
+      | `OrganizationAccessDeniedException of organization_access_denied_exception
+      | `OrganizationAllFeaturesNotEnabledException of
+        organization_all_features_not_enabled_exception
+      | `OrganizationConformancePackTemplateValidationException of
+        organization_conformance_pack_template_validation_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deploys conformance packs across member accounts in an Amazon Web Services Organization. For \
@@ -2558,6 +3398,15 @@ module PutRemediationConfigurations : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_remediation_configurations_request ->
+    ( put_remediation_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or updates the remediation configuration with a specific Config rule with the selected \
@@ -2610,6 +3459,15 @@ module PutRemediationExceptions : sig
     'http_type Smaws_Lib.Context.t ->
     put_remediation_exceptions_request ->
     ( put_remediation_exceptions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_remediation_exceptions_request ->
+    ( put_remediation_exceptions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
@@ -2683,6 +3541,17 @@ module PutResourceConfig : sig
       | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_config_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `MaxActiveResourcesExceededException of max_active_resources_exceeded_exception
+      | `NoRunningConfigurationRecorderException of no_running_configuration_recorder_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Records the configuration state for the resource provided in the request. The configuration \
@@ -2716,6 +3585,16 @@ module PutRetentionConfiguration : sig
       | `MaxNumberOfRetentionConfigurationsExceededException of
         max_number_of_retention_configurations_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_retention_configuration_request ->
+    ( put_retention_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `MaxNumberOfRetentionConfigurationsExceededException of
+        max_number_of_retention_configurations_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates and updates the retention configuration with details about retention period (number of \
@@ -2740,6 +3619,17 @@ module PutServiceLinkedConfigurationRecorder : sig
     'http_type Smaws_Lib.Context.t ->
     put_service_linked_configuration_recorder_request ->
     ( put_service_linked_configuration_recorder_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_service_linked_configuration_recorder_request ->
+    ( put_service_linked_configuration_recorder_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
@@ -2792,6 +3682,16 @@ module PutStoredQuery : sig
       | `TooManyTagsException of too_many_tags_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_stored_query_request ->
+    ( put_stored_query_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceConcurrentModificationException of resource_concurrent_modification_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Saves a new query or updates an existing saved query. The [QueryName] must be unique for a \
@@ -2819,6 +3719,17 @@ module SelectAggregateResourceConfig : sig
     'http_type Smaws_Lib.Context.t ->
     select_aggregate_resource_config_request ->
     ( select_aggregate_resource_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidExpressionException of invalid_expression_exception
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `NoSuchConfigurationAggregatorException of no_such_configuration_aggregator_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    select_aggregate_resource_config_request ->
+    ( select_aggregate_resource_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidExpressionException of invalid_expression_exception
       | `InvalidLimitException of invalid_limit_exception
@@ -2863,6 +3774,16 @@ module SelectResourceConfig : sig
       | `InvalidLimitException of invalid_limit_exception
       | `InvalidNextTokenException of invalid_next_token_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    select_resource_config_request ->
+    ( select_resource_config_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidExpressionException of invalid_expression_exception
+      | `InvalidLimitException of invalid_limit_exception
+      | `InvalidNextTokenException of invalid_next_token_exception ] )
+    result
 end
 [@@ocaml.doc
   "Accepts a structured query language (SQL) [SELECT] command, performs the corresponding search, \
@@ -2885,6 +3806,17 @@ module StartConfigRulesEvaluation : sig
     'http_type Smaws_Lib.Context.t ->
     start_config_rules_evaluation_request ->
     ( start_config_rules_evaluation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NoSuchConfigRuleException of no_such_config_rule_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_config_rules_evaluation_request ->
+    ( start_config_rules_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -2947,6 +3879,16 @@ module StartConfigurationRecorder : sig
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_configuration_recorder_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoAvailableDeliveryChannelException of no_available_delivery_channel_exception
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the customer managed configuration recorder. The customer managed configuration recorder \
@@ -2975,6 +3917,17 @@ module StartRemediationExecution : sig
       | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_remediation_execution_request ->
+    ( start_remediation_execution_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NoSuchRemediationConfigurationException of no_such_remediation_configuration_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Runs an on-demand remediation for the specified Config rules against the last known remediation \
@@ -2995,6 +3948,15 @@ module StartResourceEvaluation : sig
     'http_type Smaws_Lib.Context.t ->
     start_resource_evaluation_request ->
     ( start_resource_evaluation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InvalidParameterValueException of invalid_parameter_value_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_resource_evaluation_request ->
+    ( start_resource_evaluation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InvalidParameterValueException of invalid_parameter_value_exception ] )
@@ -3038,6 +4000,15 @@ module StopConfigurationRecorder : sig
       | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
       | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_configuration_recorder_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `NoSuchConfigurationRecorderException of no_such_configuration_recorder_exception
+      | `UnmodifiableEntityException of unmodifiable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops the customer managed configuration recorder. The customer managed configuration recorder \
@@ -3055,6 +4026,16 @@ module TagResource : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resource_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception
@@ -3078,6 +4059,15 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )

--- a/sdks/dax/Smaws_Client_DAX.mli
+++ b/sdks/dax/Smaws_Client_DAX.mli
@@ -341,6 +341,28 @@ module CreateCluster : sig
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
       | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_cluster_request ->
+    ( create_cluster_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterAlreadyExistsFault of cluster_already_exists_fault
+      | `ClusterQuotaForCustomerExceededFault of cluster_quota_for_customer_exceeded_fault
+      | `InsufficientClusterCapacityFault of insufficient_cluster_capacity_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidVPCNetworkStateFault of invalid_vpc_network_state_fault
+      | `NodeQuotaForClusterExceededFault of node_quota_for_cluster_exceeded_fault
+      | `NodeQuotaForCustomerExceededFault of node_quota_for_customer_exceeded_fault
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
+      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
+    result
 end
 [@@ocaml.doc "Creates a DAX cluster. All nodes in the cluster run the same DAX caching software.\n"]
 
@@ -359,6 +381,19 @@ module CreateParameterGroup : sig
     'http_type Smaws_Lib.Context.t ->
     create_parameter_group_request ->
     ( create_parameter_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupAlreadyExistsFault of parameter_group_already_exists_fault
+      | `ParameterGroupQuotaExceededFault of parameter_group_quota_exceeded_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_parameter_group_request ->
+    ( create_parameter_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
@@ -395,6 +430,19 @@ module CreateSubnetGroup : sig
       | `SubnetNotAllowedFault of subnet_not_allowed_fault
       | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_subnet_group_request ->
+    ( create_subnet_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidSubnet of invalid_subnet
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `SubnetGroupAlreadyExistsFault of subnet_group_already_exists_fault
+      | `SubnetGroupQuotaExceededFault of subnet_group_quota_exceeded_fault
+      | `SubnetNotAllowedFault of subnet_not_allowed_fault
+      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
+    result
 end
 [@@ocaml.doc "Creates a new subnet group.\n"]
 
@@ -413,6 +461,19 @@ module DecreaseReplicationFactor : sig
     'http_type Smaws_Lib.Context.t ->
     decrease_replication_factor_request ->
     ( decrease_replication_factor_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NodeNotFoundFault of node_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    decrease_replication_factor_request ->
+    ( decrease_replication_factor_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidClusterStateFault of invalid_cluster_state_fault
@@ -450,6 +511,18 @@ module DeleteCluster : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_cluster_request ->
+    ( delete_cluster_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a previously provisioned DAX cluster. {i DeleteCluster} deletes all associated nodes, \
@@ -470,6 +543,18 @@ module DeleteParameterGroup : sig
     'http_type Smaws_Lib.Context.t ->
     delete_parameter_group_request ->
     ( delete_parameter_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_parameter_group_request ->
+    ( delete_parameter_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
@@ -499,6 +584,16 @@ module DeleteSubnetGroup : sig
       | `SubnetGroupInUseFault of subnet_group_in_use_fault
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_subnet_group_request ->
+    ( delete_subnet_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `SubnetGroupInUseFault of subnet_group_in_use_fault
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a subnet group.\n\n\
@@ -519,6 +614,17 @@ module DescribeClusters : sig
     'http_type Smaws_Lib.Context.t ->
     describe_clusters_request ->
     ( describe_clusters_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_clusters_request ->
+    ( describe_clusters_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
@@ -559,6 +665,16 @@ module DescribeDefaultParameters : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_default_parameters_request ->
+    ( describe_default_parameters_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc "Returns the default system parameter information for the DAX caching software.\n"]
 
@@ -574,6 +690,16 @@ module DescribeEvents : sig
     'http_type Smaws_Lib.Context.t ->
     describe_events_request ->
     ( describe_events_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_events_request ->
+    ( describe_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -606,6 +732,17 @@ module DescribeParameterGroups : sig
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_parameter_groups_request ->
+    ( describe_parameter_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of parameter group descriptions. If a parameter group name is specified, the \
@@ -630,6 +767,17 @@ module DescribeParameters : sig
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_parameters_request ->
+    ( describe_parameters_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc "Returns the detailed parameter list for a particular parameter group.\n"]
 
@@ -644,6 +792,15 @@ module DescribeSubnetGroups : sig
     'http_type Smaws_Lib.Context.t ->
     describe_subnet_groups_request ->
     ( describe_subnet_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_subnet_groups_request ->
+    ( describe_subnet_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
@@ -682,6 +839,22 @@ module IncreaseReplicationFactor : sig
       | `NodeQuotaForCustomerExceededFault of node_quota_for_customer_exceeded_fault
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    increase_replication_factor_request ->
+    ( increase_replication_factor_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InsufficientClusterCapacityFault of insufficient_cluster_capacity_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidVPCNetworkStateFault of invalid_vpc_network_state_fault
+      | `NodeQuotaForClusterExceededFault of node_quota_for_cluster_exceeded_fault
+      | `NodeQuotaForCustomerExceededFault of node_quota_for_customer_exceeded_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc "Adds one or more nodes to a DAX cluster.\n"]
 
@@ -700,6 +873,19 @@ module ListTags : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_request ->
     ( list_tags_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidARNFault of invalid_arn_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_request ->
+    ( list_tags_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidARNFault of invalid_arn_fault
@@ -728,6 +914,19 @@ module RebootNode : sig
     'http_type Smaws_Lib.Context.t ->
     reboot_node_request ->
     ( reboot_node_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NodeNotFoundFault of node_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reboot_node_request ->
+    ( reboot_node_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidClusterStateFault of invalid_cluster_state_fault
@@ -769,6 +968,20 @@ module TagResource : sig
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
       | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidARNFault of invalid_arn_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
+    result
 end
 [@@ocaml.doc
   "Associates a set of tags with a DAX resource. You can call [TagResource] up to 5 times per \
@@ -790,6 +1003,20 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidARNFault of invalid_arn_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `TagNotFoundFault of tag_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidARNFault of invalid_arn_fault
@@ -829,6 +1056,20 @@ module UpdateCluster : sig
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_cluster_request ->
+    ( update_cluster_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc
   "Modifies the settings for a DAX cluster. You can use this action to change one or more cluster \
@@ -848,6 +1089,18 @@ module UpdateParameterGroup : sig
     'http_type Smaws_Lib.Context.t ->
     update_parameter_group_request ->
     ( update_parameter_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_parameter_group_request ->
+    ( update_parameter_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
@@ -876,6 +1129,19 @@ module UpdateSubnetGroup : sig
     'http_type Smaws_Lib.Context.t ->
     update_subnet_group_request ->
     ( update_subnet_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidSubnet of invalid_subnet
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
+      | `SubnetInUse of subnet_in_use
+      | `SubnetNotAllowedFault of subnet_not_allowed_fault
+      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_subnet_group_request ->
+    ( update_subnet_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidSubnet of invalid_subnet
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault

--- a/sdks/dax/Smaws_Client_DAX.mli
+++ b/sdks/dax/Smaws_Client_DAX.mli
@@ -361,7 +361,8 @@ module CreateCluster : sig
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
-      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
+      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a DAX cluster. All nodes in the cluster run the same DAX caching software.\n"]
@@ -400,7 +401,8 @@ module CreateParameterGroup : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupAlreadyExistsFault of parameter_group_already_exists_fault
       | `ParameterGroupQuotaExceededFault of parameter_group_quota_exceeded_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -441,7 +443,8 @@ module CreateSubnetGroup : sig
       | `SubnetGroupAlreadyExistsFault of subnet_group_already_exists_fault
       | `SubnetGroupQuotaExceededFault of subnet_group_quota_exceeded_fault
       | `SubnetNotAllowedFault of subnet_not_allowed_fault
-      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
+      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a new subnet group.\n"]
@@ -480,7 +483,8 @@ module DecreaseReplicationFactor : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NodeNotFoundFault of node_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -521,7 +525,8 @@ module DeleteCluster : sig
       | `InvalidClusterStateFault of invalid_cluster_state_fault
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -560,7 +565,8 @@ module DeleteParameterGroup : sig
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -592,7 +598,8 @@ module DeleteSubnetGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
       | `SubnetGroupInUseFault of subnet_group_in_use_fault
-      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -629,7 +636,8 @@ module DescribeClusters : sig
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -673,7 +681,8 @@ module DescribeDefaultParameters : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the default system parameter information for the DAX caching software.\n"]
@@ -703,7 +712,8 @@ module DescribeEvents : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -741,7 +751,8 @@ module DescribeParameterGroups : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -776,7 +787,8 @@ module DescribeParameters : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the detailed parameter list for a particular parameter group.\n"]
@@ -803,7 +815,8 @@ module DescribeSubnetGroups : sig
     ( describe_subnet_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
-      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -853,7 +866,8 @@ module IncreaseReplicationFactor : sig
       | `InvalidVPCNetworkStateFault of invalid_vpc_network_state_fault
       | `NodeQuotaForClusterExceededFault of node_quota_for_cluster_exceeded_fault
       | `NodeQuotaForCustomerExceededFault of node_quota_for_customer_exceeded_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds one or more nodes to a DAX cluster.\n"]
@@ -892,7 +906,8 @@ module ListTags : sig
       | `InvalidClusterStateFault of invalid_cluster_state_fault
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -933,7 +948,8 @@ module RebootNode : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NodeNotFoundFault of node_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -980,7 +996,8 @@ module TagResource : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
-      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
+      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1024,7 +1041,8 @@ module UntagResource : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
-      | `TagNotFoundFault of tag_not_found_fault ] )
+      | `TagNotFoundFault of tag_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1068,7 +1086,8 @@ module UpdateCluster : sig
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1106,7 +1125,8 @@ module UpdateParameterGroup : sig
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1148,7 +1168,8 @@ module UpdateSubnetGroup : sig
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
       | `SubnetInUse of subnet_in_use
       | `SubnetNotAllowedFault of subnet_not_allowed_fault
-      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
+      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Modifies an existing subnet group.\n"]

--- a/sdks/dax/operations.ml
+++ b/sdks/dax/operations.ml
@@ -79,6 +79,12 @@ module CreateCluster = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.CreateCluster" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_cluster_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_cluster_request) =
+    let input = Json_serializers.create_cluster_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.CreateCluster"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_cluster_response_of_yojson ~error_deserializer
 end
 
 module CreateParameterGroup = struct
@@ -123,6 +129,13 @@ module CreateParameterGroup = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_parameter_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_parameter_group_request) =
+    let input = Json_serializers.create_parameter_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.CreateParameterGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_parameter_group_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateSubnetGroup = struct
@@ -161,6 +174,13 @@ module CreateSubnetGroup = struct
     let input = Json_serializers.create_subnet_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.CreateSubnetGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_subnet_group_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_subnet_group_request) =
+    let input = Json_serializers.create_subnet_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.CreateSubnetGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_subnet_group_response_of_yojson
       ~error_deserializer
 end
 
@@ -204,6 +224,13 @@ module DecreaseReplicationFactor = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.decrease_replication_factor_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : decrease_replication_factor_request) =
+    let input = Json_serializers.decrease_replication_factor_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonDAXV3.DecreaseReplicationFactor" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.decrease_replication_factor_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteCluster = struct
@@ -242,6 +269,12 @@ module DeleteCluster = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.DeleteCluster" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_cluster_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_cluster_request) =
+    let input = Json_serializers.delete_cluster_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.DeleteCluster"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_cluster_response_of_yojson ~error_deserializer
 end
 
 module DeleteParameterGroup = struct
@@ -282,6 +315,13 @@ module DeleteParameterGroup = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.delete_parameter_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_parameter_group_request) =
+    let input = Json_serializers.delete_parameter_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.DeleteParameterGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_parameter_group_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteSubnetGroup = struct
@@ -310,6 +350,13 @@ module DeleteSubnetGroup = struct
     let input = Json_serializers.delete_subnet_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.DeleteSubnetGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_subnet_group_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_subnet_group_request) =
+    let input = Json_serializers.delete_subnet_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.DeleteSubnetGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_subnet_group_response_of_yojson
       ~error_deserializer
 end
 
@@ -345,6 +392,13 @@ module DescribeClusters = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.DescribeClusters" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_clusters_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_clusters_request) =
+    let input = Json_serializers.describe_clusters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.DescribeClusters"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_clusters_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeDefaultParameters = struct
@@ -375,6 +429,13 @@ module DescribeDefaultParameters = struct
     let input = Json_serializers.describe_default_parameters_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.DescribeDefaultParameters" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_default_parameters_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_default_parameters_request) =
+    let input = Json_serializers.describe_default_parameters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonDAXV3.DescribeDefaultParameters" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_default_parameters_response_of_yojson
       ~error_deserializer
 end
@@ -408,6 +469,12 @@ module DescribeEvents = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.DescribeEvents" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_events_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_events_request) =
+    let input = Json_serializers.describe_events_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.DescribeEvents"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_events_response_of_yojson ~error_deserializer
 end
 
 module DescribeParameterGroups = struct
@@ -442,6 +509,13 @@ module DescribeParameterGroups = struct
     let input = Json_serializers.describe_parameter_groups_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.DescribeParameterGroups" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_parameter_groups_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_parameter_groups_request) =
+    let input = Json_serializers.describe_parameter_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonDAXV3.DescribeParameterGroups" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_parameter_groups_response_of_yojson
       ~error_deserializer
 end
@@ -479,6 +553,13 @@ module DescribeParameters = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.DescribeParameters" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_parameters_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_parameters_request) =
+    let input = Json_serializers.describe_parameters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.DescribeParameters"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_parameters_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeSubnetGroups = struct
@@ -504,6 +585,13 @@ module DescribeSubnetGroups = struct
     let input = Json_serializers.describe_subnet_groups_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.DescribeSubnetGroups" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_subnet_groups_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_subnet_groups_request) =
+    let input = Json_serializers.describe_subnet_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.DescribeSubnetGroups"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_subnet_groups_response_of_yojson
       ~error_deserializer
 end
@@ -561,6 +649,13 @@ module IncreaseReplicationFactor = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.increase_replication_factor_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : increase_replication_factor_request) =
+    let input = Json_serializers.increase_replication_factor_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonDAXV3.IncreaseReplicationFactor" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.increase_replication_factor_response_of_yojson
+      ~error_deserializer
 end
 
 module ListTags = struct
@@ -601,6 +696,12 @@ module ListTags = struct
     let input = Json_serializers.list_tags_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.ListTags" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_request) =
+    let input = Json_serializers.list_tags_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.ListTags" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_tags_response_of_yojson
+      ~error_deserializer
 end
 
 module RebootNode = struct
@@ -641,6 +742,12 @@ module RebootNode = struct
     let input = Json_serializers.reboot_node_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.RebootNode" ~service ~context
       ~input ~output_deserializer:Json_deserializers.reboot_node_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : reboot_node_request) =
+    let input = Json_serializers.reboot_node_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.RebootNode" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.reboot_node_response_of_yojson
       ~error_deserializer
 end
 
@@ -687,6 +794,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.TagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.TagResource" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -731,6 +844,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.UntagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
 module UpdateCluster = struct
@@ -777,6 +896,12 @@ module UpdateCluster = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.UpdateCluster" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_cluster_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_cluster_request) =
+    let input = Json_serializers.update_cluster_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.UpdateCluster"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_cluster_response_of_yojson ~error_deserializer
 end
 
 module UpdateParameterGroup = struct
@@ -817,6 +942,13 @@ module UpdateParameterGroup = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_parameter_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_parameter_group_request) =
+    let input = Json_serializers.update_parameter_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.UpdateParameterGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_parameter_group_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateSubnetGroup = struct
@@ -853,5 +985,12 @@ module UpdateSubnetGroup = struct
     let input = Json_serializers.update_subnet_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonDAXV3.UpdateSubnetGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_subnet_group_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_subnet_group_request) =
+    let input = Json_serializers.update_subnet_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonDAXV3.UpdateSubnetGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_subnet_group_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/dax/operations.mli
+++ b/sdks/dax/operations.mli
@@ -41,6 +41,28 @@ module CreateCluster : sig
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
       | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_cluster_request ->
+    ( create_cluster_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterAlreadyExistsFault of cluster_already_exists_fault
+      | `ClusterQuotaForCustomerExceededFault of cluster_quota_for_customer_exceeded_fault
+      | `InsufficientClusterCapacityFault of insufficient_cluster_capacity_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidVPCNetworkStateFault of invalid_vpc_network_state_fault
+      | `NodeQuotaForClusterExceededFault of node_quota_for_cluster_exceeded_fault
+      | `NodeQuotaForCustomerExceededFault of node_quota_for_customer_exceeded_fault
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
+      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
+    result
 end
 [@@ocaml.doc "Creates a DAX cluster. All nodes in the cluster run the same DAX caching software.\n"]
 
@@ -59,6 +81,19 @@ module CreateParameterGroup : sig
     'http_type Smaws_Lib.Context.t ->
     create_parameter_group_request ->
     ( create_parameter_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupAlreadyExistsFault of parameter_group_already_exists_fault
+      | `ParameterGroupQuotaExceededFault of parameter_group_quota_exceeded_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_parameter_group_request ->
+    ( create_parameter_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
@@ -95,6 +130,19 @@ module CreateSubnetGroup : sig
       | `SubnetNotAllowedFault of subnet_not_allowed_fault
       | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_subnet_group_request ->
+    ( create_subnet_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidSubnet of invalid_subnet
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `SubnetGroupAlreadyExistsFault of subnet_group_already_exists_fault
+      | `SubnetGroupQuotaExceededFault of subnet_group_quota_exceeded_fault
+      | `SubnetNotAllowedFault of subnet_not_allowed_fault
+      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
+    result
 end
 [@@ocaml.doc "Creates a new subnet group.\n"]
 
@@ -113,6 +161,19 @@ module DecreaseReplicationFactor : sig
     'http_type Smaws_Lib.Context.t ->
     decrease_replication_factor_request ->
     ( decrease_replication_factor_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NodeNotFoundFault of node_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    decrease_replication_factor_request ->
+    ( decrease_replication_factor_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidClusterStateFault of invalid_cluster_state_fault
@@ -150,6 +211,18 @@ module DeleteCluster : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_cluster_request ->
+    ( delete_cluster_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a previously provisioned DAX cluster. {i DeleteCluster} deletes all associated nodes, \
@@ -170,6 +243,18 @@ module DeleteParameterGroup : sig
     'http_type Smaws_Lib.Context.t ->
     delete_parameter_group_request ->
     ( delete_parameter_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_parameter_group_request ->
+    ( delete_parameter_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
@@ -199,6 +284,16 @@ module DeleteSubnetGroup : sig
       | `SubnetGroupInUseFault of subnet_group_in_use_fault
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_subnet_group_request ->
+    ( delete_subnet_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `SubnetGroupInUseFault of subnet_group_in_use_fault
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a subnet group.\n\n\
@@ -219,6 +314,17 @@ module DescribeClusters : sig
     'http_type Smaws_Lib.Context.t ->
     describe_clusters_request ->
     ( describe_clusters_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_clusters_request ->
+    ( describe_clusters_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
@@ -259,6 +365,16 @@ module DescribeDefaultParameters : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_default_parameters_request ->
+    ( describe_default_parameters_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc "Returns the default system parameter information for the DAX caching software.\n"]
 
@@ -274,6 +390,16 @@ module DescribeEvents : sig
     'http_type Smaws_Lib.Context.t ->
     describe_events_request ->
     ( describe_events_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_events_request ->
+    ( describe_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
@@ -306,6 +432,17 @@ module DescribeParameterGroups : sig
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_parameter_groups_request ->
+    ( describe_parameter_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of parameter group descriptions. If a parameter group name is specified, the \
@@ -330,6 +467,17 @@ module DescribeParameters : sig
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_parameters_request ->
+    ( describe_parameters_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc "Returns the detailed parameter list for a particular parameter group.\n"]
 
@@ -344,6 +492,15 @@ module DescribeSubnetGroups : sig
     'http_type Smaws_Lib.Context.t ->
     describe_subnet_groups_request ->
     ( describe_subnet_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_subnet_groups_request ->
+    ( describe_subnet_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
@@ -382,6 +539,22 @@ module IncreaseReplicationFactor : sig
       | `NodeQuotaForCustomerExceededFault of node_quota_for_customer_exceeded_fault
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    increase_replication_factor_request ->
+    ( increase_replication_factor_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InsufficientClusterCapacityFault of insufficient_cluster_capacity_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `InvalidVPCNetworkStateFault of invalid_vpc_network_state_fault
+      | `NodeQuotaForClusterExceededFault of node_quota_for_cluster_exceeded_fault
+      | `NodeQuotaForCustomerExceededFault of node_quota_for_customer_exceeded_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc "Adds one or more nodes to a DAX cluster.\n"]
 
@@ -400,6 +573,19 @@ module ListTags : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_request ->
     ( list_tags_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidARNFault of invalid_arn_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_request ->
+    ( list_tags_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidARNFault of invalid_arn_fault
@@ -428,6 +614,19 @@ module RebootNode : sig
     'http_type Smaws_Lib.Context.t ->
     reboot_node_request ->
     ( reboot_node_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `NodeNotFoundFault of node_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reboot_node_request ->
+    ( reboot_node_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidClusterStateFault of invalid_cluster_state_fault
@@ -469,6 +668,20 @@ module TagResource : sig
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
       | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidARNFault of invalid_arn_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
+    result
 end
 [@@ocaml.doc
   "Associates a set of tags with a DAX resource. You can call [TagResource] up to 5 times per \
@@ -490,6 +703,20 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidARNFault of invalid_arn_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `TagNotFoundFault of tag_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidARNFault of invalid_arn_fault
@@ -529,6 +756,20 @@ module UpdateCluster : sig
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_cluster_request ->
+    ( update_cluster_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterNotFoundFault of cluster_not_found_fault
+      | `InvalidClusterStateFault of invalid_cluster_state_fault
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
 end
 [@@ocaml.doc
   "Modifies the settings for a DAX cluster. You can use this action to change one or more cluster \
@@ -548,6 +789,18 @@ module UpdateParameterGroup : sig
     'http_type Smaws_Lib.Context.t ->
     update_parameter_group_request ->
     ( update_parameter_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterCombinationException of invalid_parameter_combination_exception
+      | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
+      | `InvalidParameterValueException of invalid_parameter_value_exception
+      | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_parameter_group_request ->
+    ( update_parameter_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
@@ -575,6 +828,19 @@ module UpdateSubnetGroup : sig
     'http_type Smaws_Lib.Context.t ->
     update_subnet_group_request ->
     ( update_subnet_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidSubnet of invalid_subnet
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
+      | `SubnetInUse of subnet_in_use
+      | `SubnetNotAllowedFault of subnet_not_allowed_fault
+      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_subnet_group_request ->
+    ( update_subnet_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidSubnet of invalid_subnet
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault

--- a/sdks/dax/operations.mli
+++ b/sdks/dax/operations.mli
@@ -61,7 +61,8 @@ module CreateCluster : sig
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
-      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
+      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a DAX cluster. All nodes in the cluster run the same DAX caching software.\n"]
@@ -100,7 +101,8 @@ module CreateParameterGroup : sig
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupAlreadyExistsFault of parameter_group_already_exists_fault
       | `ParameterGroupQuotaExceededFault of parameter_group_quota_exceeded_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -141,7 +143,8 @@ module CreateSubnetGroup : sig
       | `SubnetGroupAlreadyExistsFault of subnet_group_already_exists_fault
       | `SubnetGroupQuotaExceededFault of subnet_group_quota_exceeded_fault
       | `SubnetNotAllowedFault of subnet_not_allowed_fault
-      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
+      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a new subnet group.\n"]
@@ -180,7 +183,8 @@ module DecreaseReplicationFactor : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NodeNotFoundFault of node_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -221,7 +225,8 @@ module DeleteCluster : sig
       | `InvalidClusterStateFault of invalid_cluster_state_fault
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -260,7 +265,8 @@ module DeleteParameterGroup : sig
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -292,7 +298,8 @@ module DeleteSubnetGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
       | `SubnetGroupInUseFault of subnet_group_in_use_fault
-      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -329,7 +336,8 @@ module DescribeClusters : sig
       | `ClusterNotFoundFault of cluster_not_found_fault
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -373,7 +381,8 @@ module DescribeDefaultParameters : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the default system parameter information for the DAX caching software.\n"]
@@ -403,7 +412,8 @@ module DescribeEvents : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -441,7 +451,8 @@ module DescribeParameterGroups : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -476,7 +487,8 @@ module DescribeParameters : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the detailed parameter list for a particular parameter group.\n"]
@@ -503,7 +515,8 @@ module DescribeSubnetGroups : sig
     ( describe_subnet_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
-      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ] )
+      | `SubnetGroupNotFoundFault of subnet_group_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -553,7 +566,8 @@ module IncreaseReplicationFactor : sig
       | `InvalidVPCNetworkStateFault of invalid_vpc_network_state_fault
       | `NodeQuotaForClusterExceededFault of node_quota_for_cluster_exceeded_fault
       | `NodeQuotaForCustomerExceededFault of node_quota_for_customer_exceeded_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds one or more nodes to a DAX cluster.\n"]
@@ -592,7 +606,8 @@ module ListTags : sig
       | `InvalidClusterStateFault of invalid_cluster_state_fault
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -633,7 +648,8 @@ module RebootNode : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `NodeNotFoundFault of node_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -680,7 +696,8 @@ module TagResource : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
-      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ] )
+      | `TagQuotaPerResourceExceeded of tag_quota_per_resource_exceeded ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -724,7 +741,8 @@ module UntagResource : sig
       | `InvalidParameterCombinationException of invalid_parameter_combination_exception
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault
-      | `TagNotFoundFault of tag_not_found_fault ] )
+      | `TagNotFoundFault of tag_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -768,7 +786,8 @@ module UpdateCluster : sig
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -806,7 +825,8 @@ module UpdateParameterGroup : sig
       | `InvalidParameterGroupStateFault of invalid_parameter_group_state_fault
       | `InvalidParameterValueException of invalid_parameter_value_exception
       | `ParameterGroupNotFoundFault of parameter_group_not_found_fault
-      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ] )
+      | `ServiceLinkedRoleNotFoundFault of service_linked_role_not_found_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -847,7 +867,8 @@ module UpdateSubnetGroup : sig
       | `SubnetGroupNotFoundFault of subnet_group_not_found_fault
       | `SubnetInUse of subnet_in_use
       | `SubnetNotAllowedFault of subnet_not_allowed_fault
-      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ] )
+      | `SubnetQuotaExceededFault of subnet_quota_exceeded_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Modifies an existing subnet group.\n"]

--- a/sdks/directory-service/Smaws_Client_DirectoryService.mli
+++ b/sdks/directory-service/Smaws_Client_DirectoryService.mli
@@ -901,7 +901,8 @@ module AcceptSharedDirectory : sig
       | `DirectoryAlreadySharedException of directory_already_shared_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -944,7 +945,8 @@ module AddIpRoutes : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `IpRouteLimitExceededException of ip_route_limit_exceeded_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1006,7 +1008,8 @@ module AddRegion : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `RegionLimitExceededException of region_limit_exceeded_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds two domain controllers in the specified Region for the specified directory.\n"]
@@ -1042,7 +1045,8 @@ module AddTagsToResource : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `TagLimitExceededException of tag_limit_exceeded_exception ] )
+      | `TagLimitExceededException of tag_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1075,7 +1079,8 @@ module CancelSchemaExtension : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1112,7 +1117,8 @@ module ConnectDirectory : sig
       | `ClientException of client_exception
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1155,7 +1161,8 @@ module CreateAlias : sig
       | `EntityAlreadyExistsException of entity_already_exists_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1210,7 +1217,8 @@ module CreateComputer : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates an Active Directory computer object in the specified directory.\n"]
@@ -1252,7 +1260,8 @@ module CreateConditionalForwarder : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1288,7 +1297,8 @@ module CreateDirectory : sig
       | `ClientException of client_exception
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1339,7 +1349,8 @@ module CreateHybridAD : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1386,7 +1397,8 @@ module CreateLogSubscription : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1424,7 +1436,8 @@ module CreateMicrosoftAD : sig
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1469,7 +1482,8 @@ module CreateSnapshot : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1512,7 +1526,8 @@ module CreateTrust : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1556,7 +1571,8 @@ module DeleteADAssessment : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1600,7 +1616,8 @@ module DeleteConditionalForwarder : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1631,7 +1648,8 @@ module DeleteDirectory : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1671,7 +1689,8 @@ module DeleteLogSubscription : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified log subscription.\n"]
@@ -1704,7 +1723,8 @@ module DeleteSnapshot : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a directory snapshot.\n"]
@@ -1740,7 +1760,8 @@ module DeleteTrust : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1787,7 +1808,8 @@ module DeregisterCertificate : sig
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1822,7 +1844,8 @@ module DeregisterEventTopic : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the specified directory as a publisher to the specified Amazon SNS topic.\n"]
@@ -1858,7 +1881,8 @@ module DescribeADAssessment : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1894,7 +1918,8 @@ module DescribeCAEnrollmentPolicy : sig
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1936,7 +1961,8 @@ module DescribeCertificate : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1977,7 +2003,8 @@ module DescribeClientAuthenticationSettings : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2020,7 +2047,8 @@ module DescribeConditionalForwarders : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2060,7 +2088,8 @@ module DescribeDirectories : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2108,7 +2137,8 @@ module DescribeDirectoryDataAccess : sig
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2149,7 +2179,8 @@ module DescribeDomainControllers : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides information about any domain controllers in your directory.\n"]
@@ -2182,7 +2213,8 @@ module DescribeEventTopics : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2226,7 +2258,8 @@ module DescribeHybridADUpdate : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2268,7 +2301,8 @@ module DescribeLDAPSSettings : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes the status of LDAP security for the specified directory.\n"]
@@ -2310,7 +2344,8 @@ module DescribeRegions : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2350,7 +2385,8 @@ module DescribeSettings : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves information about the configurable settings for the specified directory.\n"]
@@ -2389,7 +2425,8 @@ module DescribeSharedDirectories : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the shared directories in your account. \n"]
@@ -2425,7 +2462,8 @@ module DescribeSnapshots : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2471,7 +2509,8 @@ module DescribeTrusts : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2514,7 +2553,8 @@ module DescribeUpdateDirectory : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Describes the updates of a directory for a particular update type. \n"]
@@ -2559,7 +2599,8 @@ module DisableCAEnrollmentPolicy : sig
       | `DisableAlreadyInProgressException of disable_already_in_progress_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2605,7 +2646,8 @@ module DisableClientAuthentication : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidClientAuthStatusException of invalid_client_auth_status_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Disables alternative client authentication methods for the specified directory. \n"]
@@ -2647,7 +2689,8 @@ module DisableDirectoryDataAccess : sig
       | `DirectoryInDesiredStateException of directory_in_desired_state_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2693,7 +2736,8 @@ module DisableLDAPS : sig
       | `InvalidLDAPSStatusException of invalid_ldaps_status_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deactivates LDAP secure calls for the specified directory.\n"]
@@ -2723,7 +2767,8 @@ module DisableRadius : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2761,7 +2806,8 @@ module DisableSso : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Disables single-sign on for a directory.\n"]
@@ -2809,7 +2855,8 @@ module EnableCAEnrollmentPolicy : sig
       | `EntityAlreadyExistsException of entity_already_exists_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2859,7 +2906,8 @@ module EnableClientAuthentication : sig
       | `InvalidClientAuthStatusException of invalid_client_auth_status_exception
       | `NoAvailableCertificateException of no_available_certificate_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Enables alternative client authentication methods for the specified directory.\n"]
@@ -2901,7 +2949,8 @@ module EnableDirectoryDataAccess : sig
       | `DirectoryInDesiredStateException of directory_in_desired_state_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2950,7 +2999,8 @@ module EnableLDAPS : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NoAvailableCertificateException of no_available_certificate_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Activates the switch for the specific directory to always use LDAP secure calls.\n"]
@@ -2986,7 +3036,8 @@ module EnableRadius : sig
       | `EntityAlreadyExistsException of entity_already_exists_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3024,7 +3075,8 @@ module EnableSso : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3057,7 +3109,8 @@ module GetDirectoryLimits : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Obtains directory limit information for the current Region.\n"]
@@ -3087,7 +3140,8 @@ module GetSnapshotLimits : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Obtains the manual snapshot limits for a directory.\n"]
@@ -3123,7 +3177,8 @@ module ListADAssessments : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3164,7 +3219,8 @@ module ListCertificates : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3202,7 +3258,8 @@ module ListIpRoutes : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the address blocks that you have added to a directory.\n"]
@@ -3235,7 +3292,8 @@ module ListLogSubscriptions : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the active log subscriptions for the Amazon Web Services account.\n"]
@@ -3268,7 +3326,8 @@ module ListSchemaExtensions : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all schema extensions applied to a Microsoft AD Directory.\n"]
@@ -3304,7 +3363,8 @@ module ListTagsForResource : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all tags on a directory.\n"]
@@ -3352,7 +3412,8 @@ module RegisterCertificate : sig
       | `InvalidCertificateException of invalid_certificate_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Registers a certificate for a secure LDAP or client certificate authentication.\n"]
@@ -3385,7 +3446,8 @@ module RegisterEventTopic : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3426,7 +3488,8 @@ module RejectSharedDirectory : sig
       | `DirectoryAlreadySharedException of directory_already_shared_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3463,7 +3526,8 @@ module RemoveIpRoutes : sig
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes IP address blocks from a directory.\n"]
@@ -3502,7 +3566,8 @@ module RemoveRegion : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3537,7 +3602,8 @@ module RemoveTagsFromResource : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tags from a directory.\n"]
@@ -3579,7 +3645,8 @@ module ResetUserPassword : sig
       | `InvalidPasswordException of invalid_password_exception
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception
-      | `UserDoesNotExistException of user_does_not_exist_exception ] )
+      | `UserDoesNotExistException of user_does_not_exist_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3631,7 +3698,8 @@ module RestoreFromSnapshot : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3691,7 +3759,8 @@ module ShareDirectory : sig
       | `OrganizationsException of organizations_exception
       | `ServiceException of service_exception
       | `ShareLimitExceededException of share_limit_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3747,7 +3816,8 @@ module StartADAssessment : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3803,7 +3873,8 @@ module StartSchemaExtension : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Applies a schema extension to a Microsoft AD directory.\n"]
@@ -3839,7 +3910,8 @@ module UnshareDirectory : sig
       | `DirectoryNotSharedException of directory_not_shared_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidTargetException of invalid_target_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Stops the directory sharing between the directory owner and consumer accounts. \n"]
@@ -3878,7 +3950,8 @@ module UpdateConditionalForwarder : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3927,7 +4000,8 @@ module UpdateDirectorySetup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
       | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates directory configuration for the specified update type.\n"]
@@ -3966,7 +4040,8 @@ module UpdateHybridAD : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4024,7 +4099,8 @@ module UpdateNumberOfDomainControllers : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4062,7 +4138,8 @@ module UpdateRadius : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4109,7 +4186,8 @@ module UpdateSettings : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception
-      | `UnsupportedSettingsException of unsupported_settings_exception ] )
+      | `UnsupportedSettingsException of unsupported_settings_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the configurable settings for the specified directory.\n"]
@@ -4142,7 +4220,8 @@ module UpdateTrust : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4181,7 +4260,8 @@ module VerifyTrust : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/directory-service/Smaws_Client_DirectoryService.mli
+++ b/sdks/directory-service/Smaws_Client_DirectoryService.mli
@@ -891,6 +891,18 @@ module AcceptSharedDirectory : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_shared_directory_request ->
+    ( accept_shared_directory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryAlreadySharedException of directory_already_shared_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Accepts a directory sharing request that was sent from the directory owner account.\n"]
@@ -911,6 +923,20 @@ module AddIpRoutes : sig
     'http_type Smaws_Lib.Context.t ->
     add_ip_routes_request ->
     ( add_ip_routes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `IpRouteLimitExceededException of ip_route_limit_exceeded_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_ip_routes_request ->
+    ( add_ip_routes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -965,6 +991,23 @@ module AddRegion : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_region_request ->
+    ( add_region_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryAlreadyInRegionException of directory_already_in_region_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `RegionLimitExceededException of region_limit_exceeded_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Adds two domain controllers in the specified Region for the specified directory.\n"]
 
@@ -982,6 +1025,18 @@ module AddTagsToResource : sig
     'http_type Smaws_Lib.Context.t ->
     add_tags_to_resource_request ->
     ( add_tags_to_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `TagLimitExceededException of tag_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_to_resource_request ->
+    ( add_tags_to_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1007,6 +1062,16 @@ module CancelSchemaExtension : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_schema_extension_request ->
     ( cancel_schema_extension_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_schema_extension_request ->
+    ( cancel_schema_extension_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1038,6 +1103,17 @@ module ConnectDirectory : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    connect_directory_request ->
+    ( connect_directory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryLimitExceededException of directory_limit_exceeded_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an AD Connector to connect to a self-managed directory.\n\n\
@@ -1062,6 +1138,18 @@ module CreateAlias : sig
     'http_type Smaws_Lib.Context.t ->
     create_alias_request ->
     ( create_alias_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_alias_request ->
+    ( create_alias_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityAlreadyExistsException of entity_already_exists_exception
@@ -1109,6 +1197,21 @@ module CreateComputer : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_computer_request ->
+    ( create_computer_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AuthenticationFailedException of authentication_failed_exception
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Creates an Active Directory computer object in the specified directory.\n"]
 
@@ -1137,6 +1240,20 @@ module CreateConditionalForwarder : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_conditional_forwarder_request ->
+    ( create_conditional_forwarder_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a conditional forwarder associated with your Amazon Web Services directory. Conditional \
@@ -1156,6 +1273,17 @@ module CreateDirectory : sig
     'http_type Smaws_Lib.Context.t ->
     create_directory_request ->
     ( create_directory_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryLimitExceededException of directory_limit_exceeded_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_directory_request ->
+    ( create_directory_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
@@ -1199,6 +1327,20 @@ module CreateHybridAD : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_hybrid_ad_request ->
+    ( create_hybrid_ad_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ADAssessmentLimitExceededException of ad_assessment_limit_exceeded_exception
+      | `ClientException of client_exception
+      | `DirectoryLimitExceededException of directory_limit_exceeded_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a hybrid directory that connects your self-managed Active Directory (AD) infrastructure \
@@ -1233,6 +1375,19 @@ module CreateLogSubscription : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_log_subscription_request ->
+    ( create_log_subscription_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a subscription to forward real-time Directory Service domain controller security logs \
@@ -1252,6 +1407,18 @@ module CreateMicrosoftAD : sig
     'http_type Smaws_Lib.Context.t ->
     create_microsoft_ad_request ->
     ( create_microsoft_ad_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryLimitExceededException of directory_limit_exceeded_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_microsoft_ad_request ->
+    ( create_microsoft_ad_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
@@ -1292,6 +1459,18 @@ module CreateSnapshot : sig
       | `ServiceException of service_exception
       | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_snapshot_request ->
+    ( create_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a snapshot of a Simple AD or Microsoft AD directory in the Amazon Web Services cloud.\n\n\
@@ -1314,6 +1493,19 @@ module CreateTrust : sig
     'http_type Smaws_Lib.Context.t ->
     create_trust_request ->
     ( create_trust_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_trust_request ->
+    ( create_trust_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityAlreadyExistsException of entity_already_exists_exception
@@ -1354,6 +1546,18 @@ module DeleteADAssessment : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ad_assessment_request ->
+    ( delete_ad_assessment_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a directory assessment and all associated data. This operation permanently removes the \
@@ -1385,6 +1589,19 @@ module DeleteConditionalForwarder : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_conditional_forwarder_request ->
+    ( delete_conditional_forwarder_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a conditional forwarder that has been set up for your Amazon Web Services directory.\n"]
@@ -1401,6 +1618,16 @@ module DeleteDirectory : sig
     'http_type Smaws_Lib.Context.t ->
     delete_directory_request ->
     ( delete_directory_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_directory_request ->
+    ( delete_directory_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1435,6 +1662,17 @@ module DeleteLogSubscription : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_log_subscription_request ->
+    ( delete_log_subscription_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified log subscription.\n"]
 
@@ -1451,6 +1689,17 @@ module DeleteSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     delete_snapshot_request ->
     ( delete_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_snapshot_request ->
+    ( delete_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1474,6 +1723,18 @@ module DeleteTrust : sig
     'http_type Smaws_Lib.Context.t ->
     delete_trust_request ->
     ( delete_trust_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_trust_request ->
+    ( delete_trust_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1513,6 +1774,21 @@ module DeregisterCertificate : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_certificate_request ->
+    ( deregister_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CertificateDoesNotExistException of certificate_does_not_exist_exception
+      | `CertificateInUseException of certificate_in_use_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes from the system the certificate that was registered for secure LDAP or client \
@@ -1531,6 +1807,17 @@ module DeregisterEventTopic : sig
     'http_type Smaws_Lib.Context.t ->
     deregister_event_topic_request ->
     ( deregister_event_topic_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_event_topic_request ->
+    ( deregister_event_topic_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1561,6 +1848,18 @@ module DescribeADAssessment : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_ad_assessment_request ->
+    ( describe_ad_assessment_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves detailed information about a directory assessment, including its current status, \
@@ -1580,6 +1879,17 @@ module DescribeCAEnrollmentPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     describe_ca_enrollment_policy_request ->
     ( describe_ca_enrollment_policy_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_ca_enrollment_policy_request ->
+    ( describe_ca_enrollment_policy_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
@@ -1615,6 +1925,19 @@ module DescribeCertificate : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_certificate_request ->
+    ( describe_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CertificateDoesNotExistException of certificate_does_not_exist_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Displays information about the certificate registered for secure LDAP or client certificate \
@@ -1635,6 +1958,19 @@ module DescribeClientAuthenticationSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_client_authentication_settings_request ->
     ( describe_client_authentication_settings_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_client_authentication_settings_request ->
+    ( describe_client_authentication_settings_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -1673,6 +2009,19 @@ module DescribeConditionalForwarders : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_conditional_forwarders_request ->
+    ( describe_conditional_forwarders_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Obtains information about the conditional forwarders for this account.\n\n\
@@ -1694,6 +2043,18 @@ module DescribeDirectories : sig
     'http_type Smaws_Lib.Context.t ->
     describe_directories_request ->
     ( describe_directories_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_directories_request ->
+    ( describe_directories_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1737,6 +2098,18 @@ module DescribeDirectoryDataAccess : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_directory_data_access_request ->
+    ( describe_directory_data_access_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Obtains status of directory data access enablement through the Directory Service Data API for \
@@ -1765,6 +2138,19 @@ module DescribeDomainControllers : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_domain_controllers_request ->
+    ( describe_domain_controllers_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Provides information about any domain controllers in your directory.\n"]
 
@@ -1781,6 +2167,17 @@ module DescribeEventTopics : sig
     'http_type Smaws_Lib.Context.t ->
     describe_event_topics_request ->
     ( describe_event_topics_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_event_topics_request ->
+    ( describe_event_topics_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1818,6 +2215,19 @@ module DescribeHybridADUpdate : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_hybrid_ad_update_request ->
+    ( describe_hybrid_ad_update_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves information about update activities for a hybrid directory. This operation provides \
@@ -1839,6 +2249,19 @@ module DescribeLDAPSSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_ldaps_settings_request ->
     ( describe_ldaps_settings_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_ldaps_settings_request ->
+    ( describe_ldaps_settings_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
@@ -1875,6 +2298,20 @@ module DescribeRegions : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_regions_request ->
+    ( describe_regions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the Regions that are configured for multi-Region replication.\n"]
@@ -1894,6 +2331,19 @@ module DescribeSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_settings_request ->
     ( describe_settings_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_settings_request ->
+    ( describe_settings_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
@@ -1928,6 +2378,19 @@ module DescribeSharedDirectories : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_shared_directories_request ->
+    ( describe_shared_directories_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the shared directories in your account. \n"]
 
@@ -1945,6 +2408,18 @@ module DescribeSnapshots : sig
     'http_type Smaws_Lib.Context.t ->
     describe_snapshots_request ->
     ( describe_snapshots_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_snapshots_request ->
+    ( describe_snapshots_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1985,6 +2460,19 @@ module DescribeTrusts : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_trusts_request ->
+    ( describe_trusts_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Obtains information about the trust relationships for this account.\n\n\
@@ -2015,6 +2503,19 @@ module DescribeUpdateDirectory : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_update_directory_request ->
+    ( describe_update_directory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc " Describes the updates of a directory for a particular update type. \n"]
 
@@ -2035,6 +2536,21 @@ module DisableCAEnrollmentPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     disable_ca_enrollment_policy_request ->
     ( disable_ca_enrollment_policy_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `DisableAlreadyInProgressException of disable_already_in_progress_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_ca_enrollment_policy_request ->
+    ( disable_ca_enrollment_policy_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -2078,6 +2594,19 @@ module DisableClientAuthentication : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_client_authentication_request ->
+    ( disable_client_authentication_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidClientAuthStatusException of invalid_client_auth_status_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Disables alternative client authentication methods for the specified directory. \n"]
 
@@ -2097,6 +2626,20 @@ module DisableDirectoryDataAccess : sig
     'http_type Smaws_Lib.Context.t ->
     disable_directory_data_access_request ->
     ( disable_directory_data_access_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryInDesiredStateException of directory_in_desired_state_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_directory_data_access_request ->
+    ( disable_directory_data_access_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -2138,6 +2681,20 @@ module DisableLDAPS : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_ldaps_request ->
+    ( disable_ldaps_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidLDAPSStatusException of invalid_ldaps_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deactivates LDAP secure calls for the specified directory.\n"]
 
@@ -2153,6 +2710,16 @@ module DisableRadius : sig
     'http_type Smaws_Lib.Context.t ->
     disable_radius_request ->
     ( disable_radius_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_radius_request ->
+    ( disable_radius_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -2184,6 +2751,18 @@ module DisableSso : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_sso_request ->
+    ( disable_sso_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AuthenticationFailedException of authentication_failed_exception
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc "Disables single-sign on for a directory.\n"]
 
@@ -2205,6 +2784,22 @@ module EnableCAEnrollmentPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     enable_ca_enrollment_policy_request ->
     ( enable_ca_enrollment_policy_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EnableAlreadyInProgressException of enable_already_in_progress_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_ca_enrollment_policy_request ->
+    ( enable_ca_enrollment_policy_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -2252,6 +2847,20 @@ module EnableClientAuthentication : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_client_authentication_request ->
+    ( enable_client_authentication_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidClientAuthStatusException of invalid_client_auth_status_exception
+      | `NoAvailableCertificateException of no_available_certificate_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Enables alternative client authentication methods for the specified directory.\n"]
 
@@ -2271,6 +2880,20 @@ module EnableDirectoryDataAccess : sig
     'http_type Smaws_Lib.Context.t ->
     enable_directory_data_access_request ->
     ( enable_directory_data_access_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryInDesiredStateException of directory_in_desired_state_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_directory_data_access_request ->
+    ( enable_directory_data_access_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -2314,6 +2937,21 @@ module EnableLDAPS : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_ldaps_request ->
+    ( enable_ldaps_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidLDAPSStatusException of invalid_ldaps_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoAvailableCertificateException of no_available_certificate_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Activates the switch for the specific directory to always use LDAP secure calls.\n"]
 
@@ -2331,6 +2969,18 @@ module EnableRadius : sig
     'http_type Smaws_Lib.Context.t ->
     enable_radius_request ->
     ( enable_radius_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_radius_request ->
+    ( enable_radius_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityAlreadyExistsException of entity_already_exists_exception
@@ -2364,6 +3014,18 @@ module EnableSso : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_sso_request ->
+    ( enable_sso_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AuthenticationFailedException of authentication_failed_exception
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables single sign-on for a directory. Single sign-on allows users in your directory to access \
@@ -2382,6 +3044,16 @@ module GetDirectoryLimits : sig
     'http_type Smaws_Lib.Context.t ->
     get_directory_limits_request ->
     ( get_directory_limits_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_directory_limits_request ->
+    ( get_directory_limits_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -2407,6 +3079,16 @@ module GetSnapshotLimits : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_snapshot_limits_request ->
+    ( get_snapshot_limits_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc "Obtains the manual snapshot limits for a directory.\n"]
 
@@ -2424,6 +3106,18 @@ module ListADAssessments : sig
     'http_type Smaws_Lib.Context.t ->
     list_ad_assessments_request ->
     ( list_ad_assessments_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ad_assessments_request ->
+    ( list_ad_assessments_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
@@ -2459,6 +3153,19 @@ module ListCertificates : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_certificates_request ->
+    ( list_certificates_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "For the specified directory, lists all the certificates registered for a secure LDAP or client \
@@ -2478,6 +3185,18 @@ module ListIpRoutes : sig
     'http_type Smaws_Lib.Context.t ->
     list_ip_routes_request ->
     ( list_ip_routes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ip_routes_request ->
+    ( list_ip_routes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -2507,6 +3226,17 @@ module ListLogSubscriptions : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_log_subscriptions_request ->
+    ( list_log_subscriptions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the active log subscriptions for the Amazon Web Services account.\n"]
 
@@ -2523,6 +3253,17 @@ module ListSchemaExtensions : sig
     'http_type Smaws_Lib.Context.t ->
     list_schema_extensions_request ->
     ( list_schema_extensions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_schema_extensions_request ->
+    ( list_schema_extensions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -2546,6 +3287,18 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -2585,6 +3338,22 @@ module RegisterCertificate : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_certificate_request ->
+    ( register_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CertificateAlreadyExistsException of certificate_already_exists_exception
+      | `CertificateLimitExceededException of certificate_limit_exceeded_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidCertificateException of invalid_certificate_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Registers a certificate for a secure LDAP or client certificate authentication.\n"]
 
@@ -2601,6 +3370,17 @@ module RegisterEventTopic : sig
     'http_type Smaws_Lib.Context.t ->
     register_event_topic_request ->
     ( register_event_topic_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_event_topic_request ->
+    ( register_event_topic_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -2636,6 +3416,18 @@ module RejectSharedDirectory : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reject_shared_directory_request ->
+    ( reject_shared_directory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryAlreadySharedException of directory_already_shared_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Rejects a directory sharing request that was sent from the directory owner account.\n"]
@@ -2654,6 +3446,18 @@ module RemoveIpRoutes : sig
     'http_type Smaws_Lib.Context.t ->
     remove_ip_routes_request ->
     ( remove_ip_routes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_ip_routes_request ->
+    ( remove_ip_routes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -2687,6 +3491,19 @@ module RemoveRegion : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_region_request ->
+    ( remove_region_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops all replication and removes the domain controllers from the specified Region. You cannot \
@@ -2705,6 +3522,17 @@ module RemoveTagsFromResource : sig
     'http_type Smaws_Lib.Context.t ->
     remove_tags_from_resource_request ->
     ( remove_tags_from_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_from_resource_request ->
+    ( remove_tags_from_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -2730,6 +3558,20 @@ module ResetUserPassword : sig
     'http_type Smaws_Lib.Context.t ->
     reset_user_password_request ->
     ( reset_user_password_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidPasswordException of invalid_password_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception
+      | `UserDoesNotExistException of user_does_not_exist_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reset_user_password_request ->
+    ( reset_user_password_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -2780,6 +3622,17 @@ module RestoreFromSnapshot : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_from_snapshot_request ->
+    ( restore_from_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Restores a directory using an existing directory snapshot.\n\n\
@@ -2811,6 +3664,23 @@ module ShareDirectory : sig
     'http_type Smaws_Lib.Context.t ->
     share_directory_request ->
     ( share_directory_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryAlreadySharedException of directory_already_shared_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTargetException of invalid_target_exception
+      | `OrganizationsException of organizations_exception
+      | `ServiceException of service_exception
+      | `ShareLimitExceededException of share_limit_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    share_directory_request ->
+    ( share_directory_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -2866,6 +3736,19 @@ module StartADAssessment : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_ad_assessment_request ->
+    ( start_ad_assessment_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ADAssessmentLimitExceededException of ad_assessment_limit_exceeded_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Initiates a directory assessment to validate your self-managed AD environment for hybrid domain \
@@ -2909,6 +3792,19 @@ module StartSchemaExtension : sig
       | `ServiceException of service_exception
       | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_schema_extension_request ->
+    ( start_schema_extension_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc "Applies a schema extension to a Microsoft AD directory.\n"]
 
@@ -2926,6 +3822,18 @@ module UnshareDirectory : sig
     'http_type Smaws_Lib.Context.t ->
     unshare_directory_request ->
     ( unshare_directory_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryNotSharedException of directory_not_shared_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidTargetException of invalid_target_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unshare_directory_request ->
+    ( unshare_directory_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryNotSharedException of directory_not_shared_exception
@@ -2951,6 +3859,19 @@ module UpdateConditionalForwarder : sig
     'http_type Smaws_Lib.Context.t ->
     update_conditional_forwarder_request ->
     ( update_conditional_forwarder_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_conditional_forwarder_request ->
+    ( update_conditional_forwarder_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -2992,6 +3913,22 @@ module UpdateDirectorySetup : sig
       | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_directory_setup_request ->
+    ( update_directory_setup_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryInDesiredStateException of directory_in_desired_state_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates directory configuration for the specified update type.\n"]
 
@@ -3010,6 +3947,19 @@ module UpdateHybridAD : sig
     'http_type Smaws_Lib.Context.t ->
     update_hybrid_ad_request ->
     ( update_hybrid_ad_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ADAssessmentLimitExceededException of ad_assessment_limit_exceeded_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_hybrid_ad_request ->
+    ( update_hybrid_ad_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ADAssessmentLimitExceededException of ad_assessment_limit_exceeded_exception
       | `ClientException of client_exception
@@ -3062,6 +4012,20 @@ module UpdateNumberOfDomainControllers : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_number_of_domain_controllers_request ->
+    ( update_number_of_domain_controllers_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `DomainControllerLimitExceededException of domain_controller_limit_exceeded_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or removes domain controllers to or from the directory. Based on the difference between \
@@ -3083,6 +4047,17 @@ module UpdateRadius : sig
     'http_type Smaws_Lib.Context.t ->
     update_radius_request ->
     ( update_radius_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_radius_request ->
+    ( update_radius_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -3121,6 +4096,21 @@ module UpdateSettings : sig
       | `UnsupportedOperationException of unsupported_operation_exception
       | `UnsupportedSettingsException of unsupported_settings_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_settings_request ->
+    ( update_settings_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `IncompatibleSettingsException of incompatible_settings_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception
+      | `UnsupportedSettingsException of unsupported_settings_exception ] )
+    result
 end
 [@@ocaml.doc "Updates the configurable settings for the specified directory.\n"]
 
@@ -3137,6 +4127,17 @@ module UpdateTrust : sig
     'http_type Smaws_Lib.Context.t ->
     update_trust_request ->
     ( update_trust_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_trust_request ->
+    ( update_trust_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -3163,6 +4164,18 @@ module VerifyTrust : sig
     'http_type Smaws_Lib.Context.t ->
     verify_trust_request ->
     ( verify_trust_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    verify_trust_request ->
+    ( verify_trust_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception

--- a/sdks/directory-service/operations.ml
+++ b/sdks/directory-service/operations.ml
@@ -37,6 +37,13 @@ module AcceptSharedDirectory = struct
       ~shape_name:"DirectoryService_20150416.AcceptSharedDirectory" ~service ~context ~input
       ~output_deserializer:Json_deserializers.accept_shared_directory_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : accept_shared_directory_request) =
+    let input = Json_serializers.accept_shared_directory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.AcceptSharedDirectory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.accept_shared_directory_result_of_yojson
+      ~error_deserializer
 end
 
 module AddIpRoutes = struct
@@ -84,6 +91,12 @@ module AddIpRoutes = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.AddIpRoutes" ~service
       ~context ~input ~output_deserializer:Json_deserializers.add_ip_routes_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_ip_routes_request) =
+    let input = Json_serializers.add_ip_routes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.AddIpRoutes" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.add_ip_routes_result_of_yojson ~error_deserializer
 end
 
 module AddRegion = struct
@@ -144,6 +157,12 @@ module AddRegion = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.AddRegion" ~service
       ~context ~input ~output_deserializer:Json_deserializers.add_region_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_region_request) =
+    let input = Json_serializers.add_region_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.AddRegion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.add_region_result_of_yojson ~error_deserializer
 end
 
 module AddTagsToResource = struct
@@ -181,6 +200,13 @@ module AddTagsToResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.add_tags_to_resource_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_tags_to_resource_request) =
+    let input = Json_serializers.add_tags_to_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.AddTagsToResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.add_tags_to_resource_result_of_yojson
+      ~error_deserializer
 end
 
 module CancelSchemaExtension = struct
@@ -207,6 +233,13 @@ module CancelSchemaExtension = struct
   let request context (request : cancel_schema_extension_request) =
     let input = Json_serializers.cancel_schema_extension_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DirectoryService_20150416.CancelSchemaExtension" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_schema_extension_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : cancel_schema_extension_request) =
+    let input = Json_serializers.cancel_schema_extension_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DirectoryService_20150416.CancelSchemaExtension" ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_schema_extension_result_of_yojson
       ~error_deserializer
@@ -242,6 +275,12 @@ module ConnectDirectory = struct
     let input = Json_serializers.connect_directory_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.ConnectDirectory"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.connect_directory_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : connect_directory_request) =
+    let input = Json_serializers.connect_directory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.ConnectDirectory" ~service ~context ~input
       ~output_deserializer:Json_deserializers.connect_directory_result_of_yojson ~error_deserializer
 end
 
@@ -280,6 +319,12 @@ module CreateAlias = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.CreateAlias" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_alias_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_alias_request) =
+    let input = Json_serializers.create_alias_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.CreateAlias" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_alias_result_of_yojson ~error_deserializer
 end
 
 module CreateComputer = struct
@@ -332,6 +377,12 @@ module CreateComputer = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.CreateComputer"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_computer_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_computer_request) =
+    let input = Json_serializers.create_computer_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.CreateComputer" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_computer_result_of_yojson ~error_deserializer
 end
 
 module CreateConditionalForwarder = struct
@@ -380,6 +431,13 @@ module CreateConditionalForwarder = struct
       ~shape_name:"DirectoryService_20150416.CreateConditionalForwarder" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_conditional_forwarder_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_conditional_forwarder_request) =
+    let input = Json_serializers.create_conditional_forwarder_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.CreateConditionalForwarder" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_conditional_forwarder_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateDirectory = struct
@@ -412,6 +470,12 @@ module CreateDirectory = struct
     let input = Json_serializers.create_directory_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.CreateDirectory"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_directory_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_directory_request) =
+    let input = Json_serializers.create_directory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.CreateDirectory" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_directory_result_of_yojson ~error_deserializer
 end
 
@@ -460,6 +524,12 @@ module CreateHybridAD = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.CreateHybridAD"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_hybrid_ad_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_hybrid_ad_request) =
+    let input = Json_serializers.create_hybrid_ad_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.CreateHybridAD" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_hybrid_ad_result_of_yojson ~error_deserializer
 end
 
 module CreateLogSubscription = struct
@@ -504,6 +574,13 @@ module CreateLogSubscription = struct
       ~shape_name:"DirectoryService_20150416.CreateLogSubscription" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_log_subscription_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_log_subscription_request) =
+    let input = Json_serializers.create_log_subscription_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.CreateLogSubscription" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_log_subscription_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateMicrosoftAD = struct
@@ -543,6 +620,13 @@ module CreateMicrosoftAD = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_microsoft_ad_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_microsoft_ad_request) =
+    let input = Json_serializers.create_microsoft_ad_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.CreateMicrosoftAD" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_microsoft_ad_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateSnapshot = struct
@@ -579,6 +663,12 @@ module CreateSnapshot = struct
     let input = Json_serializers.create_snapshot_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.CreateSnapshot"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_snapshot_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_snapshot_request) =
+    let input = Json_serializers.create_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.CreateSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_snapshot_result_of_yojson ~error_deserializer
 end
 
@@ -622,6 +712,12 @@ module CreateTrust = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.CreateTrust" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_trust_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_trust_request) =
+    let input = Json_serializers.create_trust_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.CreateTrust" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_trust_result_of_yojson ~error_deserializer
 end
 
 module DeleteADAssessment = struct
@@ -658,6 +754,13 @@ module DeleteADAssessment = struct
     let input = Json_serializers.delete_ad_assessment_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DeleteADAssessment"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_ad_assessment_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_ad_assessment_request) =
+    let input = Json_serializers.delete_ad_assessment_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DeleteADAssessment" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_ad_assessment_result_of_yojson
       ~error_deserializer
 end
@@ -703,6 +806,13 @@ module DeleteConditionalForwarder = struct
       ~shape_name:"DirectoryService_20150416.DeleteConditionalForwarder" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_conditional_forwarder_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_conditional_forwarder_request) =
+    let input = Json_serializers.delete_conditional_forwarder_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DeleteConditionalForwarder" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_conditional_forwarder_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteDirectory = struct
@@ -730,6 +840,12 @@ module DeleteDirectory = struct
     let input = Json_serializers.delete_directory_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DeleteDirectory"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_directory_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : delete_directory_request) =
+    let input = Json_serializers.delete_directory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DeleteDirectory" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_directory_result_of_yojson ~error_deserializer
 end
 
@@ -765,6 +881,13 @@ module DeleteLogSubscription = struct
       ~shape_name:"DirectoryService_20150416.DeleteLogSubscription" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_log_subscription_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_log_subscription_request) =
+    let input = Json_serializers.delete_log_subscription_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DeleteLogSubscription" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_log_subscription_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteSnapshot = struct
@@ -796,6 +919,12 @@ module DeleteSnapshot = struct
     let input = Json_serializers.delete_snapshot_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DeleteSnapshot"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_snapshot_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : delete_snapshot_request) =
+    let input = Json_serializers.delete_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DeleteSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_snapshot_result_of_yojson ~error_deserializer
 end
 
@@ -834,6 +963,12 @@ module DeleteTrust = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DeleteTrust" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_trust_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_trust_request) =
+    let input = Json_serializers.delete_trust_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DeleteTrust" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_trust_result_of_yojson ~error_deserializer
 end
 
 module DeregisterCertificate = struct
@@ -887,6 +1022,13 @@ module DeregisterCertificate = struct
       ~shape_name:"DirectoryService_20150416.DeregisterCertificate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.deregister_certificate_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deregister_certificate_request) =
+    let input = Json_serializers.deregister_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DeregisterCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.deregister_certificate_result_of_yojson
+      ~error_deserializer
 end
 
 module DeregisterEventTopic = struct
@@ -918,6 +1060,13 @@ module DeregisterEventTopic = struct
     let input = Json_serializers.deregister_event_topic_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DeregisterEventTopic"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.deregister_event_topic_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : deregister_event_topic_request) =
+    let input = Json_serializers.deregister_event_topic_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DeregisterEventTopic" ~service ~context ~input
       ~output_deserializer:Json_deserializers.deregister_event_topic_result_of_yojson
       ~error_deserializer
 end
@@ -958,6 +1107,13 @@ module DescribeADAssessment = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_ad_assessment_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_ad_assessment_request) =
+    let input = Json_serializers.describe_ad_assessment_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeADAssessment" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_ad_assessment_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeCAEnrollmentPolicy = struct
@@ -990,6 +1146,13 @@ module DescribeCAEnrollmentPolicy = struct
   let request context (request : describe_ca_enrollment_policy_request) =
     let input = Json_serializers.describe_ca_enrollment_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DirectoryService_20150416.DescribeCAEnrollmentPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_ca_enrollment_policy_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_ca_enrollment_policy_request) =
+    let input = Json_serializers.describe_ca_enrollment_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DirectoryService_20150416.DescribeCAEnrollmentPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_ca_enrollment_policy_result_of_yojson
       ~error_deserializer
@@ -1035,6 +1198,13 @@ module DescribeCertificate = struct
     let input = Json_serializers.describe_certificate_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DescribeCertificate"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_certificate_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_certificate_request) =
+    let input = Json_serializers.describe_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeCertificate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_certificate_result_of_yojson
       ~error_deserializer
 end
@@ -1083,6 +1253,17 @@ module DescribeClientAuthenticationSettings = struct
       ~output_deserializer:
         Json_deserializers.describe_client_authentication_settings_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_client_authentication_settings_request) =
+    let input =
+      Json_serializers.describe_client_authentication_settings_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeClientAuthenticationSettings" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.describe_client_authentication_settings_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeConditionalForwarders = struct
@@ -1126,6 +1307,13 @@ module DescribeConditionalForwarders = struct
       ~shape_name:"DirectoryService_20150416.DescribeConditionalForwarders" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_conditional_forwarders_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_conditional_forwarders_request) =
+    let input = Json_serializers.describe_conditional_forwarders_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeConditionalForwarders" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_conditional_forwarders_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeDirectories = struct
@@ -1163,6 +1351,13 @@ module DescribeDirectories = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_directories_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_directories_request) =
+    let input = Json_serializers.describe_directories_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeDirectories" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_directories_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeDirectoryDataAccess = struct
@@ -1198,6 +1393,13 @@ module DescribeDirectoryDataAccess = struct
   let request context (request : describe_directory_data_access_request) =
     let input = Json_serializers.describe_directory_data_access_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DirectoryService_20150416.DescribeDirectoryDataAccess" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_directory_data_access_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_directory_data_access_request) =
+    let input = Json_serializers.describe_directory_data_access_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DirectoryService_20150416.DescribeDirectoryDataAccess" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_directory_data_access_result_of_yojson
       ~error_deserializer
@@ -1243,6 +1445,13 @@ module DescribeDomainControllers = struct
       ~shape_name:"DirectoryService_20150416.DescribeDomainControllers" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_domain_controllers_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_domain_controllers_request) =
+    let input = Json_serializers.describe_domain_controllers_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeDomainControllers" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_domain_controllers_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeEventTopics = struct
@@ -1274,6 +1483,13 @@ module DescribeEventTopics = struct
     let input = Json_serializers.describe_event_topics_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DescribeEventTopics"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_event_topics_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_event_topics_request) =
+    let input = Json_serializers.describe_event_topics_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeEventTopics" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_event_topics_result_of_yojson
       ~error_deserializer
 end
@@ -1319,6 +1535,13 @@ module DescribeHybridADUpdate = struct
       ~shape_name:"DirectoryService_20150416.DescribeHybridADUpdate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_hybrid_ad_update_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_hybrid_ad_update_request) =
+    let input = Json_serializers.describe_hybrid_ad_update_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeHybridADUpdate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_hybrid_ad_update_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeLDAPSSettings = struct
@@ -1359,6 +1582,13 @@ module DescribeLDAPSSettings = struct
   let request context (request : describe_ldaps_settings_request) =
     let input = Json_serializers.describe_ldaps_settings_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DirectoryService_20150416.DescribeLDAPSSettings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_ldaps_settings_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_ldaps_settings_request) =
+    let input = Json_serializers.describe_ldaps_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DirectoryService_20150416.DescribeLDAPSSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_ldaps_settings_result_of_yojson
       ~error_deserializer
@@ -1407,6 +1637,12 @@ module DescribeRegions = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DescribeRegions"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_regions_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_regions_request) =
+    let input = Json_serializers.describe_regions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeRegions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_regions_result_of_yojson ~error_deserializer
 end
 
 module DescribeSettings = struct
@@ -1448,6 +1684,12 @@ module DescribeSettings = struct
     let input = Json_serializers.describe_settings_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DescribeSettings"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_settings_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_settings_request) =
+    let input = Json_serializers.describe_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_settings_result_of_yojson ~error_deserializer
 end
 
@@ -1491,6 +1733,13 @@ module DescribeSharedDirectories = struct
       ~shape_name:"DirectoryService_20150416.DescribeSharedDirectories" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_shared_directories_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_shared_directories_request) =
+    let input = Json_serializers.describe_shared_directories_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeSharedDirectories" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_shared_directories_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeSnapshots = struct
@@ -1526,6 +1775,13 @@ module DescribeSnapshots = struct
     let input = Json_serializers.describe_snapshots_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DescribeSnapshots"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_snapshots_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_snapshots_request) =
+    let input = Json_serializers.describe_snapshots_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeSnapshots" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_snapshots_result_of_yojson
       ~error_deserializer
 end
@@ -1569,6 +1825,12 @@ module DescribeTrusts = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DescribeTrusts"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_trusts_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_trusts_request) =
+    let input = Json_serializers.describe_trusts_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DescribeTrusts" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_trusts_result_of_yojson ~error_deserializer
 end
 
 module DescribeUpdateDirectory = struct
@@ -1607,6 +1869,13 @@ module DescribeUpdateDirectory = struct
   let request context (request : describe_update_directory_request) =
     let input = Json_serializers.describe_update_directory_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DirectoryService_20150416.DescribeUpdateDirectory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_update_directory_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_update_directory_request) =
+    let input = Json_serializers.describe_update_directory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DirectoryService_20150416.DescribeUpdateDirectory" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_update_directory_result_of_yojson
       ~error_deserializer
@@ -1661,6 +1930,13 @@ module DisableCAEnrollmentPolicy = struct
       ~shape_name:"DirectoryService_20150416.DisableCAEnrollmentPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disable_ca_enrollment_policy_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disable_ca_enrollment_policy_request) =
+    let input = Json_serializers.disable_ca_enrollment_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DisableCAEnrollmentPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disable_ca_enrollment_policy_result_of_yojson
+      ~error_deserializer
 end
 
 module DisableClientAuthentication = struct
@@ -1701,6 +1977,13 @@ module DisableClientAuthentication = struct
   let request context (request : disable_client_authentication_request) =
     let input = Json_serializers.disable_client_authentication_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DirectoryService_20150416.DisableClientAuthentication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disable_client_authentication_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disable_client_authentication_request) =
+    let input = Json_serializers.disable_client_authentication_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DirectoryService_20150416.DisableClientAuthentication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disable_client_authentication_result_of_yojson
       ~error_deserializer
@@ -1752,6 +2035,13 @@ module DisableDirectoryDataAccess = struct
       ~shape_name:"DirectoryService_20150416.DisableDirectoryDataAccess" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disable_directory_data_access_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disable_directory_data_access_request) =
+    let input = Json_serializers.disable_directory_data_access_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DisableDirectoryDataAccess" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disable_directory_data_access_result_of_yojson
+      ~error_deserializer
 end
 
 module DisableLDAPS = struct
@@ -1799,6 +2089,12 @@ module DisableLDAPS = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DisableLDAPS"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.disable_ldaps_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : disable_ldaps_request) =
+    let input = Json_serializers.disable_ldaps_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DisableLDAPS" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disable_ldaps_result_of_yojson ~error_deserializer
 end
 
 module DisableRadius = struct
@@ -1826,6 +2122,12 @@ module DisableRadius = struct
     let input = Json_serializers.disable_radius_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DisableRadius"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disable_radius_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : disable_radius_request) =
+    let input = Json_serializers.disable_radius_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DisableRadius" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disable_radius_result_of_yojson ~error_deserializer
 end
 
@@ -1865,6 +2167,12 @@ module DisableSso = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.DisableSso" ~service
       ~context ~input ~output_deserializer:Json_deserializers.disable_sso_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disable_sso_request) =
+    let input = Json_serializers.disable_sso_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.DisableSso" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disable_sso_result_of_yojson ~error_deserializer
 end
 
 module EnableCAEnrollmentPolicy = struct
@@ -1921,6 +2229,13 @@ module EnableCAEnrollmentPolicy = struct
       ~shape_name:"DirectoryService_20150416.EnableCAEnrollmentPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.enable_ca_enrollment_policy_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : enable_ca_enrollment_policy_request) =
+    let input = Json_serializers.enable_ca_enrollment_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.EnableCAEnrollmentPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enable_ca_enrollment_policy_result_of_yojson
+      ~error_deserializer
 end
 
 module EnableClientAuthentication = struct
@@ -1969,6 +2284,13 @@ module EnableClientAuthentication = struct
       ~shape_name:"DirectoryService_20150416.EnableClientAuthentication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.enable_client_authentication_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : enable_client_authentication_request) =
+    let input = Json_serializers.enable_client_authentication_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.EnableClientAuthentication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enable_client_authentication_result_of_yojson
+      ~error_deserializer
 end
 
 module EnableDirectoryDataAccess = struct
@@ -2014,6 +2336,13 @@ module EnableDirectoryDataAccess = struct
   let request context (request : enable_directory_data_access_request) =
     let input = Json_serializers.enable_directory_data_access_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DirectoryService_20150416.EnableDirectoryDataAccess" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enable_directory_data_access_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : enable_directory_data_access_request) =
+    let input = Json_serializers.enable_directory_data_access_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DirectoryService_20150416.EnableDirectoryDataAccess" ~service ~context ~input
       ~output_deserializer:Json_deserializers.enable_directory_data_access_result_of_yojson
       ~error_deserializer
@@ -2069,6 +2398,12 @@ module EnableLDAPS = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.EnableLDAPS" ~service
       ~context ~input ~output_deserializer:Json_deserializers.enable_ldaps_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : enable_ldaps_request) =
+    let input = Json_serializers.enable_ldaps_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.EnableLDAPS" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enable_ldaps_result_of_yojson ~error_deserializer
 end
 
 module EnableRadius = struct
@@ -2105,6 +2440,12 @@ module EnableRadius = struct
     let input = Json_serializers.enable_radius_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.EnableRadius"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enable_radius_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : enable_radius_request) =
+    let input = Json_serializers.enable_radius_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.EnableRadius" ~service ~context ~input
       ~output_deserializer:Json_deserializers.enable_radius_result_of_yojson ~error_deserializer
 end
 
@@ -2144,6 +2485,12 @@ module EnableSso = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.EnableSso" ~service
       ~context ~input ~output_deserializer:Json_deserializers.enable_sso_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : enable_sso_request) =
+    let input = Json_serializers.enable_sso_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.EnableSso" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enable_sso_result_of_yojson ~error_deserializer
 end
 
 module GetDirectoryLimits = struct
@@ -2173,6 +2520,13 @@ module GetDirectoryLimits = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_directory_limits_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_directory_limits_request) =
+    let input = Json_serializers.get_directory_limits_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.GetDirectoryLimits" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_directory_limits_result_of_yojson
+      ~error_deserializer
 end
 
 module GetSnapshotLimits = struct
@@ -2200,6 +2554,13 @@ module GetSnapshotLimits = struct
     let input = Json_serializers.get_snapshot_limits_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.GetSnapshotLimits"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_snapshot_limits_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_snapshot_limits_request) =
+    let input = Json_serializers.get_snapshot_limits_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.GetSnapshotLimits" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_snapshot_limits_result_of_yojson
       ~error_deserializer
 end
@@ -2239,6 +2600,13 @@ module ListADAssessments = struct
     let input = Json_serializers.list_ad_assessments_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.ListADAssessments"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_ad_assessments_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_ad_assessments_request) =
+    let input = Json_serializers.list_ad_assessments_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.ListADAssessments" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_ad_assessments_result_of_yojson
       ~error_deserializer
 end
@@ -2283,6 +2651,12 @@ module ListCertificates = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.ListCertificates"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_certificates_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_certificates_request) =
+    let input = Json_serializers.list_certificates_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.ListCertificates" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_certificates_result_of_yojson ~error_deserializer
 end
 
 module ListIpRoutes = struct
@@ -2319,6 +2693,12 @@ module ListIpRoutes = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.ListIpRoutes"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_ip_routes_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_ip_routes_request) =
+    let input = Json_serializers.list_ip_routes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.ListIpRoutes" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_ip_routes_result_of_yojson ~error_deserializer
 end
 
 module ListLogSubscriptions = struct
@@ -2352,6 +2732,13 @@ module ListLogSubscriptions = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_log_subscriptions_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_log_subscriptions_request) =
+    let input = Json_serializers.list_log_subscriptions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.ListLogSubscriptions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_log_subscriptions_result_of_yojson
+      ~error_deserializer
 end
 
 module ListSchemaExtensions = struct
@@ -2383,6 +2770,13 @@ module ListSchemaExtensions = struct
     let input = Json_serializers.list_schema_extensions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.ListSchemaExtensions"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_schema_extensions_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_schema_extensions_request) =
+    let input = Json_serializers.list_schema_extensions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.ListSchemaExtensions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_schema_extensions_result_of_yojson
       ~error_deserializer
 end
@@ -2420,6 +2814,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.ListTagsForResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_result_of_yojson
       ~error_deserializer
 end
@@ -2480,6 +2881,13 @@ module RegisterCertificate = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.register_certificate_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : register_certificate_request) =
+    let input = Json_serializers.register_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.RegisterCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.register_certificate_result_of_yojson
+      ~error_deserializer
 end
 
 module RegisterEventTopic = struct
@@ -2511,6 +2919,13 @@ module RegisterEventTopic = struct
     let input = Json_serializers.register_event_topic_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.RegisterEventTopic"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.register_event_topic_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : register_event_topic_request) =
+    let input = Json_serializers.register_event_topic_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.RegisterEventTopic" ~service ~context ~input
       ~output_deserializer:Json_deserializers.register_event_topic_result_of_yojson
       ~error_deserializer
 end
@@ -2551,6 +2966,13 @@ module RejectSharedDirectory = struct
       ~shape_name:"DirectoryService_20150416.RejectSharedDirectory" ~service ~context ~input
       ~output_deserializer:Json_deserializers.reject_shared_directory_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : reject_shared_directory_request) =
+    let input = Json_serializers.reject_shared_directory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.RejectSharedDirectory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.reject_shared_directory_result_of_yojson
+      ~error_deserializer
 end
 
 module RemoveIpRoutes = struct
@@ -2587,6 +3009,12 @@ module RemoveIpRoutes = struct
     let input = Json_serializers.remove_ip_routes_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.RemoveIpRoutes"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.remove_ip_routes_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : remove_ip_routes_request) =
+    let input = Json_serializers.remove_ip_routes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.RemoveIpRoutes" ~service ~context ~input
       ~output_deserializer:Json_deserializers.remove_ip_routes_result_of_yojson ~error_deserializer
 end
 
@@ -2630,6 +3058,12 @@ module RemoveRegion = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.RemoveRegion"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.remove_region_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : remove_region_request) =
+    let input = Json_serializers.remove_region_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.RemoveRegion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.remove_region_result_of_yojson ~error_deserializer
 end
 
 module RemoveTagsFromResource = struct
@@ -2660,6 +3094,13 @@ module RemoveTagsFromResource = struct
   let request context (request : remove_tags_from_resource_request) =
     let input = Json_serializers.remove_tags_from_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DirectoryService_20150416.RemoveTagsFromResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.remove_tags_from_resource_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : remove_tags_from_resource_request) =
+    let input = Json_serializers.remove_tags_from_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DirectoryService_20150416.RemoveTagsFromResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.remove_tags_from_resource_result_of_yojson
       ~error_deserializer
@@ -2710,6 +3151,13 @@ module ResetUserPassword = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.reset_user_password_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : reset_user_password_request) =
+    let input = Json_serializers.reset_user_password_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.ResetUserPassword" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.reset_user_password_result_of_yojson
+      ~error_deserializer
 end
 
 module RestoreFromSnapshot = struct
@@ -2741,6 +3189,13 @@ module RestoreFromSnapshot = struct
     let input = Json_serializers.restore_from_snapshot_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.RestoreFromSnapshot"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.restore_from_snapshot_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : restore_from_snapshot_request) =
+    let input = Json_serializers.restore_from_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.RestoreFromSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.restore_from_snapshot_result_of_yojson
       ~error_deserializer
 end
@@ -2798,6 +3253,12 @@ module ShareDirectory = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.ShareDirectory"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.share_directory_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : share_directory_request) =
+    let input = Json_serializers.share_directory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.ShareDirectory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.share_directory_result_of_yojson ~error_deserializer
 end
 
 module StartADAssessment = struct
@@ -2840,6 +3301,13 @@ module StartADAssessment = struct
     let input = Json_serializers.start_ad_assessment_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.StartADAssessment"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_ad_assessment_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_ad_assessment_request) =
+    let input = Json_serializers.start_ad_assessment_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.StartADAssessment" ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_ad_assessment_result_of_yojson
       ~error_deserializer
 end
@@ -2885,6 +3353,13 @@ module StartSchemaExtension = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_schema_extension_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_schema_extension_request) =
+    let input = Json_serializers.start_schema_extension_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.StartSchemaExtension" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_schema_extension_result_of_yojson
+      ~error_deserializer
 end
 
 module UnshareDirectory = struct
@@ -2919,6 +3394,12 @@ module UnshareDirectory = struct
     let input = Json_serializers.unshare_directory_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.UnshareDirectory"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.unshare_directory_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : unshare_directory_request) =
+    let input = Json_serializers.unshare_directory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.UnshareDirectory" ~service ~context ~input
       ~output_deserializer:Json_deserializers.unshare_directory_result_of_yojson ~error_deserializer
 end
 
@@ -2960,6 +3441,13 @@ module UpdateConditionalForwarder = struct
   let request context (request : update_conditional_forwarder_request) =
     let input = Json_serializers.update_conditional_forwarder_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DirectoryService_20150416.UpdateConditionalForwarder" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_conditional_forwarder_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_conditional_forwarder_request) =
+    let input = Json_serializers.update_conditional_forwarder_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DirectoryService_20150416.UpdateConditionalForwarder" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_conditional_forwarder_result_of_yojson
       ~error_deserializer
@@ -3020,6 +3508,13 @@ module UpdateDirectorySetup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_directory_setup_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_directory_setup_request) =
+    let input = Json_serializers.update_directory_setup_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.UpdateDirectorySetup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_directory_setup_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateHybridAD = struct
@@ -3062,6 +3557,12 @@ module UpdateHybridAD = struct
     let input = Json_serializers.update_hybrid_ad_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.UpdateHybridAD"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_hybrid_ad_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : update_hybrid_ad_request) =
+    let input = Json_serializers.update_hybrid_ad_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.UpdateHybridAD" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_hybrid_ad_result_of_yojson ~error_deserializer
 end
 
@@ -3112,6 +3613,14 @@ module UpdateNumberOfDomainControllers = struct
       ~input
       ~output_deserializer:Json_deserializers.update_number_of_domain_controllers_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_number_of_domain_controllers_request) =
+    let input = Json_serializers.update_number_of_domain_controllers_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.UpdateNumberOfDomainControllers" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.update_number_of_domain_controllers_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateRadius = struct
@@ -3143,6 +3652,12 @@ module UpdateRadius = struct
     let input = Json_serializers.update_radius_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.UpdateRadius"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_radius_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : update_radius_request) =
+    let input = Json_serializers.update_radius_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.UpdateRadius" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_radius_result_of_yojson ~error_deserializer
 end
 
@@ -3197,6 +3712,12 @@ module UpdateSettings = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.UpdateSettings"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_settings_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : update_settings_request) =
+    let input = Json_serializers.update_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.UpdateSettings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_settings_result_of_yojson ~error_deserializer
 end
 
 module UpdateTrust = struct
@@ -3229,6 +3750,12 @@ module UpdateTrust = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.UpdateTrust" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_trust_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_trust_request) =
+    let input = Json_serializers.update_trust_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.UpdateTrust" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_trust_result_of_yojson ~error_deserializer
 end
 
 module VerifyTrust = struct
@@ -3266,4 +3793,10 @@ module VerifyTrust = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DirectoryService_20150416.VerifyTrust" ~service
       ~context ~input ~output_deserializer:Json_deserializers.verify_trust_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : verify_trust_request) =
+    let input = Json_serializers.verify_trust_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DirectoryService_20150416.VerifyTrust" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.verify_trust_result_of_yojson ~error_deserializer
 end

--- a/sdks/directory-service/operations.mli
+++ b/sdks/directory-service/operations.mli
@@ -21,6 +21,18 @@ module AcceptSharedDirectory : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_shared_directory_request ->
+    ( accept_shared_directory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryAlreadySharedException of directory_already_shared_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Accepts a directory sharing request that was sent from the directory owner account.\n"]
@@ -41,6 +53,20 @@ module AddIpRoutes : sig
     'http_type Smaws_Lib.Context.t ->
     add_ip_routes_request ->
     ( add_ip_routes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `IpRouteLimitExceededException of ip_route_limit_exceeded_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_ip_routes_request ->
+    ( add_ip_routes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -95,6 +121,23 @@ module AddRegion : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_region_request ->
+    ( add_region_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryAlreadyInRegionException of directory_already_in_region_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `RegionLimitExceededException of region_limit_exceeded_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Adds two domain controllers in the specified Region for the specified directory.\n"]
 
@@ -112,6 +155,18 @@ module AddTagsToResource : sig
     'http_type Smaws_Lib.Context.t ->
     add_tags_to_resource_request ->
     ( add_tags_to_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `TagLimitExceededException of tag_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_to_resource_request ->
+    ( add_tags_to_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -137,6 +192,16 @@ module CancelSchemaExtension : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_schema_extension_request ->
     ( cancel_schema_extension_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_schema_extension_request ->
+    ( cancel_schema_extension_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -168,6 +233,17 @@ module ConnectDirectory : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    connect_directory_request ->
+    ( connect_directory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryLimitExceededException of directory_limit_exceeded_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an AD Connector to connect to a self-managed directory.\n\n\
@@ -192,6 +268,18 @@ module CreateAlias : sig
     'http_type Smaws_Lib.Context.t ->
     create_alias_request ->
     ( create_alias_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_alias_request ->
+    ( create_alias_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityAlreadyExistsException of entity_already_exists_exception
@@ -239,6 +327,21 @@ module CreateComputer : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_computer_request ->
+    ( create_computer_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AuthenticationFailedException of authentication_failed_exception
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Creates an Active Directory computer object in the specified directory.\n"]
 
@@ -267,6 +370,20 @@ module CreateConditionalForwarder : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_conditional_forwarder_request ->
+    ( create_conditional_forwarder_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a conditional forwarder associated with your Amazon Web Services directory. Conditional \
@@ -286,6 +403,17 @@ module CreateDirectory : sig
     'http_type Smaws_Lib.Context.t ->
     create_directory_request ->
     ( create_directory_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryLimitExceededException of directory_limit_exceeded_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_directory_request ->
+    ( create_directory_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
@@ -329,6 +457,20 @@ module CreateHybridAD : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_hybrid_ad_request ->
+    ( create_hybrid_ad_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ADAssessmentLimitExceededException of ad_assessment_limit_exceeded_exception
+      | `ClientException of client_exception
+      | `DirectoryLimitExceededException of directory_limit_exceeded_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a hybrid directory that connects your self-managed Active Directory (AD) infrastructure \
@@ -363,6 +505,19 @@ module CreateLogSubscription : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_log_subscription_request ->
+    ( create_log_subscription_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a subscription to forward real-time Directory Service domain controller security logs \
@@ -382,6 +537,18 @@ module CreateMicrosoftAD : sig
     'http_type Smaws_Lib.Context.t ->
     create_microsoft_ad_request ->
     ( create_microsoft_ad_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryLimitExceededException of directory_limit_exceeded_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_microsoft_ad_request ->
+    ( create_microsoft_ad_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
@@ -422,6 +589,18 @@ module CreateSnapshot : sig
       | `ServiceException of service_exception
       | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_snapshot_request ->
+    ( create_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a snapshot of a Simple AD or Microsoft AD directory in the Amazon Web Services cloud.\n\n\
@@ -444,6 +623,19 @@ module CreateTrust : sig
     'http_type Smaws_Lib.Context.t ->
     create_trust_request ->
     ( create_trust_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_trust_request ->
+    ( create_trust_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityAlreadyExistsException of entity_already_exists_exception
@@ -484,6 +676,18 @@ module DeleteADAssessment : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ad_assessment_request ->
+    ( delete_ad_assessment_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a directory assessment and all associated data. This operation permanently removes the \
@@ -515,6 +719,19 @@ module DeleteConditionalForwarder : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_conditional_forwarder_request ->
+    ( delete_conditional_forwarder_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a conditional forwarder that has been set up for your Amazon Web Services directory.\n"]
@@ -531,6 +748,16 @@ module DeleteDirectory : sig
     'http_type Smaws_Lib.Context.t ->
     delete_directory_request ->
     ( delete_directory_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_directory_request ->
+    ( delete_directory_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -565,6 +792,17 @@ module DeleteLogSubscription : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_log_subscription_request ->
+    ( delete_log_subscription_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified log subscription.\n"]
 
@@ -581,6 +819,17 @@ module DeleteSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     delete_snapshot_request ->
     ( delete_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_snapshot_request ->
+    ( delete_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -604,6 +853,18 @@ module DeleteTrust : sig
     'http_type Smaws_Lib.Context.t ->
     delete_trust_request ->
     ( delete_trust_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_trust_request ->
+    ( delete_trust_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -643,6 +904,21 @@ module DeregisterCertificate : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_certificate_request ->
+    ( deregister_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CertificateDoesNotExistException of certificate_does_not_exist_exception
+      | `CertificateInUseException of certificate_in_use_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes from the system the certificate that was registered for secure LDAP or client \
@@ -661,6 +937,17 @@ module DeregisterEventTopic : sig
     'http_type Smaws_Lib.Context.t ->
     deregister_event_topic_request ->
     ( deregister_event_topic_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_event_topic_request ->
+    ( deregister_event_topic_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -691,6 +978,18 @@ module DescribeADAssessment : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_ad_assessment_request ->
+    ( describe_ad_assessment_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves detailed information about a directory assessment, including its current status, \
@@ -710,6 +1009,17 @@ module DescribeCAEnrollmentPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     describe_ca_enrollment_policy_request ->
     ( describe_ca_enrollment_policy_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_ca_enrollment_policy_request ->
+    ( describe_ca_enrollment_policy_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
@@ -745,6 +1055,19 @@ module DescribeCertificate : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_certificate_request ->
+    ( describe_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CertificateDoesNotExistException of certificate_does_not_exist_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Displays information about the certificate registered for secure LDAP or client certificate \
@@ -765,6 +1088,19 @@ module DescribeClientAuthenticationSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_client_authentication_settings_request ->
     ( describe_client_authentication_settings_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_client_authentication_settings_request ->
+    ( describe_client_authentication_settings_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -803,6 +1139,19 @@ module DescribeConditionalForwarders : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_conditional_forwarders_request ->
+    ( describe_conditional_forwarders_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Obtains information about the conditional forwarders for this account.\n\n\
@@ -824,6 +1173,18 @@ module DescribeDirectories : sig
     'http_type Smaws_Lib.Context.t ->
     describe_directories_request ->
     ( describe_directories_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_directories_request ->
+    ( describe_directories_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -867,6 +1228,18 @@ module DescribeDirectoryDataAccess : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_directory_data_access_request ->
+    ( describe_directory_data_access_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Obtains status of directory data access enablement through the Directory Service Data API for \
@@ -895,6 +1268,19 @@ module DescribeDomainControllers : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_domain_controllers_request ->
+    ( describe_domain_controllers_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Provides information about any domain controllers in your directory.\n"]
 
@@ -911,6 +1297,17 @@ module DescribeEventTopics : sig
     'http_type Smaws_Lib.Context.t ->
     describe_event_topics_request ->
     ( describe_event_topics_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_event_topics_request ->
+    ( describe_event_topics_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -948,6 +1345,19 @@ module DescribeHybridADUpdate : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_hybrid_ad_update_request ->
+    ( describe_hybrid_ad_update_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves information about update activities for a hybrid directory. This operation provides \
@@ -969,6 +1379,19 @@ module DescribeLDAPSSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_ldaps_settings_request ->
     ( describe_ldaps_settings_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_ldaps_settings_request ->
+    ( describe_ldaps_settings_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
@@ -1005,6 +1428,20 @@ module DescribeRegions : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_regions_request ->
+    ( describe_regions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the Regions that are configured for multi-Region replication.\n"]
@@ -1024,6 +1461,19 @@ module DescribeSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_settings_request ->
     ( describe_settings_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_settings_request ->
+    ( describe_settings_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
@@ -1058,6 +1508,19 @@ module DescribeSharedDirectories : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_shared_directories_request ->
+    ( describe_shared_directories_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the shared directories in your account. \n"]
 
@@ -1075,6 +1538,18 @@ module DescribeSnapshots : sig
     'http_type Smaws_Lib.Context.t ->
     describe_snapshots_request ->
     ( describe_snapshots_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_snapshots_request ->
+    ( describe_snapshots_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1115,6 +1590,19 @@ module DescribeTrusts : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_trusts_request ->
+    ( describe_trusts_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Obtains information about the trust relationships for this account.\n\n\
@@ -1145,6 +1633,19 @@ module DescribeUpdateDirectory : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_update_directory_request ->
+    ( describe_update_directory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc " Describes the updates of a directory for a particular update type. \n"]
 
@@ -1165,6 +1666,21 @@ module DisableCAEnrollmentPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     disable_ca_enrollment_policy_request ->
     ( disable_ca_enrollment_policy_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `DisableAlreadyInProgressException of disable_already_in_progress_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_ca_enrollment_policy_request ->
+    ( disable_ca_enrollment_policy_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -1208,6 +1724,19 @@ module DisableClientAuthentication : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_client_authentication_request ->
+    ( disable_client_authentication_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidClientAuthStatusException of invalid_client_auth_status_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Disables alternative client authentication methods for the specified directory. \n"]
 
@@ -1227,6 +1756,20 @@ module DisableDirectoryDataAccess : sig
     'http_type Smaws_Lib.Context.t ->
     disable_directory_data_access_request ->
     ( disable_directory_data_access_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryInDesiredStateException of directory_in_desired_state_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_directory_data_access_request ->
+    ( disable_directory_data_access_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -1268,6 +1811,20 @@ module DisableLDAPS : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_ldaps_request ->
+    ( disable_ldaps_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidLDAPSStatusException of invalid_ldaps_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deactivates LDAP secure calls for the specified directory.\n"]
 
@@ -1283,6 +1840,16 @@ module DisableRadius : sig
     'http_type Smaws_Lib.Context.t ->
     disable_radius_request ->
     ( disable_radius_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_radius_request ->
+    ( disable_radius_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1314,6 +1881,18 @@ module DisableSso : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_sso_request ->
+    ( disable_sso_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AuthenticationFailedException of authentication_failed_exception
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc "Disables single-sign on for a directory.\n"]
 
@@ -1335,6 +1914,22 @@ module EnableCAEnrollmentPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     enable_ca_enrollment_policy_request ->
     ( enable_ca_enrollment_policy_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EnableAlreadyInProgressException of enable_already_in_progress_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_ca_enrollment_policy_request ->
+    ( enable_ca_enrollment_policy_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -1382,6 +1977,20 @@ module EnableClientAuthentication : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_client_authentication_request ->
+    ( enable_client_authentication_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidClientAuthStatusException of invalid_client_auth_status_exception
+      | `NoAvailableCertificateException of no_available_certificate_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Enables alternative client authentication methods for the specified directory.\n"]
 
@@ -1401,6 +2010,20 @@ module EnableDirectoryDataAccess : sig
     'http_type Smaws_Lib.Context.t ->
     enable_directory_data_access_request ->
     ( enable_directory_data_access_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryInDesiredStateException of directory_in_desired_state_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_directory_data_access_request ->
+    ( enable_directory_data_access_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -1444,6 +2067,21 @@ module EnableLDAPS : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_ldaps_request ->
+    ( enable_ldaps_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidLDAPSStatusException of invalid_ldaps_status_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NoAvailableCertificateException of no_available_certificate_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Activates the switch for the specific directory to always use LDAP secure calls.\n"]
 
@@ -1461,6 +2099,18 @@ module EnableRadius : sig
     'http_type Smaws_Lib.Context.t ->
     enable_radius_request ->
     ( enable_radius_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityAlreadyExistsException of entity_already_exists_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_radius_request ->
+    ( enable_radius_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityAlreadyExistsException of entity_already_exists_exception
@@ -1494,6 +2144,18 @@ module EnableSso : sig
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_sso_request ->
+    ( enable_sso_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AuthenticationFailedException of authentication_failed_exception
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InsufficientPermissionsException of insufficient_permissions_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables single sign-on for a directory. Single sign-on allows users in your directory to access \
@@ -1512,6 +2174,16 @@ module GetDirectoryLimits : sig
     'http_type Smaws_Lib.Context.t ->
     get_directory_limits_request ->
     ( get_directory_limits_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_directory_limits_request ->
+    ( get_directory_limits_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1537,6 +2209,16 @@ module GetSnapshotLimits : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_snapshot_limits_request ->
+    ( get_snapshot_limits_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc "Obtains the manual snapshot limits for a directory.\n"]
 
@@ -1554,6 +2236,18 @@ module ListADAssessments : sig
     'http_type Smaws_Lib.Context.t ->
     list_ad_assessments_request ->
     ( list_ad_assessments_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ad_assessments_request ->
+    ( list_ad_assessments_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
@@ -1589,6 +2283,19 @@ module ListCertificates : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_certificates_request ->
+    ( list_certificates_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "For the specified directory, lists all the certificates registered for a secure LDAP or client \
@@ -1608,6 +2315,18 @@ module ListIpRoutes : sig
     'http_type Smaws_Lib.Context.t ->
     list_ip_routes_request ->
     ( list_ip_routes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ip_routes_request ->
+    ( list_ip_routes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1637,6 +2356,17 @@ module ListLogSubscriptions : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_log_subscriptions_request ->
+    ( list_log_subscriptions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the active log subscriptions for the Amazon Web Services account.\n"]
 
@@ -1653,6 +2383,17 @@ module ListSchemaExtensions : sig
     'http_type Smaws_Lib.Context.t ->
     list_schema_extensions_request ->
     ( list_schema_extensions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_schema_extensions_request ->
+    ( list_schema_extensions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1676,6 +2417,18 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1715,6 +2468,22 @@ module RegisterCertificate : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_certificate_request ->
+    ( register_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CertificateAlreadyExistsException of certificate_already_exists_exception
+      | `CertificateLimitExceededException of certificate_limit_exceeded_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidCertificateException of invalid_certificate_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Registers a certificate for a secure LDAP or client certificate authentication.\n"]
 
@@ -1731,6 +2500,17 @@ module RegisterEventTopic : sig
     'http_type Smaws_Lib.Context.t ->
     register_event_topic_request ->
     ( register_event_topic_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_event_topic_request ->
+    ( register_event_topic_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1766,6 +2546,18 @@ module RejectSharedDirectory : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reject_shared_directory_request ->
+    ( reject_shared_directory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryAlreadySharedException of directory_already_shared_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Rejects a directory sharing request that was sent from the directory owner account.\n"]
@@ -1784,6 +2576,18 @@ module RemoveIpRoutes : sig
     'http_type Smaws_Lib.Context.t ->
     remove_ip_routes_request ->
     ( remove_ip_routes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_ip_routes_request ->
+    ( remove_ip_routes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -1817,6 +2621,19 @@ module RemoveRegion : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_region_request ->
+    ( remove_region_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops all replication and removes the domain controllers from the specified Region. You cannot \
@@ -1835,6 +2652,17 @@ module RemoveTagsFromResource : sig
     'http_type Smaws_Lib.Context.t ->
     remove_tags_from_resource_request ->
     ( remove_tags_from_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_from_resource_request ->
+    ( remove_tags_from_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -1860,6 +2688,20 @@ module ResetUserPassword : sig
     'http_type Smaws_Lib.Context.t ->
     reset_user_password_request ->
     ( reset_user_password_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidPasswordException of invalid_password_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception
+      | `UserDoesNotExistException of user_does_not_exist_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reset_user_password_request ->
+    ( reset_user_password_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -1910,6 +2752,17 @@ module RestoreFromSnapshot : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_from_snapshot_request ->
+    ( restore_from_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
 end
 [@@ocaml.doc
   "Restores a directory using an existing directory snapshot.\n\n\
@@ -1941,6 +2794,23 @@ module ShareDirectory : sig
     'http_type Smaws_Lib.Context.t ->
     share_directory_request ->
     ( share_directory_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryAlreadySharedException of directory_already_shared_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidTargetException of invalid_target_exception
+      | `OrganizationsException of organizations_exception
+      | `ServiceException of service_exception
+      | `ShareLimitExceededException of share_limit_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    share_directory_request ->
+    ( share_directory_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ClientException of client_exception
@@ -1996,6 +2866,19 @@ module StartADAssessment : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_ad_assessment_request ->
+    ( start_ad_assessment_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ADAssessmentLimitExceededException of ad_assessment_limit_exceeded_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Initiates a directory assessment to validate your self-managed AD environment for hybrid domain \
@@ -2039,6 +2922,19 @@ module StartSchemaExtension : sig
       | `ServiceException of service_exception
       | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_schema_extension_request ->
+    ( start_schema_extension_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc "Applies a schema extension to a Microsoft AD directory.\n"]
 
@@ -2056,6 +2952,18 @@ module UnshareDirectory : sig
     'http_type Smaws_Lib.Context.t ->
     unshare_directory_request ->
     ( unshare_directory_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryNotSharedException of directory_not_shared_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidTargetException of invalid_target_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unshare_directory_request ->
+    ( unshare_directory_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryNotSharedException of directory_not_shared_exception
@@ -2081,6 +2989,19 @@ module UpdateConditionalForwarder : sig
     'http_type Smaws_Lib.Context.t ->
     update_conditional_forwarder_request ->
     ( update_conditional_forwarder_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_conditional_forwarder_request ->
+    ( update_conditional_forwarder_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -2122,6 +3043,22 @@ module UpdateDirectorySetup : sig
       | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_directory_setup_request ->
+    ( update_directory_setup_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryInDesiredStateException of directory_in_desired_state_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates directory configuration for the specified update type.\n"]
 
@@ -2140,6 +3077,19 @@ module UpdateHybridAD : sig
     'http_type Smaws_Lib.Context.t ->
     update_hybrid_ad_request ->
     ( update_hybrid_ad_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ADAssessmentLimitExceededException of ad_assessment_limit_exceeded_exception
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_hybrid_ad_request ->
+    ( update_hybrid_ad_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ADAssessmentLimitExceededException of ad_assessment_limit_exceeded_exception
       | `ClientException of client_exception
@@ -2192,6 +3142,20 @@ module UpdateNumberOfDomainControllers : sig
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_number_of_domain_controllers_request ->
+    ( update_number_of_domain_controllers_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `DomainControllerLimitExceededException of domain_controller_limit_exceeded_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or removes domain controllers to or from the directory. Based on the difference between \
@@ -2213,6 +3177,17 @@ module UpdateRadius : sig
     'http_type Smaws_Lib.Context.t ->
     update_radius_request ->
     ( update_radius_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_radius_request ->
+    ( update_radius_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -2251,6 +3226,21 @@ module UpdateSettings : sig
       | `UnsupportedOperationException of unsupported_operation_exception
       | `UnsupportedSettingsException of unsupported_settings_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_settings_request ->
+    ( update_settings_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `DirectoryDoesNotExistException of directory_does_not_exist_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `IncompatibleSettingsException of incompatible_settings_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception
+      | `UnsupportedSettingsException of unsupported_settings_exception ] )
+    result
 end
 [@@ocaml.doc "Updates the configurable settings for the specified directory.\n"]
 
@@ -2267,6 +3257,17 @@ module UpdateTrust : sig
     'http_type Smaws_Lib.Context.t ->
     update_trust_request ->
     ( update_trust_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_trust_request ->
+    ( update_trust_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
@@ -2292,6 +3293,18 @@ module VerifyTrust : sig
     'http_type Smaws_Lib.Context.t ->
     verify_trust_request ->
     ( verify_trust_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClientException of client_exception
+      | `EntityDoesNotExistException of entity_does_not_exist_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ServiceException of service_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    verify_trust_request ->
+    ( verify_trust_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception

--- a/sdks/directory-service/operations.mli
+++ b/sdks/directory-service/operations.mli
@@ -31,7 +31,8 @@ module AcceptSharedDirectory : sig
       | `DirectoryAlreadySharedException of directory_already_shared_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -74,7 +75,8 @@ module AddIpRoutes : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `IpRouteLimitExceededException of ip_route_limit_exceeded_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -136,7 +138,8 @@ module AddRegion : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `RegionLimitExceededException of region_limit_exceeded_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds two domain controllers in the specified Region for the specified directory.\n"]
@@ -172,7 +175,8 @@ module AddTagsToResource : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `TagLimitExceededException of tag_limit_exceeded_exception ] )
+      | `TagLimitExceededException of tag_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -205,7 +209,8 @@ module CancelSchemaExtension : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -242,7 +247,8 @@ module ConnectDirectory : sig
       | `ClientException of client_exception
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -285,7 +291,8 @@ module CreateAlias : sig
       | `EntityAlreadyExistsException of entity_already_exists_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -340,7 +347,8 @@ module CreateComputer : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates an Active Directory computer object in the specified directory.\n"]
@@ -382,7 +390,8 @@ module CreateConditionalForwarder : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -418,7 +427,8 @@ module CreateDirectory : sig
       | `ClientException of client_exception
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -469,7 +479,8 @@ module CreateHybridAD : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -516,7 +527,8 @@ module CreateLogSubscription : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -554,7 +566,8 @@ module CreateMicrosoftAD : sig
       | `DirectoryLimitExceededException of directory_limit_exceeded_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -599,7 +612,8 @@ module CreateSnapshot : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -642,7 +656,8 @@ module CreateTrust : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -686,7 +701,8 @@ module DeleteADAssessment : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -730,7 +746,8 @@ module DeleteConditionalForwarder : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -761,7 +778,8 @@ module DeleteDirectory : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -801,7 +819,8 @@ module DeleteLogSubscription : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified log subscription.\n"]
@@ -834,7 +853,8 @@ module DeleteSnapshot : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a directory snapshot.\n"]
@@ -870,7 +890,8 @@ module DeleteTrust : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -917,7 +938,8 @@ module DeregisterCertificate : sig
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -952,7 +974,8 @@ module DeregisterEventTopic : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the specified directory as a publisher to the specified Amazon SNS topic.\n"]
@@ -988,7 +1011,8 @@ module DescribeADAssessment : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1024,7 +1048,8 @@ module DescribeCAEnrollmentPolicy : sig
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1066,7 +1091,8 @@ module DescribeCertificate : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1107,7 +1133,8 @@ module DescribeClientAuthenticationSettings : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1150,7 +1177,8 @@ module DescribeConditionalForwarders : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1190,7 +1218,8 @@ module DescribeDirectories : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1238,7 +1267,8 @@ module DescribeDirectoryDataAccess : sig
       | `ClientException of client_exception
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1279,7 +1309,8 @@ module DescribeDomainControllers : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides information about any domain controllers in your directory.\n"]
@@ -1312,7 +1343,8 @@ module DescribeEventTopics : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1356,7 +1388,8 @@ module DescribeHybridADUpdate : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1398,7 +1431,8 @@ module DescribeLDAPSSettings : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes the status of LDAP security for the specified directory.\n"]
@@ -1440,7 +1474,8 @@ module DescribeRegions : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1480,7 +1515,8 @@ module DescribeSettings : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves information about the configurable settings for the specified directory.\n"]
@@ -1519,7 +1555,8 @@ module DescribeSharedDirectories : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the shared directories in your account. \n"]
@@ -1555,7 +1592,8 @@ module DescribeSnapshots : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1601,7 +1639,8 @@ module DescribeTrusts : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1644,7 +1683,8 @@ module DescribeUpdateDirectory : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Describes the updates of a directory for a particular update type. \n"]
@@ -1689,7 +1729,8 @@ module DisableCAEnrollmentPolicy : sig
       | `DisableAlreadyInProgressException of disable_already_in_progress_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1735,7 +1776,8 @@ module DisableClientAuthentication : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidClientAuthStatusException of invalid_client_auth_status_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Disables alternative client authentication methods for the specified directory. \n"]
@@ -1777,7 +1819,8 @@ module DisableDirectoryDataAccess : sig
       | `DirectoryInDesiredStateException of directory_in_desired_state_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1823,7 +1866,8 @@ module DisableLDAPS : sig
       | `InvalidLDAPSStatusException of invalid_ldaps_status_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deactivates LDAP secure calls for the specified directory.\n"]
@@ -1853,7 +1897,8 @@ module DisableRadius : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1891,7 +1936,8 @@ module DisableSso : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Disables single-sign on for a directory.\n"]
@@ -1939,7 +1985,8 @@ module EnableCAEnrollmentPolicy : sig
       | `EntityAlreadyExistsException of entity_already_exists_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1989,7 +2036,8 @@ module EnableClientAuthentication : sig
       | `InvalidClientAuthStatusException of invalid_client_auth_status_exception
       | `NoAvailableCertificateException of no_available_certificate_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Enables alternative client authentication methods for the specified directory.\n"]
@@ -2031,7 +2079,8 @@ module EnableDirectoryDataAccess : sig
       | `DirectoryInDesiredStateException of directory_in_desired_state_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2080,7 +2129,8 @@ module EnableLDAPS : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `NoAvailableCertificateException of no_available_certificate_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Activates the switch for the specific directory to always use LDAP secure calls.\n"]
@@ -2116,7 +2166,8 @@ module EnableRadius : sig
       | `EntityAlreadyExistsException of entity_already_exists_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2154,7 +2205,8 @@ module EnableSso : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InsufficientPermissionsException of insufficient_permissions_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2187,7 +2239,8 @@ module GetDirectoryLimits : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Obtains directory limit information for the current Region.\n"]
@@ -2217,7 +2270,8 @@ module GetSnapshotLimits : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Obtains the manual snapshot limits for a directory.\n"]
@@ -2253,7 +2307,8 @@ module ListADAssessments : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2294,7 +2349,8 @@ module ListCertificates : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2332,7 +2388,8 @@ module ListIpRoutes : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the address blocks that you have added to a directory.\n"]
@@ -2365,7 +2422,8 @@ module ListLogSubscriptions : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the active log subscriptions for the Amazon Web Services account.\n"]
@@ -2398,7 +2456,8 @@ module ListSchemaExtensions : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all schema extensions applied to a Microsoft AD Directory.\n"]
@@ -2434,7 +2493,8 @@ module ListTagsForResource : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all tags on a directory.\n"]
@@ -2482,7 +2542,8 @@ module RegisterCertificate : sig
       | `InvalidCertificateException of invalid_certificate_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Registers a certificate for a secure LDAP or client certificate authentication.\n"]
@@ -2515,7 +2576,8 @@ module RegisterEventTopic : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2556,7 +2618,8 @@ module RejectSharedDirectory : sig
       | `DirectoryAlreadySharedException of directory_already_shared_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2593,7 +2656,8 @@ module RemoveIpRoutes : sig
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes IP address blocks from a directory.\n"]
@@ -2632,7 +2696,8 @@ module RemoveRegion : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2667,7 +2732,8 @@ module RemoveTagsFromResource : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tags from a directory.\n"]
@@ -2709,7 +2775,8 @@ module ResetUserPassword : sig
       | `InvalidPasswordException of invalid_password_exception
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception
-      | `UserDoesNotExistException of user_does_not_exist_exception ] )
+      | `UserDoesNotExistException of user_does_not_exist_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2761,7 +2828,8 @@ module RestoreFromSnapshot : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2821,7 +2889,8 @@ module ShareDirectory : sig
       | `OrganizationsException of organizations_exception
       | `ServiceException of service_exception
       | `ShareLimitExceededException of share_limit_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2877,7 +2946,8 @@ module StartADAssessment : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2933,7 +3003,8 @@ module StartSchemaExtension : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ] )
+      | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Applies a schema extension to a Microsoft AD directory.\n"]
@@ -2969,7 +3040,8 @@ module UnshareDirectory : sig
       | `DirectoryNotSharedException of directory_not_shared_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidTargetException of invalid_target_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Stops the directory sharing between the directory owner and consumer accounts. \n"]
@@ -3008,7 +3080,8 @@ module UpdateConditionalForwarder : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3057,7 +3130,8 @@ module UpdateDirectorySetup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
       | `SnapshotLimitExceededException of snapshot_limit_exceeded_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates directory configuration for the specified update type.\n"]
@@ -3096,7 +3170,8 @@ module UpdateHybridAD : sig
       | `DirectoryDoesNotExistException of directory_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3154,7 +3229,8 @@ module UpdateNumberOfDomainControllers : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3192,7 +3268,8 @@ module UpdateRadius : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3239,7 +3316,8 @@ module UpdateSettings : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
       | `UnsupportedOperationException of unsupported_operation_exception
-      | `UnsupportedSettingsException of unsupported_settings_exception ] )
+      | `UnsupportedSettingsException of unsupported_settings_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the configurable settings for the specified directory.\n"]
@@ -3272,7 +3350,8 @@ module UpdateTrust : sig
       | `ClientException of client_exception
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ServiceException of service_exception ] )
+      | `ServiceException of service_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3310,7 +3389,8 @@ module VerifyTrust : sig
       | `EntityDoesNotExistException of entity_does_not_exist_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `ServiceException of service_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/dynamodb-streams/Smaws_Client_DynamoDBStreams.mli
+++ b/sdks/dynamodb-streams/Smaws_Client_DynamoDBStreams.mli
@@ -119,6 +119,15 @@ module DescribeStream : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_stream_input ->
+    ( describe_stream_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a stream, including the current status of the stream, its Amazon \
@@ -146,6 +155,18 @@ module GetRecords : sig
     'http_type Smaws_Lib.Context.t ->
     get_records_input ->
     ( get_records_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExpiredIteratorException of expired_iterator_exception
+      | `InternalServerError of internal_server_error
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TrimmedDataAccessException of trimmed_data_access_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_records_input ->
+    ( get_records_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExpiredIteratorException of expired_iterator_exception
       | `InternalServerError of internal_server_error
@@ -184,6 +205,16 @@ module GetShardIterator : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TrimmedDataAccessException of trimmed_data_access_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_shard_iterator_input ->
+    ( get_shard_iterator_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TrimmedDataAccessException of trimmed_data_access_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a shard iterator. A shard iterator provides information about how to retrieve the \
@@ -205,6 +236,15 @@ module ListStreams : sig
     'http_type Smaws_Lib.Context.t ->
     list_streams_input ->
     ( list_streams_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_streams_input ->
+    ( list_streams_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )

--- a/sdks/dynamodb-streams/Smaws_Client_DynamoDBStreams.mli
+++ b/sdks/dynamodb-streams/Smaws_Client_DynamoDBStreams.mli
@@ -126,7 +126,8 @@ module DescribeStream : sig
     ( describe_stream_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -172,7 +173,8 @@ module GetRecords : sig
       | `InternalServerError of internal_server_error
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TrimmedDataAccessException of trimmed_data_access_exception ] )
+      | `TrimmedDataAccessException of trimmed_data_access_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -213,7 +215,8 @@ module GetShardIterator : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TrimmedDataAccessException of trimmed_data_access_exception ] )
+      | `TrimmedDataAccessException of trimmed_data_access_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -247,7 +250,8 @@ module ListStreams : sig
     ( list_streams_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/dynamodb-streams/operations.ml
+++ b/sdks/dynamodb-streams/operations.ml
@@ -24,6 +24,12 @@ module DescribeStream = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDBStreams_20120810.DescribeStream"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_stream_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_stream_input) =
+    let input = Json_serializers.describe_stream_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDBStreams_20120810.DescribeStream" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_stream_output_of_yojson ~error_deserializer
 end
 
 module GetRecords = struct
@@ -60,6 +66,12 @@ module GetRecords = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDBStreams_20120810.GetRecords" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_records_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_records_input) =
+    let input = Json_serializers.get_records_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDBStreams_20120810.GetRecords" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_records_output_of_yojson ~error_deserializer
 end
 
 module GetShardIterator = struct
@@ -90,6 +102,13 @@ module GetShardIterator = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_shard_iterator_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_shard_iterator_input) =
+    let input = Json_serializers.get_shard_iterator_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDBStreams_20120810.GetShardIterator" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_shard_iterator_output_of_yojson
+      ~error_deserializer
 end
 
 module ListStreams = struct
@@ -115,4 +134,10 @@ module ListStreams = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDBStreams_20120810.ListStreams" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_streams_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_streams_input) =
+    let input = Json_serializers.list_streams_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDBStreams_20120810.ListStreams" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_streams_output_of_yojson ~error_deserializer
 end

--- a/sdks/dynamodb-streams/operations.mli
+++ b/sdks/dynamodb-streams/operations.mli
@@ -22,7 +22,8 @@ module DescribeStream : sig
     ( describe_stream_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -68,7 +69,8 @@ module GetRecords : sig
       | `InternalServerError of internal_server_error
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TrimmedDataAccessException of trimmed_data_access_exception ] )
+      | `TrimmedDataAccessException of trimmed_data_access_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -109,7 +111,8 @@ module GetShardIterator : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TrimmedDataAccessException of trimmed_data_access_exception ] )
+      | `TrimmedDataAccessException of trimmed_data_access_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -142,7 +145,8 @@ module ListStreams : sig
     ( list_streams_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/dynamodb-streams/operations.mli
+++ b/sdks/dynamodb-streams/operations.mli
@@ -15,6 +15,15 @@ module DescribeStream : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_stream_input ->
+    ( describe_stream_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a stream, including the current status of the stream, its Amazon \
@@ -42,6 +51,18 @@ module GetRecords : sig
     'http_type Smaws_Lib.Context.t ->
     get_records_input ->
     ( get_records_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExpiredIteratorException of expired_iterator_exception
+      | `InternalServerError of internal_server_error
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TrimmedDataAccessException of trimmed_data_access_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_records_input ->
+    ( get_records_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExpiredIteratorException of expired_iterator_exception
       | `InternalServerError of internal_server_error
@@ -80,6 +101,16 @@ module GetShardIterator : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TrimmedDataAccessException of trimmed_data_access_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_shard_iterator_input ->
+    ( get_shard_iterator_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TrimmedDataAccessException of trimmed_data_access_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a shard iterator. A shard iterator provides information about how to retrieve the \
@@ -100,6 +131,15 @@ module ListStreams : sig
     'http_type Smaws_Lib.Context.t ->
     list_streams_input ->
     ( list_streams_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_streams_input ->
+    ( list_streams_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )

--- a/sdks/dynamodb/Smaws_Client_DynamoDB.mli
+++ b/sdks/dynamodb/Smaws_Client_DynamoDB.mli
@@ -1547,7 +1547,8 @@ module BatchExecuteStatement : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `RequestLimitExceeded of request_limit_exceeded
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1601,7 +1602,8 @@ module BatchGetItem : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1699,7 +1701,8 @@ module BatchWriteItem : sig
       | `ReplicatedWriteConflictException of replicated_write_conflict_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1830,7 +1833,8 @@ module CreateBackup : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `TableInUseException of table_in_use_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1901,7 +1905,8 @@ module CreateGlobalTable : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1999,7 +2004,8 @@ module CreateTable : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2050,7 +2056,8 @@ module DeleteBackup : sig
       | `BackupNotFoundException of backup_not_found_exception
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2104,7 +2111,8 @@ module DeleteItem : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionConflictException of transaction_conflict_exception ] )
+      | `TransactionConflictException of transaction_conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2154,7 +2162,8 @@ module DeleteResourcePolicy : sig
       | `LimitExceededException of limit_exceeded_exception
       | `PolicyNotFoundException of policy_not_found_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2205,7 +2214,8 @@ module DeleteTable : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2253,7 +2263,8 @@ module DescribeBackup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BackupNotFoundException of backup_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2286,7 +2297,8 @@ module DescribeContinuousBackups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2325,7 +2337,8 @@ module DescribeContributorInsights : sig
     ( describe_contributor_insights_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2343,7 +2356,7 @@ module DescribeEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     describe_endpoints_request ->
     ( describe_endpoints_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2377,7 +2390,8 @@ module DescribeExport : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExportNotFoundException of export_not_found_exception
       | `InternalServerError of internal_server_error
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes an existing table export.\n"]
@@ -2407,7 +2421,8 @@ module DescribeGlobalTable : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableNotFoundException of global_table_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2452,7 +2467,8 @@ module DescribeGlobalTableSettings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableNotFoundException of global_table_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2490,7 +2506,7 @@ module DescribeImport : sig
     describe_import_input ->
     ( describe_import_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `ImportNotFoundException of import_not_found_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Represents the properties of the import. \n"]
@@ -2520,7 +2536,8 @@ module DescribeKinesisStreamingDestination : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the status of Kinesis streaming.\n"]
@@ -2547,7 +2564,8 @@ module DescribeLimits : sig
     ( describe_limits_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2642,7 +2660,8 @@ module DescribeTable : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2677,7 +2696,8 @@ module DescribeTableReplicaAutoScaling : sig
     ( describe_table_replica_auto_scaling_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes auto scaling settings across replicas of the global table at once.\n"]
@@ -2707,7 +2727,8 @@ module DescribeTimeToLive : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gives a description of the Time to Live (TTL) status on the specified table. \n"]
@@ -2743,7 +2764,8 @@ module DisableKinesisStreamingDestination : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2781,7 +2803,8 @@ module EnableKinesisStreamingDestination : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2832,7 +2855,8 @@ module ExecuteStatement : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionConflictException of transaction_conflict_exception ] )
+      | `TransactionConflictException of transaction_conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2890,7 +2914,8 @@ module ExecuteTransaction : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
       | `TransactionCanceledException of transaction_canceled_exception
-      | `TransactionInProgressException of transaction_in_progress_exception ] )
+      | `TransactionInProgressException of transaction_in_progress_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2938,7 +2963,8 @@ module ExportTableToPointInTime : sig
       | `InvalidExportTimeException of invalid_export_time_exception
       | `LimitExceededException of limit_exceeded_exception
       | `PointInTimeRecoveryUnavailableException of point_in_time_recovery_unavailable_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2979,7 +3005,8 @@ module GetItem : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3020,7 +3047,8 @@ module GetResourcePolicy : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
       | `PolicyNotFoundException of policy_not_found_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3083,7 +3111,8 @@ module ImportTable : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ImportConflictException of import_conflict_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Imports table data from an S3 bucket. \n"]
@@ -3110,7 +3139,8 @@ module ListBackups : sig
     ( list_backups_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3151,7 +3181,8 @@ module ListContributorInsights : sig
     ( list_contributor_insights_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3179,7 +3210,8 @@ module ListExports : sig
     ( list_exports_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3207,7 +3239,8 @@ module ListGlobalTables : sig
     ( list_global_tables_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3245,7 +3278,7 @@ module ListImports : sig
     list_imports_input ->
     ( list_imports_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Lists completed imports within the past 90 days. \n"]
@@ -3272,7 +3305,8 @@ module ListTables : sig
     ( list_tables_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3304,7 +3338,8 @@ module ListTagsOfResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3361,7 +3396,8 @@ module PutItem : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionConflictException of transaction_conflict_exception ] )
+      | `TransactionConflictException of transaction_conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3426,7 +3462,8 @@ module PutResourcePolicy : sig
       | `LimitExceededException of limit_exceeded_exception
       | `PolicyNotFoundException of policy_not_found_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3482,7 +3519,8 @@ module Query : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3569,7 +3607,8 @@ module RestoreTableFromBackup : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `TableAlreadyExistsException of table_already_exists_exception
-      | `TableInUseException of table_in_use_exception ] )
+      | `TableInUseException of table_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3641,7 +3680,8 @@ module RestoreTableToPointInTime : sig
       | `PointInTimeRecoveryUnavailableException of point_in_time_recovery_unavailable_exception
       | `TableAlreadyExistsException of table_already_exists_exception
       | `TableInUseException of table_in_use_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3733,7 +3773,8 @@ module Scan : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3810,7 +3851,8 @@ module TagResource : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3873,7 +3915,8 @@ module TransactGetItems : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionCanceledException of transaction_canceled_exception ] )
+      | `TransactionCanceledException of transaction_canceled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3944,7 +3987,8 @@ module TransactWriteItems : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
       | `TransactionCanceledException of transaction_canceled_exception
-      | `TransactionInProgressException of transaction_in_progress_exception ] )
+      | `TransactionInProgressException of transaction_in_progress_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4043,7 +4087,8 @@ module UntagResource : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4096,7 +4141,8 @@ module UpdateContinuousBackups : sig
       | `ContinuousBackupsUnavailableException of continuous_backups_unavailable_exception
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4134,7 +4180,8 @@ module UpdateContributorInsights : sig
     ( update_contributor_insights_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4179,7 +4226,8 @@ module UpdateGlobalTable : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `ReplicaAlreadyExistsException of replica_already_exists_exception
       | `ReplicaNotFoundException of replica_not_found_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4265,7 +4313,8 @@ module UpdateGlobalTableSettings : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ReplicaNotFoundException of replica_not_found_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4331,7 +4380,8 @@ module UpdateItem : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionConflictException of transaction_conflict_exception ] )
+      | `TransactionConflictException of transaction_conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4374,7 +4424,8 @@ module UpdateKinesisStreamingDestination : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The command to update the Kinesis stream destination.\n"]
@@ -4410,7 +4461,8 @@ module UpdateTable : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4463,7 +4515,8 @@ module UpdateTableReplicaAutoScaling : sig
       | `InternalServerError of internal_server_error
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates auto scaling settings on your global tables at once.\n"]
@@ -4500,7 +4553,8 @@ module UpdateTimeToLive : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/dynamodb/Smaws_Client_DynamoDB.mli
+++ b/sdks/dynamodb/Smaws_Client_DynamoDB.mli
@@ -1539,6 +1539,16 @@ module BatchExecuteStatement : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_execute_statement_input ->
+    ( batch_execute_statement_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "This operation allows you to perform batch reads or writes on data stored in DynamoDB, using \
@@ -1572,6 +1582,19 @@ module BatchGetItem : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_item_input ->
     ( batch_get_item_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_item_input ->
+    ( batch_get_item_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -1653,6 +1676,21 @@ module BatchWriteItem : sig
     'http_type Smaws_Lib.Context.t ->
     batch_write_item_input ->
     ( batch_write_item_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ReplicatedWriteConflictException of replicated_write_conflict_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_write_item_input ->
+    ( batch_write_item_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -1780,6 +1818,20 @@ module CreateBackup : sig
       | `TableInUseException of table_in_use_exception
       | `TableNotFoundException of table_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_backup_input ->
+    ( create_backup_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BackupInUseException of backup_in_use_exception
+      | `ContinuousBackupsUnavailableException of continuous_backups_unavailable_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `TableInUseException of table_in_use_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a backup for an existing table.\n\n\
@@ -1832,6 +1884,18 @@ module CreateGlobalTable : sig
     'http_type Smaws_Lib.Context.t ->
     create_global_table_input ->
     ( create_global_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableAlreadyExistsException of global_table_already_exists_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_global_table_input ->
+    ( create_global_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableAlreadyExistsException of global_table_already_exists_exception
       | `InternalServerError of internal_server_error
@@ -1926,6 +1990,17 @@ module CreateTable : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_table_input ->
+    ( create_table_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "The [CreateTable] operation adds a new table to your account. In an Amazon Web Services \
@@ -1965,6 +2040,18 @@ module DeleteBackup : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_backup_input ->
+    ( delete_backup_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BackupInUseException of backup_in_use_exception
+      | `BackupNotFoundException of backup_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an existing backup of a table.\n\n\
@@ -1990,6 +2077,23 @@ module DeleteItem : sig
     'http_type Smaws_Lib.Context.t ->
     delete_item_input ->
     ( delete_item_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ReplicatedWriteConflictException of replicated_write_conflict_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionConflictException of transaction_conflict_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_item_input ->
+    ( delete_item_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConditionalCheckFailedException of conditional_check_failed_exception
       | `InternalServerError of internal_server_error
@@ -2039,6 +2143,19 @@ module DeleteResourcePolicy : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_policy_input ->
+    ( delete_resource_policy_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `PolicyNotFoundException of policy_not_found_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the resource-based policy attached to the resource, which can be a table or stream.\n\n\
@@ -2071,6 +2188,18 @@ module DeleteTable : sig
     'http_type Smaws_Lib.Context.t ->
     delete_table_input ->
     ( delete_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_table_input ->
+    ( delete_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -2116,6 +2245,16 @@ module DescribeBackup : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_backup_input ->
+    ( describe_backup_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BackupNotFoundException of backup_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
 end
 [@@ocaml.doc
   "Describes an existing backup of a table.\n\n\
@@ -2134,6 +2273,16 @@ module DescribeContinuousBackups : sig
     'http_type Smaws_Lib.Context.t ->
     describe_continuous_backups_input ->
     ( describe_continuous_backups_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_continuous_backups_input ->
+    ( describe_continuous_backups_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -2169,6 +2318,15 @@ module DescribeContributorInsights : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_contributor_insights_input ->
+    ( describe_contributor_insights_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about contributor insights for a given table or global secondary index.\n"]
@@ -2180,6 +2338,13 @@ module DescribeEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     describe_endpoints_request ->
     (describe_endpoints_response, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_endpoints_request ->
+    ( describe_endpoints_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc
   "Returns the regional endpoint information. For more information on policy permissions, please \
@@ -2204,6 +2369,16 @@ module DescribeExport : sig
       | `InternalServerError of internal_server_error
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_export_input ->
+    ( describe_export_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExportNotFoundException of export_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc "Describes an existing table export.\n"]
 
@@ -2219,6 +2394,16 @@ module DescribeGlobalTable : sig
     'http_type Smaws_Lib.Context.t ->
     describe_global_table_input ->
     ( describe_global_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableNotFoundException of global_table_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_global_table_input ->
+    ( describe_global_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableNotFoundException of global_table_not_found_exception
       | `InternalServerError of internal_server_error
@@ -2259,6 +2444,16 @@ module DescribeGlobalTableSettings : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_global_table_settings_input ->
+    ( describe_global_table_settings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableNotFoundException of global_table_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
 end
 [@@ocaml.doc
   "Describes Region-specific settings for a global table.\n\n\
@@ -2289,6 +2484,14 @@ module DescribeImport : sig
       [> Smaws_Lib.Protocols.AwsJson.error | `ImportNotFoundException of import_not_found_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_import_input ->
+    ( describe_import_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `ImportNotFoundException of import_not_found_exception ]
+    )
+    result
 end
 [@@ocaml.doc " Represents the properties of the import. \n"]
 
@@ -2309,6 +2512,16 @@ module DescribeKinesisStreamingDestination : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_kinesis_streaming_destination_input ->
+    ( describe_kinesis_streaming_destination_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the status of Kinesis streaming.\n"]
 
@@ -2323,6 +2536,15 @@ module DescribeLimits : sig
     'http_type Smaws_Lib.Context.t ->
     describe_limits_input ->
     ( describe_limits_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_limits_input ->
+    ( describe_limits_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
@@ -2412,6 +2634,16 @@ module DescribeTable : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_table_input ->
+    ( describe_table_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the table, including the current status of the table, when it was \
@@ -2438,6 +2670,15 @@ module DescribeTableReplicaAutoScaling : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_table_replica_auto_scaling_input ->
+    ( describe_table_replica_auto_scaling_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Describes auto scaling settings across replicas of the global table at once.\n"]
 
@@ -2453,6 +2694,16 @@ module DescribeTimeToLive : sig
     'http_type Smaws_Lib.Context.t ->
     describe_time_to_live_input ->
     ( describe_time_to_live_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_time_to_live_input ->
+    ( describe_time_to_live_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -2475,6 +2726,18 @@ module DisableKinesisStreamingDestination : sig
     'http_type Smaws_Lib.Context.t ->
     kinesis_streaming_destination_input ->
     ( kinesis_streaming_destination_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    kinesis_streaming_destination_input ->
+    ( kinesis_streaming_destination_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -2508,6 +2771,18 @@ module EnableKinesisStreamingDestination : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    kinesis_streaming_destination_input ->
+    ( kinesis_streaming_destination_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts table data replication to the specified Kinesis data stream at a timestamp chosen during \
@@ -2532,6 +2807,22 @@ module ExecuteStatement : sig
     'http_type Smaws_Lib.Context.t ->
     execute_statement_input ->
     ( execute_statement_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `DuplicateItemException of duplicate_item_exception
+      | `InternalServerError of internal_server_error
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionConflictException of transaction_conflict_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    execute_statement_input ->
+    ( execute_statement_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConditionalCheckFailedException of conditional_check_failed_exception
       | `DuplicateItemException of duplicate_item_exception
@@ -2586,6 +2877,21 @@ module ExecuteTransaction : sig
       | `TransactionCanceledException of transaction_canceled_exception
       | `TransactionInProgressException of transaction_in_progress_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    execute_transaction_input ->
+    ( execute_transaction_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatchException of idempotent_parameter_mismatch_exception
+      | `InternalServerError of internal_server_error
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionCanceledException of transaction_canceled_exception
+      | `TransactionInProgressException of transaction_in_progress_exception ] )
+    result
 end
 [@@ocaml.doc
   "This operation allows you to perform transactional reads or writes on data stored in DynamoDB, \
@@ -2613,6 +2919,19 @@ module ExportTableToPointInTime : sig
     'http_type Smaws_Lib.Context.t ->
     export_table_to_point_in_time_input ->
     ( export_table_to_point_in_time_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExportConflictException of export_conflict_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidExportTimeException of invalid_export_time_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `PointInTimeRecoveryUnavailableException of point_in_time_recovery_unavailable_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    export_table_to_point_in_time_input ->
+    ( export_table_to_point_in_time_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExportConflictException of export_conflict_exception
       | `InternalServerError of internal_server_error
@@ -2649,6 +2968,19 @@ module GetItem : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_item_input ->
+    ( get_item_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "The [GetItem] operation returns a set of attributes for the item with the given primary key. If \
@@ -2673,6 +3005,17 @@ module GetResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_policy_input ->
     ( get_resource_policy_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `PolicyNotFoundException of policy_not_found_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_policy_input ->
+    ( get_resource_policy_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -2732,6 +3075,16 @@ module ImportTable : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_table_input ->
+    ( import_table_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ImportConflictException of import_conflict_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc " Imports table data from an S3 bucket. \n"]
 
@@ -2746,6 +3099,15 @@ module ListBackups : sig
     'http_type Smaws_Lib.Context.t ->
     list_backups_input ->
     ( list_backups_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_backups_input ->
+    ( list_backups_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
@@ -2782,6 +3144,15 @@ module ListContributorInsights : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_contributor_insights_input ->
+    ( list_contributor_insights_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of ContributorInsightsSummary for a table and all its global secondary indexes.\n"]
@@ -2801,6 +3172,15 @@ module ListExports : sig
       | `InternalServerError of internal_server_error
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_exports_input ->
+    ( list_exports_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists completed exports within the past 90 days, in reverse alphanumeric order of [ExportArn].\n"]
@@ -2816,6 +3196,15 @@ module ListGlobalTables : sig
     'http_type Smaws_Lib.Context.t ->
     list_global_tables_input ->
     ( list_global_tables_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_global_tables_input ->
+    ( list_global_tables_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
@@ -2850,6 +3239,14 @@ module ListImports : sig
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_imports_input ->
+    ( list_imports_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
+    )
+    result
 end
 [@@ocaml.doc " Lists completed imports within the past 90 days. \n"]
 
@@ -2864,6 +3261,15 @@ module ListTables : sig
     'http_type Smaws_Lib.Context.t ->
     list_tables_input ->
     ( list_tables_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tables_input ->
+    ( list_tables_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
@@ -2885,6 +3291,16 @@ module ListTagsOfResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_of_resource_input ->
     ( list_tags_of_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_of_resource_input ->
+    ( list_tags_of_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -2918,6 +3334,23 @@ module PutItem : sig
     'http_type Smaws_Lib.Context.t ->
     put_item_input ->
     ( put_item_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ReplicatedWriteConflictException of replicated_write_conflict_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionConflictException of transaction_conflict_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_item_input ->
+    ( put_item_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConditionalCheckFailedException of conditional_check_failed_exception
       | `InternalServerError of internal_server_error
@@ -2982,6 +3415,19 @@ module PutResourcePolicy : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_policy_input ->
+    ( put_resource_policy_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `PolicyNotFoundException of policy_not_found_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attaches a resource-based policy document to the resource, which can be a table or stream. When \
@@ -3017,6 +3463,19 @@ module Query : sig
     'http_type Smaws_Lib.Context.t ->
     query_input ->
     ( query_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_input ->
+    ( query_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -3098,6 +3557,20 @@ module RestoreTableFromBackup : sig
       | `TableAlreadyExistsException of table_already_exists_exception
       | `TableInUseException of table_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_table_from_backup_input ->
+    ( restore_table_from_backup_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BackupInUseException of backup_in_use_exception
+      | `BackupNotFoundException of backup_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `TableAlreadyExistsException of table_already_exists_exception
+      | `TableInUseException of table_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new table from an existing backup. Any number of users can execute up to 50 \
@@ -3145,6 +3618,21 @@ module RestoreTableToPointInTime : sig
     'http_type Smaws_Lib.Context.t ->
     restore_table_to_point_in_time_input ->
     ( restore_table_to_point_in_time_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `InvalidRestoreTimeException of invalid_restore_time_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `PointInTimeRecoveryUnavailableException of point_in_time_recovery_unavailable_exception
+      | `TableAlreadyExistsException of table_already_exists_exception
+      | `TableInUseException of table_in_use_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_table_to_point_in_time_input ->
+    ( restore_table_to_point_in_time_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -3234,6 +3722,19 @@ module Scan : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    scan_input ->
+    ( scan_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "The [Scan] operation returns one or more items and item attributes by accessing every item in a \
@@ -3299,6 +3800,18 @@ module TagResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associate a set of tags with an Amazon DynamoDB resource. You can then activate these \
@@ -3339,6 +3852,20 @@ module TransactGetItems : sig
     'http_type Smaws_Lib.Context.t ->
     transact_get_items_input ->
     ( transact_get_items_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionCanceledException of transaction_canceled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    transact_get_items_input ->
+    ( transact_get_items_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -3392,6 +3919,22 @@ module TransactWriteItems : sig
     'http_type Smaws_Lib.Context.t ->
     transact_write_items_input ->
     ( transact_write_items_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatchException of idempotent_parameter_mismatch_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionCanceledException of transaction_canceled_exception
+      | `TransactionInProgressException of transaction_in_progress_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    transact_write_items_input ->
+    ( transact_write_items_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatchException of idempotent_parameter_mismatch_exception
       | `InternalServerError of internal_server_error
@@ -3490,6 +4033,18 @@ module UntagResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the association of tags from an Amazon DynamoDB resource. You can call [UntagResource] \
@@ -3532,6 +4087,17 @@ module UpdateContinuousBackups : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `TableNotFoundException of table_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_continuous_backups_input ->
+    ( update_continuous_backups_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ContinuousBackupsUnavailableException of continuous_backups_unavailable_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   " [UpdateContinuousBackups] enables or disables point in time recovery for the specified table. \
@@ -3561,6 +4127,15 @@ module UpdateContributorInsights : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_contributor_insights_input ->
+    ( update_contributor_insights_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the status for contributor insights for a specific table or index. CloudWatch \
@@ -3585,6 +4160,19 @@ module UpdateGlobalTable : sig
     'http_type Smaws_Lib.Context.t ->
     update_global_table_input ->
     ( update_global_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableNotFoundException of global_table_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ReplicaAlreadyExistsException of replica_already_exists_exception
+      | `ReplicaNotFoundException of replica_not_found_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_global_table_input ->
+    ( update_global_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableNotFoundException of global_table_not_found_exception
       | `InternalServerError of internal_server_error
@@ -3665,6 +4253,20 @@ module UpdateGlobalTableSettings : sig
       | `ReplicaNotFoundException of replica_not_found_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_global_table_settings_input ->
+    ( update_global_table_settings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableNotFoundException of global_table_not_found_exception
+      | `IndexNotFoundException of index_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ReplicaNotFoundException of replica_not_found_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates settings for a global table.\n\n\
@@ -3714,6 +4316,23 @@ module UpdateItem : sig
       | `ThrottlingException of throttling_exception
       | `TransactionConflictException of transaction_conflict_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_item_input ->
+    ( update_item_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ReplicatedWriteConflictException of replicated_write_conflict_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionConflictException of transaction_conflict_exception ] )
+    result
 end
 [@@ocaml.doc
   "Edits an existing item's attributes, or adds a new item to the table if it does not already \
@@ -3745,6 +4364,18 @@ module UpdateKinesisStreamingDestination : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_kinesis_streaming_destination_input ->
+    ( update_kinesis_streaming_destination_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "The command to update the Kinesis stream destination.\n"]
 
@@ -3762,6 +4393,18 @@ module UpdateTable : sig
     'http_type Smaws_Lib.Context.t ->
     update_table_input ->
     ( update_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_table_input ->
+    ( update_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -3811,6 +4454,17 @@ module UpdateTableReplicaAutoScaling : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_table_replica_auto_scaling_input ->
+    ( update_table_replica_auto_scaling_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Updates auto scaling settings on your global tables at once.\n"]
 
@@ -3829,6 +4483,18 @@ module UpdateTimeToLive : sig
     'http_type Smaws_Lib.Context.t ->
     update_time_to_live_input ->
     ( update_time_to_live_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_time_to_live_input ->
+    ( update_time_to_live_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception

--- a/sdks/dynamodb/operations.ml
+++ b/sdks/dynamodb/operations.ml
@@ -27,6 +27,13 @@ module BatchExecuteStatement = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_execute_statement_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_execute_statement_input) =
+    let input = Json_serializers.batch_execute_statement_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.BatchExecuteStatement" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_execute_statement_output_of_yojson
+      ~error_deserializer
 end
 
 module BatchGetItem = struct
@@ -67,6 +74,12 @@ module BatchGetItem = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.BatchGetItem" ~service
       ~context ~input ~output_deserializer:Json_deserializers.batch_get_item_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_get_item_input) =
+    let input = Json_serializers.batch_get_item_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.BatchGetItem"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_get_item_output_of_yojson ~error_deserializer
 end
 
 module BatchWriteItem = struct
@@ -117,6 +130,12 @@ module BatchWriteItem = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.BatchWriteItem" ~service
       ~context ~input ~output_deserializer:Json_deserializers.batch_write_item_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_write_item_input) =
+    let input = Json_serializers.batch_write_item_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.BatchWriteItem"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_write_item_output_of_yojson ~error_deserializer
 end
 
 module CreateBackup = struct
@@ -159,6 +178,12 @@ module CreateBackup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.CreateBackup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_backup_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_backup_input) =
+    let input = Json_serializers.create_backup_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.CreateBackup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_backup_output_of_yojson ~error_deserializer
 end
 
 module CreateGlobalTable = struct
@@ -195,6 +220,13 @@ module CreateGlobalTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.CreateGlobalTable" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_global_table_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_global_table_input) =
+    let input = Json_serializers.create_global_table_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.CreateGlobalTable" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_global_table_output_of_yojson
+      ~error_deserializer
 end
 
 module CreateTable = struct
@@ -225,6 +257,12 @@ module CreateTable = struct
     let input = Json_serializers.create_table_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.CreateTable" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_table_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_table_input) =
+    let input = Json_serializers.create_table_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.CreateTable"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.create_table_output_of_yojson
       ~error_deserializer
 end
 
@@ -261,6 +299,12 @@ module DeleteBackup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DeleteBackup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_backup_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_backup_input) =
+    let input = Json_serializers.delete_backup_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.DeleteBackup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_backup_output_of_yojson ~error_deserializer
 end
 
 module DeleteItem = struct
@@ -319,6 +363,12 @@ module DeleteItem = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DeleteItem" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_item_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_item_input) =
+    let input = Json_serializers.delete_item_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.DeleteItem"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.delete_item_output_of_yojson
+      ~error_deserializer
 end
 
 module DeleteResourcePolicy = struct
@@ -359,6 +409,13 @@ module DeleteResourcePolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_resource_policy_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_resource_policy_input) =
+    let input = Json_serializers.delete_resource_policy_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.DeleteResourcePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_resource_policy_output_of_yojson
+      ~error_deserializer
 end
 
 module DeleteTable = struct
@@ -394,6 +451,12 @@ module DeleteTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DeleteTable" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_table_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_table_input) =
+    let input = Json_serializers.delete_table_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.DeleteTable"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.delete_table_output_of_yojson
+      ~error_deserializer
 end
 
 module DescribeBackup = struct
@@ -423,6 +486,12 @@ module DescribeBackup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DescribeBackup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_backup_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_backup_input) =
+    let input = Json_serializers.describe_backup_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.DescribeBackup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_backup_output_of_yojson ~error_deserializer
 end
 
 module DescribeContinuousBackups = struct
@@ -452,6 +521,13 @@ module DescribeContinuousBackups = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_continuous_backups_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_continuous_backups_input) =
+    let input = Json_serializers.describe_continuous_backups_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.DescribeContinuousBackups" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_continuous_backups_output_of_yojson
+      ~error_deserializer
 end
 
 module DescribeContributorInsights = struct
@@ -478,6 +554,13 @@ module DescribeContributorInsights = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_contributor_insights_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_contributor_insights_input) =
+    let input = Json_serializers.describe_contributor_insights_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.DescribeContributorInsights" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_contributor_insights_output_of_yojson
+      ~error_deserializer
 end
 
 module DescribeEndpoints = struct
@@ -492,6 +575,13 @@ module DescribeEndpoints = struct
     let input = Json_serializers.describe_endpoints_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DescribeEndpoints" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_endpoints_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_endpoints_request) =
+    let input = Json_serializers.describe_endpoints_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.DescribeEndpoints" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_endpoints_response_of_yojson
       ~error_deserializer
 end
 
@@ -521,6 +611,12 @@ module DescribeExport = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DescribeExport" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_export_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_export_input) =
+    let input = Json_serializers.describe_export_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.DescribeExport"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_export_output_of_yojson ~error_deserializer
 end
 
 module DescribeGlobalTable = struct
@@ -549,6 +645,13 @@ module DescribeGlobalTable = struct
     let input = Json_serializers.describe_global_table_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DescribeGlobalTable" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_global_table_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_global_table_input) =
+    let input = Json_serializers.describe_global_table_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.DescribeGlobalTable" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_global_table_output_of_yojson
       ~error_deserializer
 end
 
@@ -580,6 +683,13 @@ module DescribeGlobalTableSettings = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_global_table_settings_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_global_table_settings_input) =
+    let input = Json_serializers.describe_global_table_settings_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.DescribeGlobalTableSettings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_global_table_settings_output_of_yojson
+      ~error_deserializer
 end
 
 module DescribeImport = struct
@@ -602,6 +712,12 @@ module DescribeImport = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DescribeImport" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_import_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_import_input) =
+    let input = Json_serializers.describe_import_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.DescribeImport"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_import_output_of_yojson ~error_deserializer
 end
 
 module DescribeKinesisStreamingDestination = struct
@@ -633,6 +749,14 @@ module DescribeKinesisStreamingDestination = struct
       ~output_deserializer:
         Json_deserializers.describe_kinesis_streaming_destination_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_kinesis_streaming_destination_input) =
+    let input = Json_serializers.describe_kinesis_streaming_destination_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.DescribeKinesisStreamingDestination" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_kinesis_streaming_destination_output_of_yojson
+      ~error_deserializer
 end
 
 module DescribeLimits = struct
@@ -658,6 +782,12 @@ module DescribeLimits = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DescribeLimits" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_limits_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_limits_input) =
+    let input = Json_serializers.describe_limits_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.DescribeLimits"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_limits_output_of_yojson ~error_deserializer
 end
 
 module DescribeTable = struct
@@ -687,6 +817,12 @@ module DescribeTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DescribeTable" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_table_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_table_input) =
+    let input = Json_serializers.describe_table_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.DescribeTable"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_table_output_of_yojson ~error_deserializer
 end
 
 module DescribeTableReplicaAutoScaling = struct
@@ -710,6 +846,13 @@ module DescribeTableReplicaAutoScaling = struct
   let request context (request : describe_table_replica_auto_scaling_input) =
     let input = Json_serializers.describe_table_replica_auto_scaling_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DynamoDB_20120810.DescribeTableReplicaAutoScaling" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_table_replica_auto_scaling_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_table_replica_auto_scaling_input) =
+    let input = Json_serializers.describe_table_replica_auto_scaling_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DynamoDB_20120810.DescribeTableReplicaAutoScaling" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_table_replica_auto_scaling_output_of_yojson
       ~error_deserializer
@@ -741,6 +884,13 @@ module DescribeTimeToLive = struct
     let input = Json_serializers.describe_time_to_live_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.DescribeTimeToLive" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_time_to_live_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_time_to_live_input) =
+    let input = Json_serializers.describe_time_to_live_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.DescribeTimeToLive" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_time_to_live_output_of_yojson
       ~error_deserializer
 end
 
@@ -778,6 +928,13 @@ module DisableKinesisStreamingDestination = struct
       ~shape_name:"DynamoDB_20120810.DisableKinesisStreamingDestination" ~service ~context ~input
       ~output_deserializer:Json_deserializers.kinesis_streaming_destination_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : kinesis_streaming_destination_input) =
+    let input = Json_serializers.kinesis_streaming_destination_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.DisableKinesisStreamingDestination" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.kinesis_streaming_destination_output_of_yojson
+      ~error_deserializer
 end
 
 module EnableKinesisStreamingDestination = struct
@@ -811,6 +968,13 @@ module EnableKinesisStreamingDestination = struct
   let request context (request : kinesis_streaming_destination_input) =
     let input = Json_serializers.kinesis_streaming_destination_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DynamoDB_20120810.EnableKinesisStreamingDestination" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.kinesis_streaming_destination_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : kinesis_streaming_destination_input) =
+    let input = Json_serializers.kinesis_streaming_destination_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DynamoDB_20120810.EnableKinesisStreamingDestination" ~service ~context ~input
       ~output_deserializer:Json_deserializers.kinesis_streaming_destination_output_of_yojson
       ~error_deserializer
@@ -866,6 +1030,12 @@ module ExecuteStatement = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.ExecuteStatement" ~service
       ~context ~input ~output_deserializer:Json_deserializers.execute_statement_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : execute_statement_input) =
+    let input = Json_serializers.execute_statement_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.ExecuteStatement" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.execute_statement_output_of_yojson ~error_deserializer
 end
 
 module ExecuteTransaction = struct
@@ -915,6 +1085,13 @@ module ExecuteTransaction = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.ExecuteTransaction" ~service
       ~context ~input ~output_deserializer:Json_deserializers.execute_transaction_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : execute_transaction_input) =
+    let input = Json_serializers.execute_transaction_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.ExecuteTransaction" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.execute_transaction_output_of_yojson
+      ~error_deserializer
 end
 
 module ExportTableToPointInTime = struct
@@ -956,6 +1133,13 @@ module ExportTableToPointInTime = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.export_table_to_point_in_time_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : export_table_to_point_in_time_input) =
+    let input = Json_serializers.export_table_to_point_in_time_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.ExportTableToPointInTime" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.export_table_to_point_in_time_output_of_yojson
+      ~error_deserializer
 end
 
 module GetItem = struct
@@ -995,6 +1179,12 @@ module GetItem = struct
     let input = Json_serializers.get_item_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.GetItem" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_item_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_item_input) =
+    let input = Json_serializers.get_item_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.GetItem"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_item_output_of_yojson
+      ~error_deserializer
 end
 
 module GetResourcePolicy = struct
@@ -1028,6 +1218,13 @@ module GetResourcePolicy = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.GetResourcePolicy" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_resource_policy_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_policy_input) =
+    let input = Json_serializers.get_resource_policy_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.GetResourcePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_policy_output_of_yojson
+      ~error_deserializer
 end
 
 module ImportTable = struct
@@ -1056,6 +1253,12 @@ module ImportTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.ImportTable" ~service
       ~context ~input ~output_deserializer:Json_deserializers.import_table_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : import_table_input) =
+    let input = Json_serializers.import_table_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.ImportTable"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.import_table_output_of_yojson
+      ~error_deserializer
 end
 
 module ListBackups = struct
@@ -1080,6 +1283,12 @@ module ListBackups = struct
     let input = Json_serializers.list_backups_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.ListBackups" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_backups_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_backups_input) =
+    let input = Json_serializers.list_backups_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.ListBackups"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_backups_output_of_yojson
       ~error_deserializer
 end
 
@@ -1107,6 +1316,13 @@ module ListContributorInsights = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_contributor_insights_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_contributor_insights_input) =
+    let input = Json_serializers.list_contributor_insights_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.ListContributorInsights" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_contributor_insights_output_of_yojson
+      ~error_deserializer
 end
 
 module ListExports = struct
@@ -1130,6 +1346,12 @@ module ListExports = struct
     let input = Json_serializers.list_exports_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.ListExports" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_exports_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_exports_input) =
+    let input = Json_serializers.list_exports_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.ListExports"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_exports_output_of_yojson
       ~error_deserializer
 end
 
@@ -1156,6 +1378,13 @@ module ListGlobalTables = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.ListGlobalTables" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_global_tables_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_global_tables_input) =
+    let input = Json_serializers.list_global_tables_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.ListGlobalTables" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_global_tables_output_of_yojson
+      ~error_deserializer
 end
 
 module ListImports = struct
@@ -1176,6 +1405,12 @@ module ListImports = struct
     let input = Json_serializers.list_imports_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.ListImports" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_imports_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_imports_input) =
+    let input = Json_serializers.list_imports_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.ListImports"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_imports_output_of_yojson
       ~error_deserializer
 end
 
@@ -1201,6 +1436,12 @@ module ListTables = struct
     let input = Json_serializers.list_tables_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.ListTables" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_tables_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tables_input) =
+    let input = Json_serializers.list_tables_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.ListTables"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_tables_output_of_yojson
       ~error_deserializer
 end
 
@@ -1230,6 +1471,13 @@ module ListTagsOfResource = struct
     let input = Json_serializers.list_tags_of_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.ListTagsOfResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_tags_of_resource_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_of_resource_input) =
+    let input = Json_serializers.list_tags_of_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.ListTagsOfResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_of_resource_output_of_yojson
       ~error_deserializer
 end
 
@@ -1288,6 +1536,12 @@ module PutItem = struct
     let input = Json_serializers.put_item_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.PutItem" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_item_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : put_item_input) =
+    let input = Json_serializers.put_item_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.PutItem"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.put_item_output_of_yojson
+      ~error_deserializer
 end
 
 module PutResourcePolicy = struct
@@ -1326,6 +1580,13 @@ module PutResourcePolicy = struct
     let input = Json_serializers.put_resource_policy_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.PutResourcePolicy" ~service
       ~context ~input ~output_deserializer:Json_deserializers.put_resource_policy_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_resource_policy_input) =
+    let input = Json_serializers.put_resource_policy_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.PutResourcePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_resource_policy_output_of_yojson
       ~error_deserializer
 end
 
@@ -1366,6 +1627,12 @@ module Query = struct
     let input = Json_serializers.query_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.Query" ~service ~context
       ~input ~output_deserializer:Json_deserializers.query_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : query_input) =
+    let input = Json_serializers.query_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.Query" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.query_output_of_yojson
+      ~error_deserializer
 end
 
 module RestoreTableFromBackup = struct
@@ -1407,6 +1674,13 @@ module RestoreTableFromBackup = struct
     let input = Json_serializers.restore_table_from_backup_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.RestoreTableFromBackup"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.restore_table_from_backup_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : restore_table_from_backup_input) =
+    let input = Json_serializers.restore_table_from_backup_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.RestoreTableFromBackup" ~service ~context ~input
       ~output_deserializer:Json_deserializers.restore_table_from_backup_output_of_yojson
       ~error_deserializer
 end
@@ -1457,6 +1731,13 @@ module RestoreTableToPointInTime = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.restore_table_to_point_in_time_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : restore_table_to_point_in_time_input) =
+    let input = Json_serializers.restore_table_to_point_in_time_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.RestoreTableToPointInTime" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.restore_table_to_point_in_time_output_of_yojson
+      ~error_deserializer
 end
 
 module Scan = struct
@@ -1496,6 +1777,12 @@ module Scan = struct
     let input = Json_serializers.scan_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.Scan" ~service ~context
       ~input ~output_deserializer:Json_deserializers.scan_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : scan_input) =
+    let input = Json_serializers.scan_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.Scan" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.scan_output_of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -1530,6 +1817,13 @@ module TagResource = struct
     let input = Json_serializers.tag_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.TagResource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_input) =
+    let input = Json_serializers.tag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1574,6 +1868,13 @@ module TransactGetItems = struct
     let input = Json_serializers.transact_get_items_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.TransactGetItems" ~service
       ~context ~input ~output_deserializer:Json_deserializers.transact_get_items_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : transact_get_items_input) =
+    let input = Json_serializers.transact_get_items_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.TransactGetItems" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.transact_get_items_output_of_yojson
       ~error_deserializer
 end
 
@@ -1628,6 +1929,13 @@ module TransactWriteItems = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.TransactWriteItems" ~service
       ~context ~input ~output_deserializer:Json_deserializers.transact_write_items_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : transact_write_items_input) =
+    let input = Json_serializers.transact_write_items_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.TransactWriteItems" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.transact_write_items_output_of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1663,6 +1971,13 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.UntagResource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_input) =
+    let input = Json_serializers.untag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UpdateContinuousBackups = struct
@@ -1697,6 +2012,13 @@ module UpdateContinuousBackups = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_continuous_backups_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_continuous_backups_input) =
+    let input = Json_serializers.update_continuous_backups_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.UpdateContinuousBackups" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_continuous_backups_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateContributorInsights = struct
@@ -1721,6 +2043,13 @@ module UpdateContributorInsights = struct
     let input = Json_serializers.update_contributor_insights_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.UpdateContributorInsights"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_contributor_insights_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_contributor_insights_input) =
+    let input = Json_serializers.update_contributor_insights_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.UpdateContributorInsights" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_contributor_insights_output_of_yojson
       ~error_deserializer
 end
@@ -1763,6 +2092,13 @@ module UpdateGlobalTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.UpdateGlobalTable" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_global_table_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_global_table_input) =
+    let input = Json_serializers.update_global_table_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.UpdateGlobalTable" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_global_table_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateGlobalTableSettings = struct
@@ -1804,6 +2140,13 @@ module UpdateGlobalTableSettings = struct
     let input = Json_serializers.update_global_table_settings_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.UpdateGlobalTableSettings"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_global_table_settings_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_global_table_settings_input) =
+    let input = Json_serializers.update_global_table_settings_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.UpdateGlobalTableSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_global_table_settings_output_of_yojson
       ~error_deserializer
 end
@@ -1864,6 +2207,12 @@ module UpdateItem = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.UpdateItem" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_item_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_item_input) =
+    let input = Json_serializers.update_item_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.UpdateItem"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.update_item_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateKinesisStreamingDestination = struct
@@ -1897,6 +2246,13 @@ module UpdateKinesisStreamingDestination = struct
   let request context (request : update_kinesis_streaming_destination_input) =
     let input = Json_serializers.update_kinesis_streaming_destination_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DynamoDB_20120810.UpdateKinesisStreamingDestination" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_kinesis_streaming_destination_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_kinesis_streaming_destination_input) =
+    let input = Json_serializers.update_kinesis_streaming_destination_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DynamoDB_20120810.UpdateKinesisStreamingDestination" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_kinesis_streaming_destination_output_of_yojson
       ~error_deserializer
@@ -1935,6 +2291,12 @@ module UpdateTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.UpdateTable" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_table_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_table_input) =
+    let input = Json_serializers.update_table_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"DynamoDB_20120810.UpdateTable"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.update_table_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateTableReplicaAutoScaling = struct
@@ -1964,6 +2326,13 @@ module UpdateTableReplicaAutoScaling = struct
   let request context (request : update_table_replica_auto_scaling_input) =
     let input = Json_serializers.update_table_replica_auto_scaling_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"DynamoDB_20120810.UpdateTableReplicaAutoScaling" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_table_replica_auto_scaling_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_table_replica_auto_scaling_input) =
+    let input = Json_serializers.update_table_replica_auto_scaling_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"DynamoDB_20120810.UpdateTableReplicaAutoScaling" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_table_replica_auto_scaling_output_of_yojson
       ~error_deserializer
@@ -2001,5 +2370,12 @@ module UpdateTimeToLive = struct
     let input = Json_serializers.update_time_to_live_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"DynamoDB_20120810.UpdateTimeToLive" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_time_to_live_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_time_to_live_input) =
+    let input = Json_serializers.update_time_to_live_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"DynamoDB_20120810.UpdateTimeToLive" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_time_to_live_output_of_yojson
       ~error_deserializer
 end

--- a/sdks/dynamodb/operations.mli
+++ b/sdks/dynamodb/operations.mli
@@ -17,6 +17,16 @@ module BatchExecuteStatement : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_execute_statement_input ->
+    ( batch_execute_statement_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "This operation allows you to perform batch reads or writes on data stored in DynamoDB, using \
@@ -50,6 +60,19 @@ module BatchGetItem : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_item_input ->
     ( batch_get_item_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_item_input ->
+    ( batch_get_item_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -131,6 +154,21 @@ module BatchWriteItem : sig
     'http_type Smaws_Lib.Context.t ->
     batch_write_item_input ->
     ( batch_write_item_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ReplicatedWriteConflictException of replicated_write_conflict_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_write_item_input ->
+    ( batch_write_item_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -258,6 +296,20 @@ module CreateBackup : sig
       | `TableInUseException of table_in_use_exception
       | `TableNotFoundException of table_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_backup_input ->
+    ( create_backup_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BackupInUseException of backup_in_use_exception
+      | `ContinuousBackupsUnavailableException of continuous_backups_unavailable_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `TableInUseException of table_in_use_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a backup for an existing table.\n\n\
@@ -310,6 +362,18 @@ module CreateGlobalTable : sig
     'http_type Smaws_Lib.Context.t ->
     create_global_table_input ->
     ( create_global_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableAlreadyExistsException of global_table_already_exists_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_global_table_input ->
+    ( create_global_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableAlreadyExistsException of global_table_already_exists_exception
       | `InternalServerError of internal_server_error
@@ -404,6 +468,17 @@ module CreateTable : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_table_input ->
+    ( create_table_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "The [CreateTable] operation adds a new table to your account. In an Amazon Web Services \
@@ -443,6 +518,18 @@ module DeleteBackup : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_backup_input ->
+    ( delete_backup_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BackupInUseException of backup_in_use_exception
+      | `BackupNotFoundException of backup_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an existing backup of a table.\n\n\
@@ -468,6 +555,23 @@ module DeleteItem : sig
     'http_type Smaws_Lib.Context.t ->
     delete_item_input ->
     ( delete_item_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ReplicatedWriteConflictException of replicated_write_conflict_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionConflictException of transaction_conflict_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_item_input ->
+    ( delete_item_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConditionalCheckFailedException of conditional_check_failed_exception
       | `InternalServerError of internal_server_error
@@ -517,6 +621,19 @@ module DeleteResourcePolicy : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_policy_input ->
+    ( delete_resource_policy_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `PolicyNotFoundException of policy_not_found_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the resource-based policy attached to the resource, which can be a table or stream.\n\n\
@@ -549,6 +666,18 @@ module DeleteTable : sig
     'http_type Smaws_Lib.Context.t ->
     delete_table_input ->
     ( delete_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_table_input ->
+    ( delete_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -594,6 +723,16 @@ module DescribeBackup : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_backup_input ->
+    ( describe_backup_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BackupNotFoundException of backup_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
 end
 [@@ocaml.doc
   "Describes an existing backup of a table.\n\n\
@@ -612,6 +751,16 @@ module DescribeContinuousBackups : sig
     'http_type Smaws_Lib.Context.t ->
     describe_continuous_backups_input ->
     ( describe_continuous_backups_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_continuous_backups_input ->
+    ( describe_continuous_backups_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -647,6 +796,15 @@ module DescribeContributorInsights : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_contributor_insights_input ->
+    ( describe_contributor_insights_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about contributor insights for a given table or global secondary index.\n"]
@@ -658,6 +816,13 @@ module DescribeEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     describe_endpoints_request ->
     (describe_endpoints_response, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_endpoints_request ->
+    ( describe_endpoints_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] )
+    result
 end
 [@@ocaml.doc
   "Returns the regional endpoint information. For more information on policy permissions, please \
@@ -682,6 +847,16 @@ module DescribeExport : sig
       | `InternalServerError of internal_server_error
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_export_input ->
+    ( describe_export_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExportNotFoundException of export_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc "Describes an existing table export.\n"]
 
@@ -697,6 +872,16 @@ module DescribeGlobalTable : sig
     'http_type Smaws_Lib.Context.t ->
     describe_global_table_input ->
     ( describe_global_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableNotFoundException of global_table_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_global_table_input ->
+    ( describe_global_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableNotFoundException of global_table_not_found_exception
       | `InternalServerError of internal_server_error
@@ -737,6 +922,16 @@ module DescribeGlobalTableSettings : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_global_table_settings_input ->
+    ( describe_global_table_settings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableNotFoundException of global_table_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
 end
 [@@ocaml.doc
   "Describes Region-specific settings for a global table.\n\n\
@@ -767,6 +962,14 @@ module DescribeImport : sig
       [> Smaws_Lib.Protocols.AwsJson.error | `ImportNotFoundException of import_not_found_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_import_input ->
+    ( describe_import_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `ImportNotFoundException of import_not_found_exception ]
+    )
+    result
 end
 [@@ocaml.doc " Represents the properties of the import. \n"]
 
@@ -787,6 +990,16 @@ module DescribeKinesisStreamingDestination : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_kinesis_streaming_destination_input ->
+    ( describe_kinesis_streaming_destination_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the status of Kinesis streaming.\n"]
 
@@ -801,6 +1014,15 @@ module DescribeLimits : sig
     'http_type Smaws_Lib.Context.t ->
     describe_limits_input ->
     ( describe_limits_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_limits_input ->
+    ( describe_limits_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
@@ -890,6 +1112,16 @@ module DescribeTable : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_table_input ->
+    ( describe_table_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the table, including the current status of the table, when it was \
@@ -916,6 +1148,15 @@ module DescribeTableReplicaAutoScaling : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_table_replica_auto_scaling_input ->
+    ( describe_table_replica_auto_scaling_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Describes auto scaling settings across replicas of the global table at once.\n"]
 
@@ -931,6 +1172,16 @@ module DescribeTimeToLive : sig
     'http_type Smaws_Lib.Context.t ->
     describe_time_to_live_input ->
     ( describe_time_to_live_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_time_to_live_input ->
+    ( describe_time_to_live_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -953,6 +1204,18 @@ module DisableKinesisStreamingDestination : sig
     'http_type Smaws_Lib.Context.t ->
     kinesis_streaming_destination_input ->
     ( kinesis_streaming_destination_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    kinesis_streaming_destination_input ->
+    ( kinesis_streaming_destination_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -986,6 +1249,18 @@ module EnableKinesisStreamingDestination : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    kinesis_streaming_destination_input ->
+    ( kinesis_streaming_destination_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts table data replication to the specified Kinesis data stream at a timestamp chosen during \
@@ -1010,6 +1285,22 @@ module ExecuteStatement : sig
     'http_type Smaws_Lib.Context.t ->
     execute_statement_input ->
     ( execute_statement_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `DuplicateItemException of duplicate_item_exception
+      | `InternalServerError of internal_server_error
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionConflictException of transaction_conflict_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    execute_statement_input ->
+    ( execute_statement_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConditionalCheckFailedException of conditional_check_failed_exception
       | `DuplicateItemException of duplicate_item_exception
@@ -1064,6 +1355,21 @@ module ExecuteTransaction : sig
       | `TransactionCanceledException of transaction_canceled_exception
       | `TransactionInProgressException of transaction_in_progress_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    execute_transaction_input ->
+    ( execute_transaction_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatchException of idempotent_parameter_mismatch_exception
+      | `InternalServerError of internal_server_error
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionCanceledException of transaction_canceled_exception
+      | `TransactionInProgressException of transaction_in_progress_exception ] )
+    result
 end
 [@@ocaml.doc
   "This operation allows you to perform transactional reads or writes on data stored in DynamoDB, \
@@ -1091,6 +1397,19 @@ module ExportTableToPointInTime : sig
     'http_type Smaws_Lib.Context.t ->
     export_table_to_point_in_time_input ->
     ( export_table_to_point_in_time_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExportConflictException of export_conflict_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidExportTimeException of invalid_export_time_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `PointInTimeRecoveryUnavailableException of point_in_time_recovery_unavailable_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    export_table_to_point_in_time_input ->
+    ( export_table_to_point_in_time_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExportConflictException of export_conflict_exception
       | `InternalServerError of internal_server_error
@@ -1127,6 +1446,19 @@ module GetItem : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_item_input ->
+    ( get_item_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "The [GetItem] operation returns a set of attributes for the item with the given primary key. If \
@@ -1151,6 +1483,17 @@ module GetResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_policy_input ->
     ( get_resource_policy_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `PolicyNotFoundException of policy_not_found_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_policy_input ->
+    ( get_resource_policy_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -1210,6 +1553,16 @@ module ImportTable : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_table_input ->
+    ( import_table_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ImportConflictException of import_conflict_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc " Imports table data from an S3 bucket. \n"]
 
@@ -1224,6 +1577,15 @@ module ListBackups : sig
     'http_type Smaws_Lib.Context.t ->
     list_backups_input ->
     ( list_backups_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_backups_input ->
+    ( list_backups_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
@@ -1260,6 +1622,15 @@ module ListContributorInsights : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_contributor_insights_input ->
+    ( list_contributor_insights_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of ContributorInsightsSummary for a table and all its global secondary indexes.\n"]
@@ -1279,6 +1650,15 @@ module ListExports : sig
       | `InternalServerError of internal_server_error
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_exports_input ->
+    ( list_exports_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists completed exports within the past 90 days, in reverse alphanumeric order of [ExportArn].\n"]
@@ -1294,6 +1674,15 @@ module ListGlobalTables : sig
     'http_type Smaws_Lib.Context.t ->
     list_global_tables_input ->
     ( list_global_tables_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_global_tables_input ->
+    ( list_global_tables_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
@@ -1328,6 +1717,14 @@ module ListImports : sig
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_imports_input ->
+    ( list_imports_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
+    )
+    result
 end
 [@@ocaml.doc " Lists completed imports within the past 90 days. \n"]
 
@@ -1342,6 +1739,15 @@ module ListTables : sig
     'http_type Smaws_Lib.Context.t ->
     list_tables_input ->
     ( list_tables_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tables_input ->
+    ( list_tables_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception ] )
@@ -1363,6 +1769,16 @@ module ListTagsOfResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_of_resource_input ->
     ( list_tags_of_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_of_resource_input ->
+    ( list_tags_of_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -1396,6 +1812,23 @@ module PutItem : sig
     'http_type Smaws_Lib.Context.t ->
     put_item_input ->
     ( put_item_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ReplicatedWriteConflictException of replicated_write_conflict_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionConflictException of transaction_conflict_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_item_input ->
+    ( put_item_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConditionalCheckFailedException of conditional_check_failed_exception
       | `InternalServerError of internal_server_error
@@ -1460,6 +1893,19 @@ module PutResourcePolicy : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_policy_input ->
+    ( put_resource_policy_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `PolicyNotFoundException of policy_not_found_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attaches a resource-based policy document to the resource, which can be a table or stream. When \
@@ -1495,6 +1941,19 @@ module Query : sig
     'http_type Smaws_Lib.Context.t ->
     query_input ->
     ( query_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_input ->
+    ( query_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -1576,6 +2035,20 @@ module RestoreTableFromBackup : sig
       | `TableAlreadyExistsException of table_already_exists_exception
       | `TableInUseException of table_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_table_from_backup_input ->
+    ( restore_table_from_backup_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BackupInUseException of backup_in_use_exception
+      | `BackupNotFoundException of backup_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `TableAlreadyExistsException of table_already_exists_exception
+      | `TableInUseException of table_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new table from an existing backup. Any number of users can execute up to 50 \
@@ -1623,6 +2096,21 @@ module RestoreTableToPointInTime : sig
     'http_type Smaws_Lib.Context.t ->
     restore_table_to_point_in_time_input ->
     ( restore_table_to_point_in_time_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `InvalidRestoreTimeException of invalid_restore_time_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `PointInTimeRecoveryUnavailableException of point_in_time_recovery_unavailable_exception
+      | `TableAlreadyExistsException of table_already_exists_exception
+      | `TableInUseException of table_in_use_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_table_to_point_in_time_input ->
+    ( restore_table_to_point_in_time_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -1712,6 +2200,19 @@ module Scan : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    scan_input ->
+    ( scan_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "The [Scan] operation returns one or more items and item attributes by accessing every item in a \
@@ -1777,6 +2278,18 @@ module TagResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associate a set of tags with an Amazon DynamoDB resource. You can then activate these \
@@ -1817,6 +2330,20 @@ module TransactGetItems : sig
     'http_type Smaws_Lib.Context.t ->
     transact_get_items_input ->
     ( transact_get_items_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionCanceledException of transaction_canceled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    transact_get_items_input ->
+    ( transact_get_items_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -1870,6 +2397,22 @@ module TransactWriteItems : sig
     'http_type Smaws_Lib.Context.t ->
     transact_write_items_input ->
     ( transact_write_items_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatchException of idempotent_parameter_mismatch_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionCanceledException of transaction_canceled_exception
+      | `TransactionInProgressException of transaction_in_progress_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    transact_write_items_input ->
+    ( transact_write_items_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatchException of idempotent_parameter_mismatch_exception
       | `InternalServerError of internal_server_error
@@ -1968,6 +2511,18 @@ module UntagResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the association of tags from an Amazon DynamoDB resource. You can call [UntagResource] \
@@ -2010,6 +2565,17 @@ module UpdateContinuousBackups : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `TableNotFoundException of table_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_continuous_backups_input ->
+    ( update_continuous_backups_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ContinuousBackupsUnavailableException of continuous_backups_unavailable_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   " [UpdateContinuousBackups] enables or disables point in time recovery for the specified table. \
@@ -2039,6 +2605,15 @@ module UpdateContributorInsights : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_contributor_insights_input ->
+    ( update_contributor_insights_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the status for contributor insights for a specific table or index. CloudWatch \
@@ -2063,6 +2638,19 @@ module UpdateGlobalTable : sig
     'http_type Smaws_Lib.Context.t ->
     update_global_table_input ->
     ( update_global_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableNotFoundException of global_table_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ReplicaAlreadyExistsException of replica_already_exists_exception
+      | `ReplicaNotFoundException of replica_not_found_exception
+      | `TableNotFoundException of table_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_global_table_input ->
+    ( update_global_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableNotFoundException of global_table_not_found_exception
       | `InternalServerError of internal_server_error
@@ -2143,6 +2731,20 @@ module UpdateGlobalTableSettings : sig
       | `ReplicaNotFoundException of replica_not_found_exception
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_global_table_settings_input ->
+    ( update_global_table_settings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `GlobalTableNotFoundException of global_table_not_found_exception
+      | `IndexNotFoundException of index_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ReplicaNotFoundException of replica_not_found_exception
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates settings for a global table.\n\n\
@@ -2192,6 +2794,23 @@ module UpdateItem : sig
       | `ThrottlingException of throttling_exception
       | `TransactionConflictException of transaction_conflict_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_item_input ->
+    ( update_item_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConditionalCheckFailedException of conditional_check_failed_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `ItemCollectionSizeLimitExceededException of item_collection_size_limit_exceeded_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ReplicatedWriteConflictException of replicated_write_conflict_exception
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `TransactionConflictException of transaction_conflict_exception ] )
+    result
 end
 [@@ocaml.doc
   "Edits an existing item's attributes, or adds a new item to the table if it does not already \
@@ -2223,6 +2842,18 @@ module UpdateKinesisStreamingDestination : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_kinesis_streaming_destination_input ->
+    ( update_kinesis_streaming_destination_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "The command to update the Kinesis stream destination.\n"]
 
@@ -2240,6 +2871,18 @@ module UpdateTable : sig
     'http_type Smaws_Lib.Context.t ->
     update_table_input ->
     ( update_table_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_table_input ->
+    ( update_table_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
@@ -2289,6 +2932,17 @@ module UpdateTableReplicaAutoScaling : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_table_replica_auto_scaling_input ->
+    ( update_table_replica_auto_scaling_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Updates auto scaling settings on your global tables at once.\n"]
 
@@ -2306,6 +2960,18 @@ module UpdateTimeToLive : sig
     'http_type Smaws_Lib.Context.t ->
     update_time_to_live_input ->
     ( update_time_to_live_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidEndpointException of invalid_endpoint_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_time_to_live_input ->
+    ( update_time_to_live_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception

--- a/sdks/dynamodb/operations.mli
+++ b/sdks/dynamodb/operations.mli
@@ -25,7 +25,8 @@ module BatchExecuteStatement : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `RequestLimitExceeded of request_limit_exceeded
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -79,7 +80,8 @@ module BatchGetItem : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -177,7 +179,8 @@ module BatchWriteItem : sig
       | `ReplicatedWriteConflictException of replicated_write_conflict_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -308,7 +311,8 @@ module CreateBackup : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `TableInUseException of table_in_use_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -379,7 +383,8 @@ module CreateGlobalTable : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -477,7 +482,8 @@ module CreateTable : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -528,7 +534,8 @@ module DeleteBackup : sig
       | `BackupNotFoundException of backup_not_found_exception
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -582,7 +589,8 @@ module DeleteItem : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionConflictException of transaction_conflict_exception ] )
+      | `TransactionConflictException of transaction_conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -632,7 +640,8 @@ module DeleteResourcePolicy : sig
       | `LimitExceededException of limit_exceeded_exception
       | `PolicyNotFoundException of policy_not_found_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -683,7 +692,8 @@ module DeleteTable : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -731,7 +741,8 @@ module DescribeBackup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BackupNotFoundException of backup_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -764,7 +775,8 @@ module DescribeContinuousBackups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -803,7 +815,8 @@ module DescribeContributorInsights : sig
     ( describe_contributor_insights_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -821,7 +834,7 @@ module DescribeEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     describe_endpoints_request ->
     ( describe_endpoints_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -855,7 +868,8 @@ module DescribeExport : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExportNotFoundException of export_not_found_exception
       | `InternalServerError of internal_server_error
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes an existing table export.\n"]
@@ -885,7 +899,8 @@ module DescribeGlobalTable : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableNotFoundException of global_table_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -930,7 +945,8 @@ module DescribeGlobalTableSettings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `GlobalTableNotFoundException of global_table_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -968,7 +984,7 @@ module DescribeImport : sig
     describe_import_input ->
     ( describe_import_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `ImportNotFoundException of import_not_found_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Represents the properties of the import. \n"]
@@ -998,7 +1014,8 @@ module DescribeKinesisStreamingDestination : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the status of Kinesis streaming.\n"]
@@ -1025,7 +1042,8 @@ module DescribeLimits : sig
     ( describe_limits_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1120,7 +1138,8 @@ module DescribeTable : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1155,7 +1174,8 @@ module DescribeTableReplicaAutoScaling : sig
     ( describe_table_replica_auto_scaling_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes auto scaling settings across replicas of the global table at once.\n"]
@@ -1185,7 +1205,8 @@ module DescribeTimeToLive : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gives a description of the Time to Live (TTL) status on the specified table. \n"]
@@ -1221,7 +1242,8 @@ module DisableKinesisStreamingDestination : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1259,7 +1281,8 @@ module EnableKinesisStreamingDestination : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1310,7 +1333,8 @@ module ExecuteStatement : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionConflictException of transaction_conflict_exception ] )
+      | `TransactionConflictException of transaction_conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1368,7 +1392,8 @@ module ExecuteTransaction : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
       | `TransactionCanceledException of transaction_canceled_exception
-      | `TransactionInProgressException of transaction_in_progress_exception ] )
+      | `TransactionInProgressException of transaction_in_progress_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1416,7 +1441,8 @@ module ExportTableToPointInTime : sig
       | `InvalidExportTimeException of invalid_export_time_exception
       | `LimitExceededException of limit_exceeded_exception
       | `PointInTimeRecoveryUnavailableException of point_in_time_recovery_unavailable_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1457,7 +1483,8 @@ module GetItem : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1498,7 +1525,8 @@ module GetResourcePolicy : sig
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
       | `PolicyNotFoundException of policy_not_found_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1561,7 +1589,8 @@ module ImportTable : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ImportConflictException of import_conflict_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Imports table data from an S3 bucket. \n"]
@@ -1588,7 +1617,8 @@ module ListBackups : sig
     ( list_backups_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1629,7 +1659,8 @@ module ListContributorInsights : sig
     ( list_contributor_insights_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1657,7 +1688,8 @@ module ListExports : sig
     ( list_exports_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1685,7 +1717,8 @@ module ListGlobalTables : sig
     ( list_global_tables_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1723,7 +1756,7 @@ module ListImports : sig
     list_imports_input ->
     ( list_imports_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Lists completed imports within the past 90 days. \n"]
@@ -1750,7 +1783,8 @@ module ListTables : sig
     ( list_tables_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidEndpointException of invalid_endpoint_exception ] )
+      | `InvalidEndpointException of invalid_endpoint_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1782,7 +1816,8 @@ module ListTagsOfResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1839,7 +1874,8 @@ module PutItem : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionConflictException of transaction_conflict_exception ] )
+      | `TransactionConflictException of transaction_conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1904,7 +1940,8 @@ module PutResourcePolicy : sig
       | `LimitExceededException of limit_exceeded_exception
       | `PolicyNotFoundException of policy_not_found_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1960,7 +1997,8 @@ module Query : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2047,7 +2085,8 @@ module RestoreTableFromBackup : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `TableAlreadyExistsException of table_already_exists_exception
-      | `TableInUseException of table_in_use_exception ] )
+      | `TableInUseException of table_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2119,7 +2158,8 @@ module RestoreTableToPointInTime : sig
       | `PointInTimeRecoveryUnavailableException of point_in_time_recovery_unavailable_exception
       | `TableAlreadyExistsException of table_already_exists_exception
       | `TableInUseException of table_in_use_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2211,7 +2251,8 @@ module Scan : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2288,7 +2329,8 @@ module TagResource : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2351,7 +2393,8 @@ module TransactGetItems : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionCanceledException of transaction_canceled_exception ] )
+      | `TransactionCanceledException of transaction_canceled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2422,7 +2465,8 @@ module TransactWriteItems : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
       | `TransactionCanceledException of transaction_canceled_exception
-      | `TransactionInProgressException of transaction_in_progress_exception ] )
+      | `TransactionInProgressException of transaction_in_progress_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2521,7 +2565,8 @@ module UntagResource : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2574,7 +2619,8 @@ module UpdateContinuousBackups : sig
       | `ContinuousBackupsUnavailableException of continuous_backups_unavailable_exception
       | `InternalServerError of internal_server_error
       | `InvalidEndpointException of invalid_endpoint_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2612,7 +2658,8 @@ module UpdateContributorInsights : sig
     ( update_contributor_insights_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2657,7 +2704,8 @@ module UpdateGlobalTable : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `ReplicaAlreadyExistsException of replica_already_exists_exception
       | `ReplicaNotFoundException of replica_not_found_exception
-      | `TableNotFoundException of table_not_found_exception ] )
+      | `TableNotFoundException of table_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2743,7 +2791,8 @@ module UpdateGlobalTableSettings : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ReplicaNotFoundException of replica_not_found_exception
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2809,7 +2858,8 @@ module UpdateItem : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `TransactionConflictException of transaction_conflict_exception ] )
+      | `TransactionConflictException of transaction_conflict_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2852,7 +2902,8 @@ module UpdateKinesisStreamingDestination : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The command to update the Kinesis stream destination.\n"]
@@ -2888,7 +2939,8 @@ module UpdateTable : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2941,7 +2993,8 @@ module UpdateTableReplicaAutoScaling : sig
       | `InternalServerError of internal_server_error
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates auto scaling settings on your global tables at once.\n"]
@@ -2977,7 +3030,8 @@ module UpdateTimeToLive : sig
       | `InvalidEndpointException of invalid_endpoint_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/eventbridge/Smaws_Client_EventBridge.mli
+++ b/sdks/eventbridge/Smaws_Client_EventBridge.mli
@@ -1149,7 +1149,8 @@ module ActivateEventSource : sig
       | `InternalException of internal_exception
       | `InvalidStateException of invalid_state_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1184,7 +1185,8 @@ module CancelReplay : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `IllegalStatusException of illegal_status_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Cancels the specified replay.\n"]
@@ -1217,7 +1219,8 @@ module CreateApiDestination : sig
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1264,7 +1267,8 @@ module CreateArchive : sig
       | `InvalidEventPatternException of invalid_event_pattern_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1317,7 +1321,8 @@ module CreateConnection : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1353,7 +1358,8 @@ module CreateEndpoint : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1401,7 +1407,8 @@ module CreateEventBus : sig
       | `LimitExceededException of limit_exceeded_exception
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1440,7 +1447,8 @@ module CreatePartnerEventSource : sig
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1518,7 +1526,8 @@ module DeactivateEventSource : sig
       | `InternalException of internal_exception
       | `InvalidStateException of invalid_state_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1556,7 +1565,8 @@ module DeauthorizeConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1588,7 +1598,8 @@ module DeleteApiDestination : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified API destination.\n"]
@@ -1618,7 +1629,8 @@ module DeleteArchive : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified archive.\n"]
@@ -1648,7 +1660,8 @@ module DeleteConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a connection.\n"]
@@ -1678,7 +1691,8 @@ module DeleteEndpoint : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1709,7 +1723,8 @@ module DeleteEventBus : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
-      | `InternalException of internal_exception ] )
+      | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1741,7 +1756,8 @@ module DeletePartnerEventSource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `OperationDisabledException of operation_disabled_exception ] )
+      | `OperationDisabledException of operation_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1781,7 +1797,8 @@ module DeleteRule : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1823,7 +1840,8 @@ module DescribeApiDestination : sig
     ( describe_api_destination_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves details about an API destination.\n"]
@@ -1853,7 +1871,8 @@ module DescribeArchive : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves details about an archive.\n"]
@@ -1880,7 +1899,8 @@ module DescribeConnection : sig
     ( describe_connection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves details about a connection.\n"]
@@ -1907,7 +1927,8 @@ module DescribeEndpoint : sig
     ( describe_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1939,7 +1960,8 @@ module DescribeEventBus : sig
     ( describe_event_bus_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1979,7 +2001,8 @@ module DescribeEventSource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2010,7 +2033,8 @@ module DescribePartnerEventSource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2042,7 +2066,8 @@ module DescribeReplay : sig
     ( describe_replay_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2077,7 +2102,8 @@ module DescribeRule : sig
     ( describe_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2115,7 +2141,8 @@ module DisableRule : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2153,7 +2180,8 @@ module EnableRule : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2177,7 +2205,8 @@ module ListApiDestinations : sig
     'http_type Smaws_Lib.Context.t ->
     list_api_destinations_request ->
     ( list_api_destinations_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of API destination in the account in the current Region.\n"]
@@ -2204,7 +2233,8 @@ module ListArchives : sig
     ( list_archives_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2226,7 +2256,8 @@ module ListConnections : sig
     'http_type Smaws_Lib.Context.t ->
     list_connections_request ->
     ( list_connections_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of connections from the account.\n"]
@@ -2246,7 +2277,8 @@ module ListEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     list_endpoints_request ->
     ( list_endpoints_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2271,7 +2303,8 @@ module ListEventBuses : sig
     'http_type Smaws_Lib.Context.t ->
     list_event_buses_request ->
     ( list_event_buses_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2300,7 +2333,8 @@ module ListEventSources : sig
     ( list_event_sources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `OperationDisabledException of operation_disabled_exception ] )
+      | `OperationDisabledException of operation_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2333,7 +2367,8 @@ module ListPartnerEventSourceAccounts : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2363,7 +2398,8 @@ module ListPartnerEventSources : sig
     ( list_partner_event_sources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `OperationDisabledException of operation_disabled_exception ] )
+      | `OperationDisabledException of operation_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2385,7 +2421,8 @@ module ListReplays : sig
     'http_type Smaws_Lib.Context.t ->
     list_replays_request ->
     ( list_replays_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2414,7 +2451,8 @@ module ListRuleNamesByTarget : sig
     ( list_rule_names_by_target_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2445,7 +2483,8 @@ module ListRules : sig
     ( list_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2479,7 +2518,8 @@ module ListTagsForResource : sig
     ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2508,7 +2548,8 @@ module ListTargetsByRule : sig
     ( list_targets_by_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2531,7 +2572,8 @@ module PutEvents : sig
     'http_type Smaws_Lib.Context.t ->
     put_events_request ->
     ( put_events_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2572,7 +2614,8 @@ module PutPartnerEvents : sig
     ( put_partner_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `OperationDisabledException of operation_disabled_exception ] )
+      | `OperationDisabledException of operation_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2614,7 +2657,8 @@ module PutPermission : sig
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
       | `PolicyLengthExceededException of policy_length_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2674,7 +2718,8 @@ module PutRule : sig
       | `InvalidEventPatternException of invalid_event_pattern_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2770,7 +2815,8 @@ module PutTargets : sig
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2916,7 +2962,8 @@ module RemovePermission : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2954,7 +3001,8 @@ module RemoveTargets : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3004,7 +3052,8 @@ module StartReplay : sig
       | `InvalidEventPatternException of invalid_event_pattern_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3045,7 +3094,8 @@ module TagResource : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3086,7 +3136,8 @@ module TestEventPattern : sig
     ( test_event_pattern_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `InvalidEventPatternException of invalid_event_pattern_exception ] )
+      | `InvalidEventPatternException of invalid_event_pattern_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3125,7 +3176,8 @@ module UntagResource : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3160,7 +3212,8 @@ module UpdateApiDestination : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an API destination.\n"]
@@ -3196,7 +3249,8 @@ module UpdateArchive : sig
       | `InternalException of internal_exception
       | `InvalidEventPatternException of invalid_event_pattern_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the specified archive.\n"]
@@ -3235,7 +3289,8 @@ module UpdateConnection : sig
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates settings for a connection.\n"]
@@ -3265,7 +3320,8 @@ module UpdateEndpoint : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3303,7 +3359,8 @@ module UpdateEventBus : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the specified event bus.\n"]

--- a/sdks/eventbridge/Smaws_Client_EventBridge.mli
+++ b/sdks/eventbridge/Smaws_Client_EventBridge.mli
@@ -1139,6 +1139,18 @@ module ActivateEventSource : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    activate_event_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidStateException of invalid_state_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Activates a partner event source that has been deactivated. Once activated, your matching event \
@@ -1163,6 +1175,17 @@ module CancelReplay : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_replay_request ->
+    ( cancel_replay_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `IllegalStatusException of illegal_status_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Cancels the specified replay.\n"]
 
@@ -1179,6 +1202,17 @@ module CreateApiDestination : sig
     'http_type Smaws_Lib.Context.t ->
     create_api_destination_request ->
     ( create_api_destination_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_api_destination_request ->
+    ( create_api_destination_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -1211,6 +1245,19 @@ module CreateArchive : sig
     'http_type Smaws_Lib.Context.t ->
     create_archive_request ->
     ( create_archive_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_archive_request ->
+    ( create_archive_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1259,6 +1306,19 @@ module CreateConnection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_connection_request ->
+    ( create_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a connection. A connection defines the authorization type and credentials to use for \
@@ -1280,6 +1340,16 @@ module CreateEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     create_endpoint_request ->
     ( create_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_endpoint_request ->
+    ( create_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -1319,6 +1389,20 @@ module CreateEventBus : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_event_bus_request ->
+    ( create_event_bus_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidStateException of invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new event bus within your account. This can be a custom event bus which you can use \
@@ -1339,6 +1423,18 @@ module CreatePartnerEventSource : sig
     'http_type Smaws_Lib.Context.t ->
     create_partner_event_source_request ->
     ( create_partner_event_source_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_partner_event_source_request ->
+    ( create_partner_event_source_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1412,6 +1508,18 @@ module DeactivateEventSource : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deactivate_event_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidStateException of invalid_state_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "You can use this operation to temporarily stop receiving events from the specified partner \
@@ -1440,6 +1548,16 @@ module DeauthorizeConnection : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deauthorize_connection_request ->
+    ( deauthorize_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes all authorization parameters from the connection. This lets you remove the secret from \
@@ -1457,6 +1575,16 @@ module DeleteApiDestination : sig
     'http_type Smaws_Lib.Context.t ->
     delete_api_destination_request ->
     ( delete_api_destination_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_api_destination_request ->
+    ( delete_api_destination_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1482,6 +1610,16 @@ module DeleteArchive : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_archive_request ->
+    ( delete_archive_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified archive.\n"]
 
@@ -1502,6 +1640,16 @@ module DeleteConnection : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_connection_request ->
+    ( delete_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a connection.\n"]
 
@@ -1517,6 +1665,16 @@ module DeleteEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     delete_endpoint_request ->
     ( delete_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_endpoint_request ->
+    ( delete_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1544,6 +1702,15 @@ module DeleteEventBus : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_event_bus_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified custom event bus or partner event bus. All rules associated with this \
@@ -1561,6 +1728,16 @@ module DeletePartnerEventSource : sig
     'http_type Smaws_Lib.Context.t ->
     delete_partner_event_source_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_partner_event_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1589,6 +1766,17 @@ module DeleteRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1628,6 +1816,15 @@ module DescribeApiDestination : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_api_destination_request ->
+    ( describe_api_destination_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves details about an API destination.\n"]
 
@@ -1643,6 +1840,16 @@ module DescribeArchive : sig
     'http_type Smaws_Lib.Context.t ->
     describe_archive_request ->
     ( describe_archive_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_archive_request ->
+    ( describe_archive_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
@@ -1666,6 +1873,15 @@ module DescribeConnection : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_connection_request ->
+    ( describe_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves details about a connection.\n"]
 
@@ -1680,6 +1896,15 @@ module DescribeEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     describe_endpoint_request ->
     ( describe_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_endpoint_request ->
+    ( describe_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -1703,6 +1928,15 @@ module DescribeEventBus : sig
     'http_type Smaws_Lib.Context.t ->
     describe_event_bus_request ->
     ( describe_event_bus_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_event_bus_request ->
+    ( describe_event_bus_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -1737,6 +1971,16 @@ module DescribeEventSource : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_event_source_request ->
+    ( describe_event_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "This operation lists details about a partner event source that is shared with your account.\n"]
@@ -1753,6 +1997,16 @@ module DescribePartnerEventSource : sig
     'http_type Smaws_Lib.Context.t ->
     describe_partner_event_source_request ->
     ( describe_partner_event_source_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_partner_event_source_request ->
+    ( describe_partner_event_source_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
@@ -1777,6 +2031,15 @@ module DescribeReplay : sig
     'http_type Smaws_Lib.Context.t ->
     describe_replay_request ->
     ( describe_replay_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_replay_request ->
+    ( describe_replay_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -1807,6 +2070,15 @@ module DescribeRule : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_rule_request ->
+    ( describe_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Describes the specified rule.\n\n\
@@ -1828,6 +2100,17 @@ module DisableRule : sig
     'http_type Smaws_Lib.Context.t ->
     disable_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1861,6 +2144,17 @@ module EnableRule : sig
       | `ManagedRuleException of managed_rule_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables the specified rule. If the rule does not exist, the operation fails.\n\n\
@@ -1876,6 +2170,13 @@ module ListApiDestinations : sig
     'http_type Smaws_Lib.Context.t ->
     list_api_destinations_request ->
     ( list_api_destinations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_api_destinations_request ->
+    ( list_api_destinations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
 end
@@ -1896,6 +2197,15 @@ module ListArchives : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_archives_request ->
+    ( list_archives_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists your archives. You can either list all the archives or you can provide a prefix to match \
@@ -1911,6 +2221,13 @@ module ListConnections : sig
     ( list_connections_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_connections_request ->
+    ( list_connections_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves a list of connections from the account.\n"]
 
@@ -1922,6 +2239,13 @@ module ListEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     list_endpoints_request ->
     ( list_endpoints_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_endpoints_request ->
+    ( list_endpoints_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
 end
@@ -1942,6 +2266,13 @@ module ListEventBuses : sig
     ( list_event_buses_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_event_buses_request ->
+    ( list_event_buses_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all the event buses in your account, including the default event bus, custom event buses, \
@@ -1958,6 +2289,15 @@ module ListEventSources : sig
     'http_type Smaws_Lib.Context.t ->
     list_event_sources_request ->
     ( list_event_sources_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_event_sources_request ->
+    ( list_event_sources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception ] )
@@ -1985,6 +2325,16 @@ module ListPartnerEventSourceAccounts : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_partner_event_source_accounts_request ->
+    ( list_partner_event_source_accounts_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "An SaaS partner can use this operation to display the Amazon Web Services account ID that a \
@@ -2006,6 +2356,15 @@ module ListPartnerEventSources : sig
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_partner_event_sources_request ->
+    ( list_partner_event_sources_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "An SaaS partner can use this operation to list all the partner event source names that they \
@@ -2019,6 +2378,13 @@ module ListReplays : sig
     'http_type Smaws_Lib.Context.t ->
     list_replays_request ->
     ( list_replays_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_replays_request ->
+    ( list_replays_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
 end
@@ -2041,6 +2407,15 @@ module ListRuleNamesByTarget : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rule_names_by_target_request ->
+    ( list_rule_names_by_target_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the rules for the specified target. You can see which of the rules in Amazon EventBridge \
@@ -2059,6 +2434,15 @@ module ListRules : sig
     'http_type Smaws_Lib.Context.t ->
     list_rules_request ->
     ( list_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rules_request ->
+    ( list_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -2088,6 +2472,15 @@ module ListTagsForResource : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Displays the tags associated with an EventBridge resource. In EventBridge, rules and event \
@@ -2108,6 +2501,15 @@ module ListTargetsByRule : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_targets_by_rule_request ->
+    ( list_targets_by_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the targets assigned to the specified rule.\n\n\
@@ -2122,6 +2524,13 @@ module PutEvents : sig
     'http_type Smaws_Lib.Context.t ->
     put_events_request ->
     ( put_events_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_events_request ->
+    ( put_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
 end
@@ -2156,6 +2565,15 @@ module PutPartnerEvents : sig
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_partner_events_request ->
+    ( put_partner_events_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "This is used by SaaS partners to write events to a customer's partner event bus. Amazon Web \
@@ -2179,6 +2597,18 @@ module PutPermission : sig
     'http_type Smaws_Lib.Context.t ->
     put_permission_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `PolicyLengthExceededException of policy_length_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_permission_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -2225,6 +2655,19 @@ module PutRule : sig
     'http_type Smaws_Lib.Context.t ->
     put_rule_request ->
     ( put_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_rule_request ->
+    ( put_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -2310,6 +2753,18 @@ module PutTargets : sig
     'http_type Smaws_Lib.Context.t ->
     put_targets_request ->
     ( put_targets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_targets_request ->
+    ( put_targets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -2452,6 +2907,17 @@ module RemovePermission : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_permission_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Revokes the permission of another Amazon Web Services account to be able to put events to the \
@@ -2473,6 +2939,17 @@ module RemoveTargets : sig
     'http_type Smaws_Lib.Context.t ->
     remove_targets_request ->
     ( remove_targets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_targets_request ->
+    ( remove_targets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -2517,6 +2994,18 @@ module StartReplay : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_replay_request ->
+    ( start_replay_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the specified replay. Events are not necessarily replayed in the exact same order that \
@@ -2541,6 +3030,17 @@ module TagResource : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resource_request ->
     ( tag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -2579,6 +3079,15 @@ module TestEventPattern : sig
       | `InternalException of internal_exception
       | `InvalidEventPatternException of invalid_event_pattern_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_event_pattern_request ->
+    ( test_event_pattern_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception ] )
+    result
 end
 [@@ocaml.doc
   "Tests whether the specified event pattern matches the provided event.\n\n\
@@ -2601,6 +3110,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -2631,6 +3151,17 @@ module UpdateApiDestination : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_api_destination_request ->
+    ( update_api_destination_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Updates an API destination.\n"]
 
@@ -2648,6 +3179,18 @@ module UpdateArchive : sig
     'http_type Smaws_Lib.Context.t ->
     update_archive_request ->
     ( update_archive_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_archive_request ->
+    ( update_archive_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -2681,6 +3224,19 @@ module UpdateConnection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_connection_request ->
+    ( update_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Updates settings for a connection.\n"]
 
@@ -2696,6 +3252,16 @@ module UpdateEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     update_endpoint_request ->
     ( update_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_endpoint_request ->
+    ( update_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -2722,6 +3288,17 @@ module UpdateEventBus : sig
     'http_type Smaws_Lib.Context.t ->
     update_event_bus_request ->
     ( update_event_bus_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_event_bus_request ->
+    ( update_event_bus_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception

--- a/sdks/eventbridge/operations.ml
+++ b/sdks/eventbridge/operations.ml
@@ -36,6 +36,13 @@ module ActivateEventSource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ActivateEventSource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : activate_event_source_request) =
+    let input = Json_serializers.activate_event_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ActivateEventSource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module CancelReplay = struct
@@ -69,6 +76,12 @@ module CancelReplay = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.CancelReplay" ~service ~context
       ~input ~output_deserializer:Json_deserializers.cancel_replay_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : cancel_replay_request) =
+    let input = Json_serializers.cancel_replay_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.CancelReplay" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.cancel_replay_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateApiDestination = struct
@@ -101,6 +114,13 @@ module CreateApiDestination = struct
     let input = Json_serializers.create_api_destination_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.CreateApiDestination" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.create_api_destination_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_api_destination_request) =
+    let input = Json_serializers.create_api_destination_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.CreateApiDestination"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_api_destination_response_of_yojson
       ~error_deserializer
 end
@@ -145,6 +165,12 @@ module CreateArchive = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.CreateArchive" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_archive_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_archive_request) =
+    let input = Json_serializers.create_archive_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.CreateArchive" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.create_archive_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateConnection = struct
@@ -184,6 +210,13 @@ module CreateConnection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.CreateConnection" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_connection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_connection_request) =
+    let input = Json_serializers.create_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.CreateConnection"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_connection_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateEndpoint = struct
@@ -213,6 +246,12 @@ module CreateEndpoint = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.CreateEndpoint" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_endpoint_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_endpoint_request) =
+    let input = Json_serializers.create_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.CreateEndpoint"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_endpoint_response_of_yojson ~error_deserializer
 end
 
 module CreateEventBus = struct
@@ -258,6 +297,13 @@ module CreateEventBus = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.CreateEventBus" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_event_bus_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_event_bus_request) =
+    let input = Json_serializers.create_event_bus_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.CreateEventBus"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_event_bus_response_of_yojson
+      ~error_deserializer
 end
 
 module CreatePartnerEventSource = struct
@@ -297,6 +343,13 @@ module CreatePartnerEventSource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_partner_event_source_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_partner_event_source_request) =
+    let input = Json_serializers.create_partner_event_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSEvents.CreatePartnerEventSource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_partner_event_source_response_of_yojson
+      ~error_deserializer
 end
 
 module DeactivateEventSource = struct
@@ -334,6 +387,13 @@ module DeactivateEventSource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DeactivateEventSource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deactivate_event_source_request) =
+    let input = Json_serializers.deactivate_event_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DeactivateEventSource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeauthorizeConnection = struct
@@ -363,6 +423,13 @@ module DeauthorizeConnection = struct
     let input = Json_serializers.deauthorize_connection_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DeauthorizeConnection" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.deauthorize_connection_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : deauthorize_connection_request) =
+    let input = Json_serializers.deauthorize_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DeauthorizeConnection"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.deauthorize_connection_response_of_yojson
       ~error_deserializer
 end
@@ -396,6 +463,13 @@ module DeleteApiDestination = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.delete_api_destination_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_api_destination_request) =
+    let input = Json_serializers.delete_api_destination_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DeleteApiDestination"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_api_destination_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteArchive = struct
@@ -425,6 +499,12 @@ module DeleteArchive = struct
     let input = Json_serializers.delete_archive_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DeleteArchive" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_archive_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_archive_request) =
+    let input = Json_serializers.delete_archive_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DeleteArchive" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.delete_archive_response_of_yojson
       ~error_deserializer
 end
 
@@ -456,6 +536,13 @@ module DeleteConnection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DeleteConnection" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_connection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_connection_request) =
+    let input = Json_serializers.delete_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DeleteConnection"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_connection_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteEndpoint = struct
@@ -486,6 +573,12 @@ module DeleteEndpoint = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DeleteEndpoint" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_endpoint_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_endpoint_request) =
+    let input = Json_serializers.delete_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DeleteEndpoint"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_endpoint_response_of_yojson ~error_deserializer
 end
 
 module DeleteEventBus = struct
@@ -511,6 +604,13 @@ module DeleteEventBus = struct
     let input = Json_serializers.delete_event_bus_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DeleteEventBus" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_event_bus_request) =
+    let input = Json_serializers.delete_event_bus_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DeleteEventBus"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -541,6 +641,13 @@ module DeletePartnerEventSource = struct
     let input = Json_serializers.delete_partner_event_source_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DeletePartnerEventSource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_partner_event_source_request) =
+    let input = Json_serializers.delete_partner_event_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSEvents.DeletePartnerEventSource" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -575,6 +682,12 @@ module DeleteRule = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DeleteRule" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_rule_request) =
+    let input = Json_serializers.delete_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DeleteRule" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DescribeApiDestination = struct
@@ -599,6 +712,13 @@ module DescribeApiDestination = struct
     let input = Json_serializers.describe_api_destination_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DescribeApiDestination" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_api_destination_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_api_destination_request) =
+    let input = Json_serializers.describe_api_destination_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DescribeApiDestination"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_api_destination_response_of_yojson
       ~error_deserializer
 end
@@ -631,6 +751,13 @@ module DescribeArchive = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DescribeArchive" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_archive_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_archive_request) =
+    let input = Json_serializers.describe_archive_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DescribeArchive"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_archive_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeConnection = struct
@@ -655,6 +782,13 @@ module DescribeConnection = struct
     let input = Json_serializers.describe_connection_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DescribeConnection" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_connection_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_connection_request) =
+    let input = Json_serializers.describe_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DescribeConnection"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_connection_response_of_yojson
       ~error_deserializer
 end
 
@@ -681,6 +815,13 @@ module DescribeEndpoint = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DescribeEndpoint" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_endpoint_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_endpoint_request) =
+    let input = Json_serializers.describe_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DescribeEndpoint"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_endpoint_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeEventBus = struct
@@ -705,6 +846,13 @@ module DescribeEventBus = struct
     let input = Json_serializers.describe_event_bus_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DescribeEventBus" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_event_bus_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_event_bus_request) =
+    let input = Json_serializers.describe_event_bus_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DescribeEventBus"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_event_bus_response_of_yojson
       ~error_deserializer
 end
 
@@ -734,6 +882,13 @@ module DescribeEventSource = struct
     let input = Json_serializers.describe_event_source_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DescribeEventSource" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_event_source_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_event_source_request) =
+    let input = Json_serializers.describe_event_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DescribeEventSource"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_event_source_response_of_yojson
       ~error_deserializer
 end
@@ -766,6 +921,13 @@ module DescribePartnerEventSource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.describe_partner_event_source_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_partner_event_source_request) =
+    let input = Json_serializers.describe_partner_event_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSEvents.DescribePartnerEventSource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_partner_event_source_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeReplay = struct
@@ -791,6 +953,12 @@ module DescribeReplay = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DescribeReplay" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_replay_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_replay_request) =
+    let input = Json_serializers.describe_replay_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DescribeReplay"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_replay_response_of_yojson ~error_deserializer
 end
 
 module DescribeRule = struct
@@ -815,6 +983,12 @@ module DescribeRule = struct
     let input = Json_serializers.describe_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DescribeRule" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_rule_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_rule_request) =
+    let input = Json_serializers.describe_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DescribeRule" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.describe_rule_response_of_yojson
       ~error_deserializer
 end
 
@@ -849,6 +1023,12 @@ module DisableRule = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.DisableRule" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disable_rule_request) =
+    let input = Json_serializers.disable_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.DisableRule" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module EnableRule = struct
@@ -882,6 +1062,12 @@ module EnableRule = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.EnableRule" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : enable_rule_request) =
+    let input = Json_serializers.enable_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.EnableRule" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module ListApiDestinations = struct
@@ -902,6 +1088,13 @@ module ListApiDestinations = struct
     let input = Json_serializers.list_api_destinations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListApiDestinations" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_api_destinations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_api_destinations_request) =
+    let input = Json_serializers.list_api_destinations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListApiDestinations"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_api_destinations_response_of_yojson
       ~error_deserializer
 end
@@ -929,6 +1122,12 @@ module ListArchives = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListArchives" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_archives_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_archives_request) =
+    let input = Json_serializers.list_archives_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListArchives" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_archives_response_of_yojson
+      ~error_deserializer
 end
 
 module ListConnections = struct
@@ -949,6 +1148,13 @@ module ListConnections = struct
     let input = Json_serializers.list_connections_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListConnections" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_connections_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_connections_request) =
+    let input = Json_serializers.list_connections_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListConnections"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_connections_response_of_yojson
       ~error_deserializer
 end
 
@@ -971,6 +1177,12 @@ module ListEndpoints = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListEndpoints" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_endpoints_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_endpoints_request) =
+    let input = Json_serializers.list_endpoints_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListEndpoints" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_endpoints_response_of_yojson
+      ~error_deserializer
 end
 
 module ListEventBuses = struct
@@ -991,6 +1203,13 @@ module ListEventBuses = struct
     let input = Json_serializers.list_event_buses_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListEventBuses" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_event_buses_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_event_buses_request) =
+    let input = Json_serializers.list_event_buses_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListEventBuses"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_event_buses_response_of_yojson
       ~error_deserializer
 end
 
@@ -1016,6 +1235,13 @@ module ListEventSources = struct
     let input = Json_serializers.list_event_sources_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListEventSources" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_event_sources_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_event_sources_request) =
+    let input = Json_serializers.list_event_sources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListEventSources"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_event_sources_response_of_yojson
       ~error_deserializer
 end
 
@@ -1047,6 +1273,13 @@ module ListPartnerEventSourceAccounts = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_partner_event_source_accounts_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_partner_event_source_accounts_request) =
+    let input = Json_serializers.list_partner_event_source_accounts_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSEvents.ListPartnerEventSourceAccounts" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_partner_event_source_accounts_response_of_yojson
+      ~error_deserializer
 end
 
 module ListPartnerEventSources = struct
@@ -1073,6 +1306,13 @@ module ListPartnerEventSources = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_partner_event_sources_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_partner_event_sources_request) =
+    let input = Json_serializers.list_partner_event_sources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSEvents.ListPartnerEventSources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_partner_event_sources_response_of_yojson
+      ~error_deserializer
 end
 
 module ListReplays = struct
@@ -1093,6 +1333,12 @@ module ListReplays = struct
     let input = Json_serializers.list_replays_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListReplays" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_replays_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_replays_request) =
+    let input = Json_serializers.list_replays_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListReplays" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_replays_response_of_yojson
+      ~error_deserializer
 end
 
 module ListRuleNamesByTarget = struct
@@ -1119,6 +1365,13 @@ module ListRuleNamesByTarget = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_rule_names_by_target_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_rule_names_by_target_request) =
+    let input = Json_serializers.list_rule_names_by_target_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListRuleNamesByTarget"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_rule_names_by_target_response_of_yojson
+      ~error_deserializer
 end
 
 module ListRules = struct
@@ -1143,6 +1396,12 @@ module ListRules = struct
     let input = Json_serializers.list_rules_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListRules" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_rules_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_rules_request) =
+    let input = Json_serializers.list_rules_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListRules" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_rules_response_of_yojson
+      ~error_deserializer
 end
 
 module ListTagsForResource = struct
@@ -1167,6 +1426,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListTagsForResource" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListTagsForResource"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
 end
@@ -1194,6 +1460,13 @@ module ListTargetsByRule = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.ListTargetsByRule" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_targets_by_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_targets_by_rule_request) =
+    let input = Json_serializers.list_targets_by_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.ListTargetsByRule"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_targets_by_rule_response_of_yojson
+      ~error_deserializer
 end
 
 module PutEvents = struct
@@ -1214,6 +1487,12 @@ module PutEvents = struct
     let input = Json_serializers.put_events_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.PutEvents" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_events_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : put_events_request) =
+    let input = Json_serializers.put_events_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.PutEvents" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.put_events_response_of_yojson
+      ~error_deserializer
 end
 
 module PutPartnerEvents = struct
@@ -1238,6 +1517,13 @@ module PutPartnerEvents = struct
     let input = Json_serializers.put_partner_events_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.PutPartnerEvents" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_partner_events_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_partner_events_request) =
+    let input = Json_serializers.put_partner_events_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.PutPartnerEvents"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_partner_events_response_of_yojson
       ~error_deserializer
 end
 
@@ -1276,6 +1562,12 @@ module PutPermission = struct
     let input = Json_serializers.put_permission_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.PutPermission" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_permission_request) =
+    let input = Json_serializers.put_permission_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.PutPermission" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1316,6 +1608,12 @@ module PutRule = struct
     let input = Json_serializers.put_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.PutRule" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_rule_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : put_rule_request) =
+    let input = Json_serializers.put_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.PutRule" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.put_rule_response_of_yojson
+      ~error_deserializer
 end
 
 module PutTargets = struct
@@ -1351,6 +1649,12 @@ module PutTargets = struct
     let input = Json_serializers.put_targets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.PutTargets" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_targets_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : put_targets_request) =
+    let input = Json_serializers.put_targets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.PutTargets" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.put_targets_response_of_yojson
+      ~error_deserializer
 end
 
 module RemovePermission = struct
@@ -1385,6 +1689,13 @@ module RemovePermission = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.RemovePermission" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : remove_permission_request) =
+    let input = Json_serializers.remove_permission_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.RemovePermission"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module RemoveTargets = struct
@@ -1417,6 +1728,12 @@ module RemoveTargets = struct
     let input = Json_serializers.remove_targets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.RemoveTargets" ~service ~context
       ~input ~output_deserializer:Json_deserializers.remove_targets_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : remove_targets_request) =
+    let input = Json_serializers.remove_targets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.RemoveTargets" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.remove_targets_response_of_yojson
       ~error_deserializer
 end
 
@@ -1454,6 +1771,12 @@ module StartReplay = struct
     let input = Json_serializers.start_replay_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.StartReplay" ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_replay_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : start_replay_request) =
+    let input = Json_serializers.start_replay_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.StartReplay" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.start_replay_response_of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -1486,6 +1809,12 @@ module TagResource = struct
     let input = Json_serializers.tag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.TagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.TagResource" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module TestEventPattern = struct
@@ -1510,6 +1839,13 @@ module TestEventPattern = struct
     let input = Json_serializers.test_event_pattern_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.TestEventPattern" ~service ~context
       ~input ~output_deserializer:Json_deserializers.test_event_pattern_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : test_event_pattern_request) =
+    let input = Json_serializers.test_event_pattern_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.TestEventPattern"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.test_event_pattern_response_of_yojson
       ~error_deserializer
 end
 
@@ -1544,6 +1880,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.UntagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.UntagResource" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateApiDestination = struct
@@ -1576,6 +1918,13 @@ module UpdateApiDestination = struct
     let input = Json_serializers.update_api_destination_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.UpdateApiDestination" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_api_destination_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_api_destination_request) =
+    let input = Json_serializers.update_api_destination_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.UpdateApiDestination"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_api_destination_response_of_yojson
       ~error_deserializer
 end
@@ -1614,6 +1963,12 @@ module UpdateArchive = struct
     let input = Json_serializers.update_archive_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.UpdateArchive" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_archive_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_archive_request) =
+    let input = Json_serializers.update_archive_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.UpdateArchive" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.update_archive_response_of_yojson
       ~error_deserializer
 end
 
@@ -1654,6 +2009,13 @@ module UpdateConnection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.UpdateConnection" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_connection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_connection_request) =
+    let input = Json_serializers.update_connection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.UpdateConnection"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_connection_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateEndpoint = struct
@@ -1684,6 +2046,12 @@ module UpdateEndpoint = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.UpdateEndpoint" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_endpoint_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_endpoint_request) =
+    let input = Json_serializers.update_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.UpdateEndpoint"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_endpoint_response_of_yojson ~error_deserializer
 end
 
 module UpdateEventBus = struct
@@ -1717,5 +2085,12 @@ module UpdateEventBus = struct
     let input = Json_serializers.update_event_bus_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSEvents.UpdateEventBus" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_event_bus_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_event_bus_request) =
+    let input = Json_serializers.update_event_bus_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSEvents.UpdateEventBus"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_event_bus_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/eventbridge/operations.mli
+++ b/sdks/eventbridge/operations.mli
@@ -31,7 +31,8 @@ module ActivateEventSource : sig
       | `InternalException of internal_exception
       | `InvalidStateException of invalid_state_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -66,7 +67,8 @@ module CancelReplay : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `IllegalStatusException of illegal_status_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Cancels the specified replay.\n"]
@@ -99,7 +101,8 @@ module CreateApiDestination : sig
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -146,7 +149,8 @@ module CreateArchive : sig
       | `InvalidEventPatternException of invalid_event_pattern_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -199,7 +203,8 @@ module CreateConnection : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -235,7 +240,8 @@ module CreateEndpoint : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -283,7 +289,8 @@ module CreateEventBus : sig
       | `LimitExceededException of limit_exceeded_exception
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -322,7 +329,8 @@ module CreatePartnerEventSource : sig
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -400,7 +408,8 @@ module DeactivateEventSource : sig
       | `InternalException of internal_exception
       | `InvalidStateException of invalid_state_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -438,7 +447,8 @@ module DeauthorizeConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -470,7 +480,8 @@ module DeleteApiDestination : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified API destination.\n"]
@@ -500,7 +511,8 @@ module DeleteArchive : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified archive.\n"]
@@ -530,7 +542,8 @@ module DeleteConnection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a connection.\n"]
@@ -560,7 +573,8 @@ module DeleteEndpoint : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -591,7 +605,8 @@ module DeleteEventBus : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
-      | `InternalException of internal_exception ] )
+      | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -623,7 +638,8 @@ module DeletePartnerEventSource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `OperationDisabledException of operation_disabled_exception ] )
+      | `OperationDisabledException of operation_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -663,7 +679,8 @@ module DeleteRule : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -705,7 +722,8 @@ module DescribeApiDestination : sig
     ( describe_api_destination_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves details about an API destination.\n"]
@@ -735,7 +753,8 @@ module DescribeArchive : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves details about an archive.\n"]
@@ -762,7 +781,8 @@ module DescribeConnection : sig
     ( describe_connection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves details about a connection.\n"]
@@ -789,7 +809,8 @@ module DescribeEndpoint : sig
     ( describe_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -821,7 +842,8 @@ module DescribeEventBus : sig
     ( describe_event_bus_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -861,7 +883,8 @@ module DescribeEventSource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -892,7 +915,8 @@ module DescribePartnerEventSource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -924,7 +948,8 @@ module DescribeReplay : sig
     ( describe_replay_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -959,7 +984,8 @@ module DescribeRule : sig
     ( describe_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -997,7 +1023,8 @@ module DisableRule : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1035,7 +1062,8 @@ module EnableRule : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1059,7 +1087,8 @@ module ListApiDestinations : sig
     'http_type Smaws_Lib.Context.t ->
     list_api_destinations_request ->
     ( list_api_destinations_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of API destination in the account in the current Region.\n"]
@@ -1086,7 +1115,8 @@ module ListArchives : sig
     ( list_archives_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1108,7 +1138,8 @@ module ListConnections : sig
     'http_type Smaws_Lib.Context.t ->
     list_connections_request ->
     ( list_connections_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of connections from the account.\n"]
@@ -1128,7 +1159,8 @@ module ListEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     list_endpoints_request ->
     ( list_endpoints_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1153,7 +1185,8 @@ module ListEventBuses : sig
     'http_type Smaws_Lib.Context.t ->
     list_event_buses_request ->
     ( list_event_buses_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1182,7 +1215,8 @@ module ListEventSources : sig
     ( list_event_sources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `OperationDisabledException of operation_disabled_exception ] )
+      | `OperationDisabledException of operation_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1215,7 +1249,8 @@ module ListPartnerEventSourceAccounts : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1245,7 +1280,8 @@ module ListPartnerEventSources : sig
     ( list_partner_event_sources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `OperationDisabledException of operation_disabled_exception ] )
+      | `OperationDisabledException of operation_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1267,7 +1303,8 @@ module ListReplays : sig
     'http_type Smaws_Lib.Context.t ->
     list_replays_request ->
     ( list_replays_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1296,7 +1333,8 @@ module ListRuleNamesByTarget : sig
     ( list_rule_names_by_target_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1327,7 +1365,8 @@ module ListRules : sig
     ( list_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1361,7 +1400,8 @@ module ListTagsForResource : sig
     ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1390,7 +1430,8 @@ module ListTargetsByRule : sig
     ( list_targets_by_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1413,7 +1454,8 @@ module PutEvents : sig
     'http_type Smaws_Lib.Context.t ->
     put_events_request ->
     ( put_events_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1454,7 +1496,8 @@ module PutPartnerEvents : sig
     ( put_partner_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `OperationDisabledException of operation_disabled_exception ] )
+      | `OperationDisabledException of operation_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1496,7 +1539,8 @@ module PutPermission : sig
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
       | `PolicyLengthExceededException of policy_length_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1556,7 +1600,8 @@ module PutRule : sig
       | `InvalidEventPatternException of invalid_event_pattern_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1652,7 +1697,8 @@ module PutTargets : sig
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1798,7 +1844,8 @@ module RemovePermission : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1836,7 +1883,8 @@ module RemoveTargets : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1886,7 +1934,8 @@ module StartReplay : sig
       | `InvalidEventPatternException of invalid_event_pattern_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1927,7 +1976,8 @@ module TagResource : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1968,7 +2018,8 @@ module TestEventPattern : sig
     ( test_event_pattern_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
-      | `InvalidEventPatternException of invalid_event_pattern_exception ] )
+      | `InvalidEventPatternException of invalid_event_pattern_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2007,7 +2058,8 @@ module UntagResource : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `ManagedRuleException of managed_rule_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2042,7 +2094,8 @@ module UpdateApiDestination : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an API destination.\n"]
@@ -2078,7 +2131,8 @@ module UpdateArchive : sig
       | `InternalException of internal_exception
       | `InvalidEventPatternException of invalid_event_pattern_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the specified archive.\n"]
@@ -2117,7 +2171,8 @@ module UpdateConnection : sig
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates settings for a connection.\n"]
@@ -2147,7 +2202,8 @@ module UpdateEndpoint : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2184,7 +2240,8 @@ module UpdateEventBus : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the specified event bus.\n"]

--- a/sdks/eventbridge/operations.mli
+++ b/sdks/eventbridge/operations.mli
@@ -21,6 +21,18 @@ module ActivateEventSource : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    activate_event_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidStateException of invalid_state_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Activates a partner event source that has been deactivated. Once activated, your matching event \
@@ -45,6 +57,17 @@ module CancelReplay : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_replay_request ->
+    ( cancel_replay_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `IllegalStatusException of illegal_status_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Cancels the specified replay.\n"]
 
@@ -61,6 +84,17 @@ module CreateApiDestination : sig
     'http_type Smaws_Lib.Context.t ->
     create_api_destination_request ->
     ( create_api_destination_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_api_destination_request ->
+    ( create_api_destination_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -93,6 +127,19 @@ module CreateArchive : sig
     'http_type Smaws_Lib.Context.t ->
     create_archive_request ->
     ( create_archive_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_archive_request ->
+    ( create_archive_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -141,6 +188,19 @@ module CreateConnection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_connection_request ->
+    ( create_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a connection. A connection defines the authorization type and credentials to use for \
@@ -162,6 +222,16 @@ module CreateEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     create_endpoint_request ->
     ( create_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_endpoint_request ->
+    ( create_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -201,6 +271,20 @@ module CreateEventBus : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_event_bus_request ->
+    ( create_event_bus_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidStateException of invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new event bus within your account. This can be a custom event bus which you can use \
@@ -221,6 +305,18 @@ module CreatePartnerEventSource : sig
     'http_type Smaws_Lib.Context.t ->
     create_partner_event_source_request ->
     ( create_partner_event_source_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_partner_event_source_request ->
+    ( create_partner_event_source_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -294,6 +390,18 @@ module DeactivateEventSource : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deactivate_event_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidStateException of invalid_state_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "You can use this operation to temporarily stop receiving events from the specified partner \
@@ -322,6 +430,16 @@ module DeauthorizeConnection : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deauthorize_connection_request ->
+    ( deauthorize_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes all authorization parameters from the connection. This lets you remove the secret from \
@@ -339,6 +457,16 @@ module DeleteApiDestination : sig
     'http_type Smaws_Lib.Context.t ->
     delete_api_destination_request ->
     ( delete_api_destination_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_api_destination_request ->
+    ( delete_api_destination_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -364,6 +492,16 @@ module DeleteArchive : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_archive_request ->
+    ( delete_archive_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified archive.\n"]
 
@@ -384,6 +522,16 @@ module DeleteConnection : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_connection_request ->
+    ( delete_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a connection.\n"]
 
@@ -399,6 +547,16 @@ module DeleteEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     delete_endpoint_request ->
     ( delete_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_endpoint_request ->
+    ( delete_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -426,6 +584,15 @@ module DeleteEventBus : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_event_bus_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified custom event bus or partner event bus. All rules associated with this \
@@ -443,6 +610,16 @@ module DeletePartnerEventSource : sig
     'http_type Smaws_Lib.Context.t ->
     delete_partner_event_source_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_partner_event_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -471,6 +648,17 @@ module DeleteRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -510,6 +698,15 @@ module DescribeApiDestination : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_api_destination_request ->
+    ( describe_api_destination_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves details about an API destination.\n"]
 
@@ -525,6 +722,16 @@ module DescribeArchive : sig
     'http_type Smaws_Lib.Context.t ->
     describe_archive_request ->
     ( describe_archive_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_archive_request ->
+    ( describe_archive_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
@@ -548,6 +755,15 @@ module DescribeConnection : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_connection_request ->
+    ( describe_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves details about a connection.\n"]
 
@@ -562,6 +778,15 @@ module DescribeEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     describe_endpoint_request ->
     ( describe_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_endpoint_request ->
+    ( describe_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -585,6 +810,15 @@ module DescribeEventBus : sig
     'http_type Smaws_Lib.Context.t ->
     describe_event_bus_request ->
     ( describe_event_bus_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_event_bus_request ->
+    ( describe_event_bus_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -619,6 +853,16 @@ module DescribeEventSource : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_event_source_request ->
+    ( describe_event_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "This operation lists details about a partner event source that is shared with your account.\n"]
@@ -635,6 +879,16 @@ module DescribePartnerEventSource : sig
     'http_type Smaws_Lib.Context.t ->
     describe_partner_event_source_request ->
     ( describe_partner_event_source_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_partner_event_source_request ->
+    ( describe_partner_event_source_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception
@@ -659,6 +913,15 @@ module DescribeReplay : sig
     'http_type Smaws_Lib.Context.t ->
     describe_replay_request ->
     ( describe_replay_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_replay_request ->
+    ( describe_replay_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -689,6 +952,15 @@ module DescribeRule : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_rule_request ->
+    ( describe_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Describes the specified rule.\n\n\
@@ -710,6 +982,17 @@ module DisableRule : sig
     'http_type Smaws_Lib.Context.t ->
     disable_rule_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -743,6 +1026,17 @@ module EnableRule : sig
       | `ManagedRuleException of managed_rule_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_rule_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables the specified rule. If the rule does not exist, the operation fails.\n\n\
@@ -758,6 +1052,13 @@ module ListApiDestinations : sig
     'http_type Smaws_Lib.Context.t ->
     list_api_destinations_request ->
     ( list_api_destinations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_api_destinations_request ->
+    ( list_api_destinations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
 end
@@ -778,6 +1079,15 @@ module ListArchives : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_archives_request ->
+    ( list_archives_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists your archives. You can either list all the archives or you can provide a prefix to match \
@@ -793,6 +1103,13 @@ module ListConnections : sig
     ( list_connections_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_connections_request ->
+    ( list_connections_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves a list of connections from the account.\n"]
 
@@ -804,6 +1121,13 @@ module ListEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     list_endpoints_request ->
     ( list_endpoints_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_endpoints_request ->
+    ( list_endpoints_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
 end
@@ -824,6 +1148,13 @@ module ListEventBuses : sig
     ( list_event_buses_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_event_buses_request ->
+    ( list_event_buses_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all the event buses in your account, including the default event bus, custom event buses, \
@@ -840,6 +1171,15 @@ module ListEventSources : sig
     'http_type Smaws_Lib.Context.t ->
     list_event_sources_request ->
     ( list_event_sources_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_event_sources_request ->
+    ( list_event_sources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception ] )
@@ -867,6 +1207,16 @@ module ListPartnerEventSourceAccounts : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_partner_event_source_accounts_request ->
+    ( list_partner_event_source_accounts_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "An SaaS partner can use this operation to display the Amazon Web Services account ID that a \
@@ -888,6 +1238,15 @@ module ListPartnerEventSources : sig
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_partner_event_sources_request ->
+    ( list_partner_event_sources_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "An SaaS partner can use this operation to list all the partner event source names that they \
@@ -901,6 +1260,13 @@ module ListReplays : sig
     'http_type Smaws_Lib.Context.t ->
     list_replays_request ->
     ( list_replays_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_replays_request ->
+    ( list_replays_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
 end
@@ -923,6 +1289,15 @@ module ListRuleNamesByTarget : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rule_names_by_target_request ->
+    ( list_rule_names_by_target_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the rules for the specified target. You can see which of the rules in Amazon EventBridge \
@@ -941,6 +1316,15 @@ module ListRules : sig
     'http_type Smaws_Lib.Context.t ->
     list_rules_request ->
     ( list_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rules_request ->
+    ( list_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -970,6 +1354,15 @@ module ListTagsForResource : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Displays the tags associated with an EventBridge resource. In EventBridge, rules and event \
@@ -990,6 +1383,15 @@ module ListTargetsByRule : sig
       | `InternalException of internal_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_targets_by_rule_request ->
+    ( list_targets_by_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the targets assigned to the specified rule.\n\n\
@@ -1004,6 +1406,13 @@ module PutEvents : sig
     'http_type Smaws_Lib.Context.t ->
     put_events_request ->
     ( put_events_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_events_request ->
+    ( put_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalException of internal_exception ] )
     result
 end
@@ -1038,6 +1447,15 @@ module PutPartnerEvents : sig
       | `InternalException of internal_exception
       | `OperationDisabledException of operation_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_partner_events_request ->
+    ( put_partner_events_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "This is used by SaaS partners to write events to a customer's partner event bus. Amazon Web \
@@ -1061,6 +1479,18 @@ module PutPermission : sig
     'http_type Smaws_Lib.Context.t ->
     put_permission_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `PolicyLengthExceededException of policy_length_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_permission_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1107,6 +1537,19 @@ module PutRule : sig
     'http_type Smaws_Lib.Context.t ->
     put_rule_request ->
     ( put_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_rule_request ->
+    ( put_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1192,6 +1635,18 @@ module PutTargets : sig
     'http_type Smaws_Lib.Context.t ->
     put_targets_request ->
     ( put_targets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_targets_request ->
+    ( put_targets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1334,6 +1789,17 @@ module RemovePermission : sig
       | `OperationDisabledException of operation_disabled_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_permission_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Revokes the permission of another Amazon Web Services account to be able to put events to the \
@@ -1355,6 +1821,17 @@ module RemoveTargets : sig
     'http_type Smaws_Lib.Context.t ->
     remove_targets_request ->
     ( remove_targets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_targets_request ->
+    ( remove_targets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1399,6 +1876,18 @@ module StartReplay : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_replay_request ->
+    ( start_replay_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the specified replay. Events are not necessarily replayed in the exact same order that \
@@ -1423,6 +1912,17 @@ module TagResource : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resource_request ->
     ( tag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1461,6 +1961,15 @@ module TestEventPattern : sig
       | `InternalException of internal_exception
       | `InvalidEventPatternException of invalid_event_pattern_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_event_pattern_request ->
+    ( test_event_pattern_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception ] )
+    result
 end
 [@@ocaml.doc
   "Tests whether the specified event pattern matches the provided event.\n\n\
@@ -1483,6 +1992,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ManagedRuleException of managed_rule_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1513,6 +2033,17 @@ module UpdateApiDestination : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_api_destination_request ->
+    ( update_api_destination_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Updates an API destination.\n"]
 
@@ -1530,6 +2061,18 @@ module UpdateArchive : sig
     'http_type Smaws_Lib.Context.t ->
     update_archive_request ->
     ( update_archive_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `InvalidEventPatternException of invalid_event_pattern_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_archive_request ->
+    ( update_archive_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1563,6 +2106,19 @@ module UpdateConnection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_connection_request ->
+    ( update_connection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Updates settings for a connection.\n"]
 
@@ -1578,6 +2134,16 @@ module UpdateEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     update_endpoint_request ->
     ( update_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_endpoint_request ->
+    ( update_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception
@@ -1603,6 +2169,17 @@ module UpdateEventBus : sig
     'http_type Smaws_Lib.Context.t ->
     update_event_bus_request ->
     ( update_event_bus_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InternalException of internal_exception
+      | `OperationDisabledException of operation_disabled_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_event_bus_request ->
+    ( update_event_bus_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InternalException of internal_exception

--- a/sdks/fms/Smaws_Client_FMS.mli
+++ b/sdks/fms/Smaws_Client_FMS.mli
@@ -1089,6 +1089,18 @@ module AssociateAdminAccount : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_admin_account_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets a Firewall Manager default administrator account. The Firewall Manager default \
@@ -1114,6 +1126,17 @@ module AssociateThirdPartyFirewall : sig
     'http_type Smaws_Lib.Context.t ->
     associate_third_party_firewall_request ->
     ( associate_third_party_firewall_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_third_party_firewall_request ->
+    ( associate_third_party_firewall_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1147,6 +1170,18 @@ module BatchAssociateResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_associate_resource_request ->
+    ( batch_associate_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Associate resources to a Firewall Manager resource set.\n"]
 
@@ -1163,6 +1198,17 @@ module BatchDisassociateResource : sig
     'http_type Smaws_Lib.Context.t ->
     batch_disassociate_resource_request ->
     ( batch_disassociate_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_disassociate_resource_request ->
+    ( batch_disassociate_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1189,6 +1235,16 @@ module DeleteAppsList : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_apps_list_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager applications list.\n"]
 
@@ -1204,6 +1260,16 @@ module DeleteNotificationChannel : sig
     'http_type Smaws_Lib.Context.t ->
     delete_notification_channel_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_notification_channel_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -1235,6 +1301,18 @@ module DeletePolicy : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_policy_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager policy. \n"]
 
@@ -1250,6 +1328,16 @@ module DeleteProtocolsList : sig
     'http_type Smaws_Lib.Context.t ->
     delete_protocols_list_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_protocols_list_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -1277,6 +1365,17 @@ module DeleteResourceSet : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_set_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified [ResourceSet].\n"]
 
@@ -1292,6 +1391,16 @@ module DisassociateAdminAccount : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_admin_account_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_admin_account_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -1326,6 +1435,17 @@ module DisassociateThirdPartyFirewall : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_third_party_firewall_request ->
+    ( disassociate_third_party_firewall_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disassociates a Firewall Manager policy administrator from a third-party firewall tenant. When \
@@ -1344,6 +1464,16 @@ module GetAdminAccount : sig
     'http_type Smaws_Lib.Context.t ->
     get_admin_account_request ->
     ( get_admin_account_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_admin_account_request ->
+    ( get_admin_account_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -1375,6 +1505,18 @@ module GetAdminScope : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_admin_scope_request ->
+    ( get_admin_scope_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the specified account's administrative scope. The administrative \
@@ -1397,6 +1539,16 @@ module GetAppsList : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_apps_list_request ->
+    ( get_apps_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager applications list.\n"]
 
@@ -1413,6 +1565,17 @@ module GetComplianceDetail : sig
     'http_type Smaws_Lib.Context.t ->
     get_compliance_detail_request ->
     ( get_compliance_detail_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_detail_request ->
+    ( get_compliance_detail_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1444,6 +1607,16 @@ module GetNotificationChannel : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_notification_channel_request ->
+    ( get_notification_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Information about the Amazon Simple Notification Service (SNS) topic that is used to record \
@@ -1468,6 +1641,17 @@ module GetPolicy : sig
       | `InvalidTypeException of invalid_type_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_policy_request ->
+    ( get_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidTypeException of invalid_type_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager policy.\n"]
 
@@ -1483,6 +1667,16 @@ module GetProtectionStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_protection_status_request ->
     ( get_protection_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_protection_status_request ->
+    ( get_protection_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1510,6 +1704,16 @@ module GetProtocolsList : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_protocols_list_request ->
+    ( get_protocols_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager protocols list.\n"]
 
@@ -1526,6 +1730,17 @@ module GetResourceSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_set_request ->
     ( get_resource_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_set_request ->
+    ( get_resource_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1554,6 +1769,17 @@ module GetThirdPartyFirewallAssociationStatus : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_third_party_firewall_association_status_request ->
+    ( get_third_party_firewall_association_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "The onboarding status of a Firewall Manager admin account to third-party firewall vendor tenant.\n"]
@@ -1570,6 +1796,16 @@ module GetViolationDetails : sig
     'http_type Smaws_Lib.Context.t ->
     get_violation_details_request ->
     ( get_violation_details_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_violation_details_request ->
+    ( get_violation_details_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1599,6 +1835,17 @@ module ListAdminAccountsForOrganization : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_admin_accounts_for_organization_request ->
+    ( list_admin_accounts_for_organization_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a [AdminAccounts] object that lists the Firewall Manager administrators within the \
@@ -1618,6 +1865,16 @@ module ListAdminsManagingAccount : sig
     'http_type Smaws_Lib.Context.t ->
     list_admins_managing_account_request ->
     ( list_admins_managing_account_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_admins_managing_account_request ->
+    ( list_admins_managing_account_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1649,6 +1906,17 @@ module ListAppsLists : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_apps_lists_request ->
+    ( list_apps_lists_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns an array of [AppsListDataSummary] objects.\n"]
 
@@ -1663,6 +1931,15 @@ module ListComplianceStatus : sig
     'http_type Smaws_Lib.Context.t ->
     list_compliance_status_request ->
     ( list_compliance_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_compliance_status_request ->
+    ( list_compliance_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -1689,6 +1966,16 @@ module ListDiscoveredResources : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_discovered_resources_request ->
+    ( list_discovered_resources_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an array of resources in the organization's accounts that are available to be \
@@ -1705,6 +1992,15 @@ module ListMemberAccounts : sig
     'http_type Smaws_Lib.Context.t ->
     list_member_accounts_request ->
     ( list_member_accounts_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_member_accounts_request ->
+    ( list_member_accounts_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -1736,6 +2032,17 @@ module ListPolicies : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_policies_request ->
+    ( list_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns an array of [PolicySummary] objects.\n"]
 
@@ -1751,6 +2058,16 @@ module ListProtocolsLists : sig
     'http_type Smaws_Lib.Context.t ->
     list_protocols_lists_request ->
     ( list_protocols_lists_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_protocols_lists_request ->
+    ( list_protocols_lists_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -1778,6 +2095,17 @@ module ListResourceSetResources : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_set_resources_request ->
+    ( list_resource_set_resources_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns an array of resources that are currently associated to a resource set.\n"]
 
@@ -1793,6 +2121,16 @@ module ListResourceSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_resource_sets_request ->
     ( list_resource_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_sets_request ->
+    ( list_resource_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1814,6 +2152,17 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1842,6 +2191,17 @@ module ListThirdPartyFirewallFirewallPolicies : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_third_party_firewall_firewall_policies_request ->
+    ( list_third_party_firewall_firewall_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of all of the third-party firewall policies that are associated with the \
@@ -1860,6 +2220,17 @@ module PutAdminAccount : sig
     'http_type Smaws_Lib.Context.t ->
     put_admin_account_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_admin_account_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1899,6 +2270,18 @@ module PutAppsList : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_apps_list_request ->
+    ( put_apps_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Creates an Firewall Manager applications list.\n"]
 
@@ -1914,6 +2297,16 @@ module PutNotificationChannel : sig
     'http_type Smaws_Lib.Context.t ->
     put_notification_channel_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_notification_channel_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -1947,6 +2340,19 @@ module PutPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     put_policy_request ->
     ( put_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidTypeException of invalid_type_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_policy_request ->
+    ( put_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -2039,6 +2445,18 @@ module PutProtocolsList : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_protocols_list_request ->
+    ( put_protocols_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Creates an Firewall Manager protocols list.\n"]
 
@@ -2055,6 +2473,17 @@ module PutResourceSet : sig
     'http_type Smaws_Lib.Context.t ->
     put_resource_set_request ->
     ( put_resource_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_set_request ->
+    ( put_resource_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -2089,6 +2518,18 @@ module TagResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Adds one or more tags to an Amazon Web Services resource.\n"]
 
@@ -2106,6 +2547,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception

--- a/sdks/fms/Smaws_Client_FMS.mli
+++ b/sdks/fms/Smaws_Client_FMS.mli
@@ -1099,7 +1099,8 @@ module AssociateAdminAccount : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1141,7 +1142,8 @@ module AssociateThirdPartyFirewall : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1180,7 +1182,8 @@ module BatchAssociateResource : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Associate resources to a Firewall Manager resource set.\n"]
@@ -1213,7 +1216,8 @@ module BatchDisassociateResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Disassociates resources from a Firewall Manager resource set.\n"]
@@ -1243,7 +1247,8 @@ module DeleteAppsList : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager applications list.\n"]
@@ -1273,7 +1278,8 @@ module DeleteNotificationChannel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1311,7 +1317,8 @@ module DeletePolicy : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager policy. \n"]
@@ -1341,7 +1348,8 @@ module DeleteProtocolsList : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager protocols list.\n"]
@@ -1374,7 +1382,8 @@ module DeleteResourceSet : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified [ResourceSet].\n"]
@@ -1404,7 +1413,8 @@ module DisassociateAdminAccount : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1444,7 +1454,8 @@ module DisassociateThirdPartyFirewall : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1477,7 +1488,8 @@ module GetAdminAccount : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1515,7 +1527,8 @@ module GetAdminScope : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1547,7 +1560,8 @@ module GetAppsList : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager applications list.\n"]
@@ -1580,7 +1594,8 @@ module GetComplianceDetail : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1615,7 +1630,8 @@ module GetNotificationChannel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1650,7 +1666,8 @@ module GetPolicy : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidTypeException of invalid_type_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager policy.\n"]
@@ -1680,7 +1697,8 @@ module GetProtectionStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1712,7 +1730,8 @@ module GetProtocolsList : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager protocols list.\n"]
@@ -1745,7 +1764,8 @@ module GetResourceSet : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about a specific resource set.\n"]
@@ -1778,7 +1798,8 @@ module GetThirdPartyFirewallAssociationStatus : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1809,7 +1830,8 @@ module GetViolationDetails : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1844,7 +1866,8 @@ module ListAdminAccountsForOrganization : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1878,7 +1901,8 @@ module ListAdminsManagingAccount : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1915,7 +1939,8 @@ module ListAppsLists : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of [AppsListDataSummary] objects.\n"]
@@ -1942,7 +1967,8 @@ module ListComplianceStatus : sig
     ( list_compliance_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1974,7 +2000,8 @@ module ListDiscoveredResources : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `InvalidOperationException of invalid_operation_exception ] )
+      | `InvalidOperationException of invalid_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2003,7 +2030,8 @@ module ListMemberAccounts : sig
     ( list_member_accounts_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2041,7 +2069,8 @@ module ListPolicies : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of [PolicySummary] objects.\n"]
@@ -2071,7 +2100,8 @@ module ListProtocolsLists : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of [ProtocolsListDataSummary] objects.\n"]
@@ -2104,7 +2134,8 @@ module ListResourceSetResources : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of resources that are currently associated to a resource set.\n"]
@@ -2134,7 +2165,8 @@ module ListResourceSets : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `InvalidOperationException of invalid_operation_exception ] )
+      | `InvalidOperationException of invalid_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of [ResourceSetSummary] objects.\n"]
@@ -2167,7 +2199,8 @@ module ListTagsForResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the list of tags for the specified Amazon Web Services resource. \n"]
@@ -2200,7 +2233,8 @@ module ListThirdPartyFirewallFirewallPolicies : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2235,7 +2269,8 @@ module PutAdminAccount : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2280,7 +2315,8 @@ module PutAppsList : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates an Firewall Manager applications list.\n"]
@@ -2310,7 +2346,8 @@ module PutNotificationChannel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2359,7 +2396,8 @@ module PutPolicy : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidTypeException of invalid_type_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2455,7 +2493,8 @@ module PutProtocolsList : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates an Firewall Manager protocols list.\n"]
@@ -2488,7 +2527,8 @@ module PutResourceSet : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2528,7 +2568,8 @@ module TagResource : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds one or more tags to an Amazon Web Services resource.\n"]
@@ -2562,7 +2603,8 @@ module UntagResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes one or more tags from an Amazon Web Services resource.\n"]

--- a/sdks/fms/operations.ml
+++ b/sdks/fms/operations.ml
@@ -34,6 +34,13 @@ module AssociateAdminAccount = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.AssociateAdminAccount" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_admin_account_request) =
+    let input = Json_serializers.associate_admin_account_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.AssociateAdminAccount" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module AssociateThirdPartyFirewall = struct
@@ -65,6 +72,13 @@ module AssociateThirdPartyFirewall = struct
     let input = Json_serializers.associate_third_party_firewall_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.AssociateThirdPartyFirewall"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_third_party_firewall_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : associate_third_party_firewall_request) =
+    let input = Json_serializers.associate_third_party_firewall_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.AssociateThirdPartyFirewall" ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_third_party_firewall_response_of_yojson
       ~error_deserializer
 end
@@ -103,6 +117,13 @@ module BatchAssociateResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_associate_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_associate_resource_request) =
+    let input = Json_serializers.batch_associate_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.BatchAssociateResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_associate_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module BatchDisassociateResource = struct
@@ -136,6 +157,13 @@ module BatchDisassociateResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_disassociate_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_disassociate_resource_request) =
+    let input = Json_serializers.batch_disassociate_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.BatchDisassociateResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_disassociate_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteAppsList = struct
@@ -165,6 +193,13 @@ module DeleteAppsList = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.DeleteAppsList" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_apps_list_request) =
+    let input = Json_serializers.delete_apps_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.DeleteAppsList"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteNotificationChannel = struct
@@ -193,6 +228,13 @@ module DeleteNotificationChannel = struct
     let input = Json_serializers.delete_notification_channel_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.DeleteNotificationChannel"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_notification_channel_request) =
+    let input = Json_serializers.delete_notification_channel_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.DeleteNotificationChannel" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -230,6 +272,13 @@ module DeletePolicy = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.DeletePolicy" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_policy_request) =
+    let input = Json_serializers.delete_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.DeletePolicy"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteProtocolsList = struct
@@ -258,6 +307,13 @@ module DeleteProtocolsList = struct
     let input = Json_serializers.delete_protocols_list_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.DeleteProtocolsList" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_protocols_list_request) =
+    let input = Json_serializers.delete_protocols_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.DeleteProtocolsList" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -291,6 +347,13 @@ module DeleteResourceSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.DeleteResourceSet" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_resource_set_request) =
+    let input = Json_serializers.delete_resource_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.DeleteResourceSet" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DisassociateAdminAccount = struct
@@ -319,6 +382,13 @@ module DisassociateAdminAccount = struct
     let input = Json_serializers.disassociate_admin_account_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.DisassociateAdminAccount"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_admin_account_request) =
+    let input = Json_serializers.disassociate_admin_account_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.DisassociateAdminAccount" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -354,6 +424,13 @@ module DisassociateThirdPartyFirewall = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_third_party_firewall_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_third_party_firewall_request) =
+    let input = Json_serializers.disassociate_third_party_firewall_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.DisassociateThirdPartyFirewall" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_third_party_firewall_response_of_yojson
+      ~error_deserializer
 end
 
 module GetAdminAccount = struct
@@ -382,6 +459,13 @@ module GetAdminAccount = struct
     let input = Json_serializers.get_admin_account_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.GetAdminAccount" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_admin_account_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_admin_account_request) =
+    let input = Json_serializers.get_admin_account_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.GetAdminAccount"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_admin_account_response_of_yojson
       ~error_deserializer
 end
 
@@ -418,6 +502,12 @@ module GetAdminScope = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.GetAdminScope" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_admin_scope_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_admin_scope_request) =
+    let input = Json_serializers.get_admin_scope_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.GetAdminScope"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_admin_scope_response_of_yojson ~error_deserializer
 end
 
 module GetAppsList = struct
@@ -447,6 +537,12 @@ module GetAppsList = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.GetAppsList" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_apps_list_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_apps_list_request) =
+    let input = Json_serializers.get_apps_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.GetAppsList"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_apps_list_response_of_yojson ~error_deserializer
 end
 
 module GetComplianceDetail = struct
@@ -480,6 +576,13 @@ module GetComplianceDetail = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_compliance_detail_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_compliance_detail_request) =
+    let input = Json_serializers.get_compliance_detail_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.GetComplianceDetail" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_compliance_detail_response_of_yojson
+      ~error_deserializer
 end
 
 module GetNotificationChannel = struct
@@ -508,6 +611,13 @@ module GetNotificationChannel = struct
     let input = Json_serializers.get_notification_channel_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.GetNotificationChannel"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_notification_channel_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_notification_channel_request) =
+    let input = Json_serializers.get_notification_channel_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.GetNotificationChannel" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_notification_channel_response_of_yojson
       ~error_deserializer
 end
@@ -542,6 +652,12 @@ module GetPolicy = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.GetPolicy" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_policy_request) =
+    let input = Json_serializers.get_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.GetPolicy"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module GetProtectionStatus = struct
@@ -569,6 +685,13 @@ module GetProtectionStatus = struct
     let input = Json_serializers.get_protection_status_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.GetProtectionStatus" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_protection_status_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_protection_status_request) =
+    let input = Json_serializers.get_protection_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.GetProtectionStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_protection_status_response_of_yojson
       ~error_deserializer
 end
@@ -599,6 +722,13 @@ module GetProtocolsList = struct
     let input = Json_serializers.get_protocols_list_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.GetProtocolsList" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_protocols_list_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_protocols_list_request) =
+    let input = Json_serializers.get_protocols_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.GetProtocolsList"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_protocols_list_response_of_yojson
       ~error_deserializer
 end
 
@@ -631,6 +761,13 @@ module GetResourceSet = struct
     let input = Json_serializers.get_resource_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.GetResourceSet" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_resource_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_set_request) =
+    let input = Json_serializers.get_resource_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.GetResourceSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_set_response_of_yojson
       ~error_deserializer
 end
 
@@ -668,6 +805,17 @@ module GetThirdPartyFirewallAssociationStatus = struct
       ~output_deserializer:
         Json_deserializers.get_third_party_firewall_association_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_third_party_firewall_association_status_request)
+      =
+    let input =
+      Json_serializers.get_third_party_firewall_association_status_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.GetThirdPartyFirewallAssociationStatus" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_third_party_firewall_association_status_response_of_yojson
+      ~error_deserializer
 end
 
 module GetViolationDetails = struct
@@ -695,6 +843,13 @@ module GetViolationDetails = struct
     let input = Json_serializers.get_violation_details_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.GetViolationDetails" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_violation_details_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_violation_details_request) =
+    let input = Json_serializers.get_violation_details_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.GetViolationDetails" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_violation_details_response_of_yojson
       ~error_deserializer
 end
@@ -731,6 +886,14 @@ module ListAdminAccountsForOrganization = struct
       ~output_deserializer:
         Json_deserializers.list_admin_accounts_for_organization_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_admin_accounts_for_organization_request) =
+    let input = Json_serializers.list_admin_accounts_for_organization_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.ListAdminAccountsForOrganization" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.list_admin_accounts_for_organization_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAdminsManagingAccount = struct
@@ -758,6 +921,13 @@ module ListAdminsManagingAccount = struct
     let input = Json_serializers.list_admins_managing_account_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.ListAdminsManagingAccount"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_admins_managing_account_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_admins_managing_account_request) =
+    let input = Json_serializers.list_admins_managing_account_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.ListAdminsManagingAccount" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_admins_managing_account_response_of_yojson
       ~error_deserializer
 end
@@ -792,6 +962,12 @@ module ListAppsLists = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.ListAppsLists" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_apps_lists_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_apps_lists_request) =
+    let input = Json_serializers.list_apps_lists_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.ListAppsLists"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_apps_lists_response_of_yojson ~error_deserializer
 end
 
 module ListComplianceStatus = struct
@@ -816,6 +992,13 @@ module ListComplianceStatus = struct
     let input = Json_serializers.list_compliance_status_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.ListComplianceStatus" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_compliance_status_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_compliance_status_request) =
+    let input = Json_serializers.list_compliance_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.ListComplianceStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_compliance_status_response_of_yojson
       ~error_deserializer
 end
@@ -847,6 +1030,13 @@ module ListDiscoveredResources = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_discovered_resources_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_discovered_resources_request) =
+    let input = Json_serializers.list_discovered_resources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.ListDiscoveredResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_discovered_resources_response_of_yojson
+      ~error_deserializer
 end
 
 module ListMemberAccounts = struct
@@ -871,6 +1061,13 @@ module ListMemberAccounts = struct
     let input = Json_serializers.list_member_accounts_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.ListMemberAccounts" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_member_accounts_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_member_accounts_request) =
+    let input = Json_serializers.list_member_accounts_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.ListMemberAccounts" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_member_accounts_response_of_yojson
       ~error_deserializer
 end
@@ -905,6 +1102,12 @@ module ListPolicies = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.ListPolicies" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_policies_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_policies_request) =
+    let input = Json_serializers.list_policies_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.ListPolicies"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_policies_response_of_yojson ~error_deserializer
 end
 
 module ListProtocolsLists = struct
@@ -933,6 +1136,13 @@ module ListProtocolsLists = struct
     let input = Json_serializers.list_protocols_lists_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.ListProtocolsLists" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_protocols_lists_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_protocols_lists_request) =
+    let input = Json_serializers.list_protocols_lists_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.ListProtocolsLists" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_protocols_lists_response_of_yojson
       ~error_deserializer
 end
@@ -968,6 +1178,13 @@ module ListResourceSetResources = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_resource_set_resources_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_resource_set_resources_request) =
+    let input = Json_serializers.list_resource_set_resources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.ListResourceSetResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resource_set_resources_response_of_yojson
+      ~error_deserializer
 end
 
 module ListResourceSets = struct
@@ -995,6 +1212,13 @@ module ListResourceSets = struct
     let input = Json_serializers.list_resource_sets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.ListResourceSets" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_resource_sets_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_resource_sets_request) =
+    let input = Json_serializers.list_resource_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.ListResourceSets"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resource_sets_response_of_yojson
       ~error_deserializer
 end
 
@@ -1027,6 +1251,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.ListTagsForResource" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
 end
@@ -1065,6 +1296,17 @@ module ListThirdPartyFirewallFirewallPolicies = struct
       ~output_deserializer:
         Json_deserializers.list_third_party_firewall_firewall_policies_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_third_party_firewall_firewall_policies_request)
+      =
+    let input =
+      Json_serializers.list_third_party_firewall_firewall_policies_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.ListThirdPartyFirewallFirewallPolicies" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.list_third_party_firewall_firewall_policies_response_of_yojson
+      ~error_deserializer
 end
 
 module PutAdminAccount = struct
@@ -1095,6 +1337,13 @@ module PutAdminAccount = struct
     let input = Json_serializers.put_admin_account_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.PutAdminAccount" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_admin_account_request) =
+    let input = Json_serializers.put_admin_account_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.PutAdminAccount"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1131,6 +1380,12 @@ module PutAppsList = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.PutAppsList" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_apps_list_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_apps_list_request) =
+    let input = Json_serializers.put_apps_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.PutAppsList"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_apps_list_response_of_yojson ~error_deserializer
 end
 
 module PutNotificationChannel = struct
@@ -1159,6 +1414,13 @@ module PutNotificationChannel = struct
     let input = Json_serializers.put_notification_channel_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.PutNotificationChannel"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_notification_channel_request) =
+    let input = Json_serializers.put_notification_channel_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSFMS_20180101.PutNotificationChannel" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -1199,6 +1461,12 @@ module PutPolicy = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.PutPolicy" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_policy_request) =
+    let input = Json_serializers.put_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.PutPolicy"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.put_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module PutProtocolsList = struct
@@ -1234,6 +1502,13 @@ module PutProtocolsList = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.PutProtocolsList" ~service
       ~context ~input ~output_deserializer:Json_deserializers.put_protocols_list_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_protocols_list_request) =
+    let input = Json_serializers.put_protocols_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.PutProtocolsList"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_protocols_list_response_of_yojson
+      ~error_deserializer
 end
 
 module PutResourceSet = struct
@@ -1264,6 +1539,13 @@ module PutResourceSet = struct
     let input = Json_serializers.put_resource_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.PutResourceSet" ~service
       ~context ~input ~output_deserializer:Json_deserializers.put_resource_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_resource_set_request) =
+    let input = Json_serializers.put_resource_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.PutResourceSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_resource_set_response_of_yojson
       ~error_deserializer
 end
 
@@ -1300,6 +1582,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.TagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1332,4 +1620,10 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSFMS_20180101.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSFMS_20180101.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end

--- a/sdks/fms/operations.mli
+++ b/sdks/fms/operations.mli
@@ -31,7 +31,8 @@ module AssociateAdminAccount : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -73,7 +74,8 @@ module AssociateThirdPartyFirewall : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -112,7 +114,8 @@ module BatchAssociateResource : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Associate resources to a Firewall Manager resource set.\n"]
@@ -145,7 +148,8 @@ module BatchDisassociateResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Disassociates resources from a Firewall Manager resource set.\n"]
@@ -175,7 +179,8 @@ module DeleteAppsList : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager applications list.\n"]
@@ -205,7 +210,8 @@ module DeleteNotificationChannel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -243,7 +249,8 @@ module DeletePolicy : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager policy. \n"]
@@ -273,7 +280,8 @@ module DeleteProtocolsList : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager protocols list.\n"]
@@ -306,7 +314,8 @@ module DeleteResourceSet : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified [ResourceSet].\n"]
@@ -336,7 +345,8 @@ module DisassociateAdminAccount : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -376,7 +386,8 @@ module DisassociateThirdPartyFirewall : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -409,7 +420,8 @@ module GetAdminAccount : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -447,7 +459,8 @@ module GetAdminScope : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -479,7 +492,8 @@ module GetAppsList : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager applications list.\n"]
@@ -512,7 +526,8 @@ module GetComplianceDetail : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -547,7 +562,8 @@ module GetNotificationChannel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -582,7 +598,8 @@ module GetPolicy : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidTypeException of invalid_type_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager policy.\n"]
@@ -612,7 +629,8 @@ module GetProtectionStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -644,7 +662,8 @@ module GetProtocolsList : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager protocols list.\n"]
@@ -677,7 +696,8 @@ module GetResourceSet : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about a specific resource set.\n"]
@@ -710,7 +730,8 @@ module GetThirdPartyFirewallAssociationStatus : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -741,7 +762,8 @@ module GetViolationDetails : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -776,7 +798,8 @@ module ListAdminAccountsForOrganization : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -810,7 +833,8 @@ module ListAdminsManagingAccount : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -847,7 +871,8 @@ module ListAppsLists : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of [AppsListDataSummary] objects.\n"]
@@ -874,7 +899,8 @@ module ListComplianceStatus : sig
     ( list_compliance_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -906,7 +932,8 @@ module ListDiscoveredResources : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `InvalidOperationException of invalid_operation_exception ] )
+      | `InvalidOperationException of invalid_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -935,7 +962,8 @@ module ListMemberAccounts : sig
     ( list_member_accounts_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -973,7 +1001,8 @@ module ListPolicies : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of [PolicySummary] objects.\n"]
@@ -1003,7 +1032,8 @@ module ListProtocolsLists : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of [ProtocolsListDataSummary] objects.\n"]
@@ -1036,7 +1066,8 @@ module ListResourceSetResources : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of resources that are currently associated to a resource set.\n"]
@@ -1066,7 +1097,8 @@ module ListResourceSets : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
-      | `InvalidOperationException of invalid_operation_exception ] )
+      | `InvalidOperationException of invalid_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of [ResourceSetSummary] objects.\n"]
@@ -1099,7 +1131,8 @@ module ListTagsForResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the list of tags for the specified Amazon Web Services resource. \n"]
@@ -1132,7 +1165,8 @@ module ListThirdPartyFirewallFirewallPolicies : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1167,7 +1201,8 @@ module PutAdminAccount : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1212,7 +1247,8 @@ module PutAppsList : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates an Firewall Manager applications list.\n"]
@@ -1242,7 +1278,8 @@ module PutNotificationChannel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1291,7 +1328,8 @@ module PutPolicy : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidTypeException of invalid_type_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1387,7 +1425,8 @@ module PutProtocolsList : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates an Firewall Manager protocols list.\n"]
@@ -1420,7 +1459,8 @@ module PutResourceSet : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1460,7 +1500,8 @@ module TagResource : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds one or more tags to an Amazon Web Services resource.\n"]
@@ -1493,7 +1534,8 @@ module UntagResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes one or more tags from an Amazon Web Services resource.\n"]

--- a/sdks/fms/operations.mli
+++ b/sdks/fms/operations.mli
@@ -21,6 +21,18 @@ module AssociateAdminAccount : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_admin_account_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets a Firewall Manager default administrator account. The Firewall Manager default \
@@ -46,6 +58,17 @@ module AssociateThirdPartyFirewall : sig
     'http_type Smaws_Lib.Context.t ->
     associate_third_party_firewall_request ->
     ( associate_third_party_firewall_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_third_party_firewall_request ->
+    ( associate_third_party_firewall_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -79,6 +102,18 @@ module BatchAssociateResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_associate_resource_request ->
+    ( batch_associate_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Associate resources to a Firewall Manager resource set.\n"]
 
@@ -95,6 +130,17 @@ module BatchDisassociateResource : sig
     'http_type Smaws_Lib.Context.t ->
     batch_disassociate_resource_request ->
     ( batch_disassociate_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_disassociate_resource_request ->
+    ( batch_disassociate_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -121,6 +167,16 @@ module DeleteAppsList : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_apps_list_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager applications list.\n"]
 
@@ -136,6 +192,16 @@ module DeleteNotificationChannel : sig
     'http_type Smaws_Lib.Context.t ->
     delete_notification_channel_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_notification_channel_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -167,6 +233,18 @@ module DeletePolicy : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_policy_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Permanently deletes an Firewall Manager policy. \n"]
 
@@ -182,6 +260,16 @@ module DeleteProtocolsList : sig
     'http_type Smaws_Lib.Context.t ->
     delete_protocols_list_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_protocols_list_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -209,6 +297,17 @@ module DeleteResourceSet : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_set_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified [ResourceSet].\n"]
 
@@ -224,6 +323,16 @@ module DisassociateAdminAccount : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_admin_account_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_admin_account_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -258,6 +367,17 @@ module DisassociateThirdPartyFirewall : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_third_party_firewall_request ->
+    ( disassociate_third_party_firewall_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disassociates a Firewall Manager policy administrator from a third-party firewall tenant. When \
@@ -276,6 +396,16 @@ module GetAdminAccount : sig
     'http_type Smaws_Lib.Context.t ->
     get_admin_account_request ->
     ( get_admin_account_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_admin_account_request ->
+    ( get_admin_account_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -307,6 +437,18 @@ module GetAdminScope : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_admin_scope_request ->
+    ( get_admin_scope_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the specified account's administrative scope. The administrative \
@@ -329,6 +471,16 @@ module GetAppsList : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_apps_list_request ->
+    ( get_apps_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager applications list.\n"]
 
@@ -345,6 +497,17 @@ module GetComplianceDetail : sig
     'http_type Smaws_Lib.Context.t ->
     get_compliance_detail_request ->
     ( get_compliance_detail_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_detail_request ->
+    ( get_compliance_detail_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -376,6 +539,16 @@ module GetNotificationChannel : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_notification_channel_request ->
+    ( get_notification_channel_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Information about the Amazon Simple Notification Service (SNS) topic that is used to record \
@@ -400,6 +573,17 @@ module GetPolicy : sig
       | `InvalidTypeException of invalid_type_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_policy_request ->
+    ( get_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidTypeException of invalid_type_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager policy.\n"]
 
@@ -415,6 +599,16 @@ module GetProtectionStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_protection_status_request ->
     ( get_protection_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_protection_status_request ->
+    ( get_protection_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -442,6 +636,16 @@ module GetProtocolsList : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_protocols_list_request ->
+    ( get_protocols_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the specified Firewall Manager protocols list.\n"]
 
@@ -458,6 +662,17 @@ module GetResourceSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_set_request ->
     ( get_resource_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_set_request ->
+    ( get_resource_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -486,6 +701,17 @@ module GetThirdPartyFirewallAssociationStatus : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_third_party_firewall_association_status_request ->
+    ( get_third_party_firewall_association_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "The onboarding status of a Firewall Manager admin account to third-party firewall vendor tenant.\n"]
@@ -502,6 +728,16 @@ module GetViolationDetails : sig
     'http_type Smaws_Lib.Context.t ->
     get_violation_details_request ->
     ( get_violation_details_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_violation_details_request ->
+    ( get_violation_details_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -531,6 +767,17 @@ module ListAdminAccountsForOrganization : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_admin_accounts_for_organization_request ->
+    ( list_admin_accounts_for_organization_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a [AdminAccounts] object that lists the Firewall Manager administrators within the \
@@ -550,6 +797,16 @@ module ListAdminsManagingAccount : sig
     'http_type Smaws_Lib.Context.t ->
     list_admins_managing_account_request ->
     ( list_admins_managing_account_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_admins_managing_account_request ->
+    ( list_admins_managing_account_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -581,6 +838,17 @@ module ListAppsLists : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_apps_lists_request ->
+    ( list_apps_lists_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns an array of [AppsListDataSummary] objects.\n"]
 
@@ -595,6 +863,15 @@ module ListComplianceStatus : sig
     'http_type Smaws_Lib.Context.t ->
     list_compliance_status_request ->
     ( list_compliance_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_compliance_status_request ->
+    ( list_compliance_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -621,6 +898,16 @@ module ListDiscoveredResources : sig
       | `InvalidInputException of invalid_input_exception
       | `InvalidOperationException of invalid_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_discovered_resources_request ->
+    ( list_discovered_resources_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an array of resources in the organization's accounts that are available to be \
@@ -637,6 +924,15 @@ module ListMemberAccounts : sig
     'http_type Smaws_Lib.Context.t ->
     list_member_accounts_request ->
     ( list_member_accounts_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_member_accounts_request ->
+    ( list_member_accounts_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -668,6 +964,17 @@ module ListPolicies : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_policies_request ->
+    ( list_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns an array of [PolicySummary] objects.\n"]
 
@@ -683,6 +990,16 @@ module ListProtocolsLists : sig
     'http_type Smaws_Lib.Context.t ->
     list_protocols_lists_request ->
     ( list_protocols_lists_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_protocols_lists_request ->
+    ( list_protocols_lists_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -710,6 +1027,17 @@ module ListResourceSetResources : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_set_resources_request ->
+    ( list_resource_set_resources_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns an array of resources that are currently associated to a resource set.\n"]
 
@@ -725,6 +1053,16 @@ module ListResourceSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_resource_sets_request ->
     ( list_resource_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_sets_request ->
+    ( list_resource_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -746,6 +1084,17 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -774,6 +1123,17 @@ module ListThirdPartyFirewallFirewallPolicies : sig
       | `InvalidOperationException of invalid_operation_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_third_party_firewall_firewall_policies_request ->
+    ( list_third_party_firewall_firewall_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of all of the third-party firewall policies that are associated with the \
@@ -792,6 +1152,17 @@ module PutAdminAccount : sig
     'http_type Smaws_Lib.Context.t ->
     put_admin_account_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_admin_account_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -831,6 +1202,18 @@ module PutAppsList : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_apps_list_request ->
+    ( put_apps_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Creates an Firewall Manager applications list.\n"]
 
@@ -846,6 +1229,16 @@ module PutNotificationChannel : sig
     'http_type Smaws_Lib.Context.t ->
     put_notification_channel_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_notification_channel_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -879,6 +1272,19 @@ module PutPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     put_policy_request ->
     ( put_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidTypeException of invalid_type_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_policy_request ->
+    ( put_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -971,6 +1377,18 @@ module PutProtocolsList : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_protocols_list_request ->
+    ( put_protocols_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Creates an Firewall Manager protocols list.\n"]
 
@@ -987,6 +1405,17 @@ module PutResourceSet : sig
     'http_type Smaws_Lib.Context.t ->
     put_resource_set_request ->
     ( put_resource_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_set_request ->
+    ( put_resource_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception
@@ -1021,6 +1450,18 @@ module TagResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Adds one or more tags to an Amazon Web Services resource.\n"]
 
@@ -1037,6 +1478,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidInputException of invalid_input_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidInputException of invalid_input_exception

--- a/sdks/kendra/Smaws_Client_Kendra.mli
+++ b/sdks/kendra/Smaws_Client_Kendra.mli
@@ -1933,7 +1933,8 @@ module AssociateEntitiesToExperience : sig
       | `ResourceAlreadyExistException of resource_already_exist_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1977,7 +1978,8 @@ module AssociatePersonasToEntities : sig
       | `ResourceAlreadyExistException of resource_already_exist_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2021,7 +2023,8 @@ module BatchDeleteDocument : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2067,7 +2070,8 @@ module BatchDeleteFeaturedResultsSet : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2109,7 +2113,8 @@ module BatchGetDocumentStatus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2163,7 +2168,8 @@ module BatchPutDocument : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2217,7 +2223,8 @@ module ClearQuerySuggestions : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2268,7 +2275,8 @@ module CreateAccessControlConfiguration : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2340,7 +2348,8 @@ module CreateDataSource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2394,7 +2403,8 @@ module CreateExperience : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2440,7 +2450,8 @@ module CreateFaq : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2490,7 +2501,8 @@ module CreateFeaturedResultsSet : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2539,7 +2551,8 @@ module CreateIndex : sig
       | `ResourceAlreadyExistException of resource_already_exist_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2593,7 +2606,8 @@ module CreateQuerySuggestionsBlockList : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2652,7 +2666,8 @@ module CreateThesaurus : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2696,7 +2711,8 @@ module DeleteAccessControlConfiguration : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2739,7 +2755,8 @@ module DeleteDataSource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2787,7 +2804,8 @@ module DeleteExperience : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2830,7 +2848,8 @@ module DeleteFaq : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a FAQ from an index.\n"]
@@ -2869,7 +2888,8 @@ module DeleteIndex : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2911,7 +2931,8 @@ module DeletePrincipalMapping : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2965,7 +2986,8 @@ module DeleteQuerySuggestionsBlockList : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3011,7 +3033,8 @@ module DeleteThesaurus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an Amazon Kendra thesaurus. \n"]
@@ -3047,7 +3070,8 @@ module DescribeAccessControlConfiguration : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3087,7 +3111,8 @@ module DescribeDataSource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra data source connector.\n"]
@@ -3123,7 +3148,8 @@ module DescribeExperience : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3163,7 +3189,8 @@ module DescribeFaq : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about a FAQ.\n"]
@@ -3199,7 +3226,8 @@ module DescribeFeaturedResultsSet : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3238,7 +3266,8 @@ module DescribeIndex : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra index.\n"]
@@ -3274,7 +3303,8 @@ module DescribePrincipalMapping : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3318,7 +3348,8 @@ module DescribeQuerySuggestionsBlockList : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3360,7 +3391,8 @@ module DescribeQuerySuggestionsConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3402,7 +3434,8 @@ module DescribeThesaurus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra thesaurus.\n"]
@@ -3438,7 +3471,8 @@ module DisassociateEntitiesFromExperience : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3479,7 +3513,8 @@ module DisassociatePersonasFromEntities : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3526,7 +3561,8 @@ module GetQuerySuggestions : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3563,7 +3599,8 @@ module GetSnapshots : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3601,7 +3638,8 @@ module ListAccessControlConfigurations : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3643,7 +3681,8 @@ module ListDataSourceSyncJobs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets statistics about synchronizing a data source connector.\n"]
@@ -3679,7 +3718,8 @@ module ListDataSources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the data source connectors that you have created.\n"]
@@ -3715,7 +3755,8 @@ module ListEntityPersonas : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3752,7 +3793,8 @@ module ListExperienceEntities : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3793,7 +3835,8 @@ module ListExperiences : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3833,7 +3876,8 @@ module ListFaqs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets a list of FAQs associated with an index.\n"]
@@ -3869,7 +3913,8 @@ module ListFeaturedResultsSets : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3911,7 +3956,8 @@ module ListGroupsOlderThanOrderingId : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3949,7 +3995,8 @@ module ListIndices : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the Amazon Kendra indexes that you created.\n"]
@@ -3985,7 +4032,8 @@ module ListQuerySuggestionsBlockLists : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4028,7 +4076,8 @@ module ListTagsForResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceUnavailableException of resource_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4066,7 +4115,8 @@ module ListThesauri : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the thesauri for an index.\n"]
@@ -4108,7 +4158,8 @@ module PutPrincipalMapping : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4166,7 +4217,8 @@ module Query : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4246,7 +4298,8 @@ module Retrieve : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4334,7 +4387,8 @@ module StartDataSourceSyncJob : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4376,7 +4430,8 @@ module StopDataSourceSyncJob : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4417,7 +4472,8 @@ module SubmitFeedback : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4457,7 +4513,8 @@ module TagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceUnavailableException of resource_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4495,7 +4552,8 @@ module UntagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceUnavailableException of resource_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a tag from an index, FAQ, data source, or other resource.\n"]
@@ -4537,7 +4595,8 @@ module UpdateAccessControlConfiguration : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4601,7 +4660,8 @@ module UpdateDataSource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an Amazon Kendra data source connector.\n"]
@@ -4640,7 +4700,8 @@ module UpdateExperience : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4683,7 +4744,8 @@ module UpdateFeaturedResultsSet : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4729,7 +4791,8 @@ module UpdateIndex : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an Amazon Kendra index.\n"]
@@ -4768,7 +4831,8 @@ module UpdateQuerySuggestionsBlockList : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4821,7 +4885,8 @@ module UpdateQuerySuggestionsConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4877,7 +4942,8 @@ module UpdateThesaurus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a thesaurus for an index.\n"]

--- a/sdks/kendra/Smaws_Client_Kendra.mli
+++ b/sdks/kendra/Smaws_Client_Kendra.mli
@@ -1922,6 +1922,19 @@ module AssociateEntitiesToExperience : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_entities_to_experience_request ->
+    ( associate_entities_to_experience_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceAlreadyExistException of resource_already_exist_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Grants users or groups in your IAM Identity Center identity source access to your Amazon Kendra \
@@ -1953,6 +1966,19 @@ module AssociatePersonasToEntities : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_personas_to_entities_request ->
+    ( associate_personas_to_entities_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceAlreadyExistException of resource_already_exist_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Defines the specific permissions of users or groups in your IAM Identity Center identity source \
@@ -1976,6 +2002,19 @@ module BatchDeleteDocument : sig
     'http_type Smaws_Lib.Context.t ->
     batch_delete_document_request ->
     ( batch_delete_document_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_delete_document_request ->
+    ( batch_delete_document_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2018,6 +2057,18 @@ module BatchDeleteFeaturedResultsSet : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_delete_featured_results_set_request ->
+    ( batch_delete_featured_results_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes one or more sets of featured results. Features results are placed above all other \
@@ -2039,6 +2090,19 @@ module BatchGetDocumentStatus : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_document_status_request ->
     ( batch_get_document_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_document_status_request ->
+    ( batch_get_document_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2078,6 +2142,20 @@ module BatchPutDocument : sig
     'http_type Smaws_Lib.Context.t ->
     batch_put_document_request ->
     ( batch_put_document_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_put_document_request ->
+    ( batch_put_document_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2128,6 +2206,19 @@ module ClearQuerySuggestions : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    clear_query_suggestions_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Clears existing query suggestions from an index.\n\n\
@@ -2156,6 +2247,20 @@ module CreateAccessControlConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     create_access_control_configuration_request ->
     ( create_access_control_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_access_control_configuration_request ->
+    ( create_access_control_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2222,6 +2327,21 @@ module CreateDataSource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_data_source_request ->
+    ( create_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceAlreadyExistException of resource_already_exist_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a data source connector that you want to use with an Amazon Kendra index.\n\n\
@@ -2262,6 +2382,20 @@ module CreateExperience : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_experience_request ->
+    ( create_experience_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an Amazon Kendra experience such as a search application. For more information on \
@@ -2285,6 +2419,20 @@ module CreateFaq : sig
     'http_type Smaws_Lib.Context.t ->
     create_faq_request ->
     ( create_faq_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_faq_request ->
+    ( create_faq_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2330,6 +2478,20 @@ module CreateFeaturedResultsSet : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_featured_results_set_request ->
+    ( create_featured_results_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `FeaturedResultsConflictException of featured_results_conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a set of featured results to display at the top of the search results page. Featured \
@@ -2356,6 +2518,20 @@ module CreateIndex : sig
     'http_type Smaws_Lib.Context.t ->
     create_index_request ->
     ( create_index_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceAlreadyExistException of resource_already_exist_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_index_request ->
+    ( create_index_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2396,6 +2572,20 @@ module CreateQuerySuggestionsBlockList : sig
     'http_type Smaws_Lib.Context.t ->
     create_query_suggestions_block_list_request ->
     ( create_query_suggestions_block_list_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_query_suggestions_block_list_request ->
+    ( create_query_suggestions_block_list_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2450,6 +2640,20 @@ module CreateThesaurus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_thesaurus_request ->
+    ( create_thesaurus_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a thesaurus for an index. The thesaurus contains a list of synonyms in Solr format.\n\n\
@@ -2481,6 +2685,19 @@ module DeleteAccessControlConfiguration : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_access_control_configuration_request ->
+    ( delete_access_control_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an access control configuration that you created for your documents in an index. This \
@@ -2503,6 +2720,19 @@ module DeleteDataSource : sig
     'http_type Smaws_Lib.Context.t ->
     delete_data_source_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_data_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2546,6 +2776,19 @@ module DeleteExperience : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_experience_request ->
+    ( delete_experience_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes your Amazon Kendra experience such as a search application. For more information on \
@@ -2568,6 +2811,19 @@ module DeleteFaq : sig
     'http_type Smaws_Lib.Context.t ->
     delete_faq_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_faq_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2602,6 +2858,19 @@ module DeleteIndex : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_index_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an Amazon Kendra index. An exception is not thrown if the index is already being \
@@ -2623,6 +2892,19 @@ module DeletePrincipalMapping : sig
     'http_type Smaws_Lib.Context.t ->
     delete_principal_mapping_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_principal_mapping_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2672,6 +2954,19 @@ module DeleteQuerySuggestionsBlockList : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_query_suggestions_block_list_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a block list used for query suggestions for an index.\n\n\
@@ -2705,6 +3000,19 @@ module DeleteThesaurus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_thesaurus_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes an Amazon Kendra thesaurus. \n"]
 
@@ -2722,6 +3030,18 @@ module DescribeAccessControlConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     describe_access_control_configuration_request ->
     ( describe_access_control_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_access_control_configuration_request ->
+    ( describe_access_control_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2757,6 +3077,18 @@ module DescribeDataSource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_data_source_request ->
+    ( describe_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra data source connector.\n"]
 
@@ -2774,6 +3106,18 @@ module DescribeExperience : sig
     'http_type Smaws_Lib.Context.t ->
     describe_experience_request ->
     ( describe_experience_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_experience_request ->
+    ( describe_experience_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2809,6 +3153,18 @@ module DescribeFaq : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_faq_request ->
+    ( describe_faq_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets information about a FAQ.\n"]
 
@@ -2826,6 +3182,18 @@ module DescribeFeaturedResultsSet : sig
     'http_type Smaws_Lib.Context.t ->
     describe_featured_results_set_request ->
     ( describe_featured_results_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_featured_results_set_request ->
+    ( describe_featured_results_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2860,6 +3228,18 @@ module DescribeIndex : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_index_request ->
+    ( describe_index_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra index.\n"]
 
@@ -2877,6 +3257,18 @@ module DescribePrincipalMapping : sig
     'http_type Smaws_Lib.Context.t ->
     describe_principal_mapping_request ->
     ( describe_principal_mapping_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_principal_mapping_request ->
+    ( describe_principal_mapping_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2916,6 +3308,18 @@ module DescribeQuerySuggestionsBlockList : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_query_suggestions_block_list_request ->
+    ( describe_query_suggestions_block_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets information about a block list used for query suggestions for an index.\n\n\
@@ -2939,6 +3343,18 @@ module DescribeQuerySuggestionsConfig : sig
     'http_type Smaws_Lib.Context.t ->
     describe_query_suggestions_config_request ->
     ( describe_query_suggestions_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_query_suggestions_config_request ->
+    ( describe_query_suggestions_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2976,6 +3392,18 @@ module DescribeThesaurus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_thesaurus_request ->
+    ( describe_thesaurus_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra thesaurus.\n"]
 
@@ -2993,6 +3421,18 @@ module DisassociateEntitiesFromExperience : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_entities_from_experience_request ->
     ( disassociate_entities_from_experience_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_entities_from_experience_request ->
+    ( disassociate_entities_from_experience_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3022,6 +3462,18 @@ module DisassociatePersonasFromEntities : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_personas_from_entities_request ->
     ( disassociate_personas_from_entities_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_personas_from_entities_request ->
+    ( disassociate_personas_from_entities_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3062,6 +3514,20 @@ module GetQuerySuggestions : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_query_suggestions_request ->
+    ( get_query_suggestions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Fetches the queries that are suggested to your users.\n\n\
@@ -3088,6 +3554,17 @@ module GetSnapshots : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_snapshots_request ->
+    ( get_snapshots_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves search metrics data. The data provides a snapshot of how your users interact with \
@@ -3107,6 +3584,18 @@ module ListAccessControlConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     list_access_control_configurations_request ->
     ( list_access_control_configurations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_access_control_configurations_request ->
+    ( list_access_control_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3143,6 +3632,19 @@ module ListDataSourceSyncJobs : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_data_source_sync_jobs_request ->
+    ( list_data_source_sync_jobs_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets statistics about synchronizing a data source connector.\n"]
 
@@ -3160,6 +3662,18 @@ module ListDataSources : sig
     'http_type Smaws_Lib.Context.t ->
     list_data_sources_request ->
     ( list_data_sources_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_data_sources_request ->
+    ( list_data_sources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3191,6 +3705,18 @@ module ListEntityPersonas : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_entity_personas_request ->
+    ( list_entity_personas_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists specific permissions of users and groups with access to your Amazon Kendra experience.\n"]
@@ -3209,6 +3735,18 @@ module ListExperienceEntities : sig
     'http_type Smaws_Lib.Context.t ->
     list_experience_entities_request ->
     ( list_experience_entities_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_experience_entities_request ->
+    ( list_experience_entities_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3245,6 +3783,18 @@ module ListExperiences : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_experiences_request ->
+    ( list_experiences_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists one or more Amazon Kendra experiences. You can create an Amazon Kendra experience such as \
@@ -3273,6 +3823,18 @@ module ListFaqs : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_faqs_request ->
+    ( list_faqs_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets a list of FAQs associated with an index.\n"]
 
@@ -3290,6 +3852,18 @@ module ListFeaturedResultsSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_featured_results_sets_request ->
     ( list_featured_results_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_featured_results_sets_request ->
+    ( list_featured_results_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3326,6 +3900,19 @@ module ListGroupsOlderThanOrderingId : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_groups_older_than_ordering_id_request ->
+    ( list_groups_older_than_ordering_id_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of groups that are mapped to users before a given ordering or timestamp \
@@ -3353,6 +3940,17 @@ module ListIndices : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_indices_request ->
+    ( list_indices_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the Amazon Kendra indexes that you created.\n"]
 
@@ -3370,6 +3968,18 @@ module ListQuerySuggestionsBlockLists : sig
     'http_type Smaws_Lib.Context.t ->
     list_query_suggestions_block_lists_request ->
     ( list_query_suggestions_block_lists_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_query_suggestions_block_lists_request ->
+    ( list_query_suggestions_block_lists_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3408,6 +4018,18 @@ module ListTagsForResource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets a list of tags associated with a resource. Indexes, FAQs, data sources, and other \
@@ -3434,6 +4056,18 @@ module ListThesauri : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_thesauri_request ->
+    ( list_thesauri_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the thesauri for an index.\n"]
 
@@ -3453,6 +4087,20 @@ module PutPrincipalMapping : sig
     'http_type Smaws_Lib.Context.t ->
     put_principal_mapping_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_principal_mapping_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3497,6 +4145,20 @@ module Query : sig
     'http_type Smaws_Lib.Context.t ->
     query_request ->
     ( query_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_request ->
+    ( query_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3563,6 +4225,20 @@ module Retrieve : sig
     'http_type Smaws_Lib.Context.t ->
     retrieve_request ->
     ( retrieve_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    retrieve_request ->
+    ( retrieve_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3646,6 +4322,20 @@ module StartDataSourceSyncJob : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_data_source_sync_job_request ->
+    ( start_data_source_sync_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts a synchronization job for a data source connector. If a synchronization job is already \
@@ -3676,6 +4366,18 @@ module StopDataSourceSyncJob : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_data_source_sync_job_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops a synchronization job that is currently running. You can't stop a scheduled \
@@ -3696,6 +4398,19 @@ module SubmitFeedback : sig
     'http_type Smaws_Lib.Context.t ->
     submit_feedback_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    submit_feedback_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3732,6 +4447,18 @@ module TagResource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds the specified tag to the specified index, FAQ, data source, or other resource. If the tag \
@@ -3758,6 +4485,18 @@ module UntagResource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Removes a tag from an index, FAQ, data source, or other resource.\n"]
 
@@ -3777,6 +4516,20 @@ module UpdateAccessControlConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     update_access_control_configuration_request ->
     ( update_access_control_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_access_control_configuration_request ->
+    ( update_access_control_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3837,6 +4590,19 @@ module UpdateDataSource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_data_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates an Amazon Kendra data source connector.\n"]
 
@@ -3855,6 +4621,19 @@ module UpdateExperience : sig
     'http_type Smaws_Lib.Context.t ->
     update_experience_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_experience_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3885,6 +4664,19 @@ module UpdateFeaturedResultsSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_featured_results_set_request ->
     ( update_featured_results_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `FeaturedResultsConflictException of featured_results_conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_featured_results_set_request ->
+    ( update_featured_results_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `FeaturedResultsConflictException of featured_results_conflict_exception
@@ -3925,6 +4717,20 @@ module UpdateIndex : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_index_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates an Amazon Kendra index.\n"]
 
@@ -3943,6 +4749,19 @@ module UpdateQuerySuggestionsBlockList : sig
     'http_type Smaws_Lib.Context.t ->
     update_query_suggestions_block_list_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_query_suggestions_block_list_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3991,6 +4810,19 @@ module UpdateQuerySuggestionsConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_query_suggestions_config_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the settings of query suggestions for an index.\n\n\
@@ -4026,6 +4858,19 @@ module UpdateThesaurus : sig
     'http_type Smaws_Lib.Context.t ->
     update_thesaurus_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_thesaurus_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/kendra/operations.ml
+++ b/sdks/kendra/operations.ml
@@ -39,6 +39,13 @@ module AssociateEntitiesToExperience = struct
       ~shape_name:"AWSKendraFrontendService.AssociateEntitiesToExperience" ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_entities_to_experience_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_entities_to_experience_request) =
+    let input = Json_serializers.associate_entities_to_experience_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.AssociateEntitiesToExperience" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_entities_to_experience_response_of_yojson
+      ~error_deserializer
 end
 
 module AssociatePersonasToEntities = struct
@@ -76,6 +83,13 @@ module AssociatePersonasToEntities = struct
   let request context (request : associate_personas_to_entities_request) =
     let input = Json_serializers.associate_personas_to_entities_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.AssociatePersonasToEntities" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_personas_to_entities_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : associate_personas_to_entities_request) =
+    let input = Json_serializers.associate_personas_to_entities_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.AssociatePersonasToEntities" ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_personas_to_entities_response_of_yojson
       ~error_deserializer
@@ -118,6 +132,13 @@ module BatchDeleteDocument = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_delete_document_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_delete_document_request) =
+    let input = Json_serializers.batch_delete_document_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.BatchDeleteDocument" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_delete_document_response_of_yojson
+      ~error_deserializer
 end
 
 module BatchDeleteFeaturedResultsSet = struct
@@ -151,6 +172,13 @@ module BatchDeleteFeaturedResultsSet = struct
   let request context (request : batch_delete_featured_results_set_request) =
     let input = Json_serializers.batch_delete_featured_results_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.BatchDeleteFeaturedResultsSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_delete_featured_results_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : batch_delete_featured_results_set_request) =
+    let input = Json_serializers.batch_delete_featured_results_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.BatchDeleteFeaturedResultsSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_delete_featured_results_set_response_of_yojson
       ~error_deserializer
@@ -190,6 +218,13 @@ module BatchGetDocumentStatus = struct
   let request context (request : batch_get_document_status_request) =
     let input = Json_serializers.batch_get_document_status_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.BatchGetDocumentStatus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_get_document_status_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : batch_get_document_status_request) =
+    let input = Json_serializers.batch_get_document_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.BatchGetDocumentStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_get_document_status_response_of_yojson
       ~error_deserializer
@@ -236,6 +271,13 @@ module BatchPutDocument = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_put_document_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_put_document_request) =
+    let input = Json_serializers.batch_put_document_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.BatchPutDocument" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_put_document_response_of_yojson
+      ~error_deserializer
 end
 
 module ClearQuerySuggestions = struct
@@ -273,6 +315,13 @@ module ClearQuerySuggestions = struct
     let input = Json_serializers.clear_query_suggestions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.ClearQuerySuggestions"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : clear_query_suggestions_request) =
+    let input = Json_serializers.clear_query_suggestions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ClearQuerySuggestions" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -315,6 +364,14 @@ module CreateAccessControlConfiguration = struct
   let request context (request : create_access_control_configuration_request) =
     let input = Json_serializers.create_access_control_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.CreateAccessControlConfiguration" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.create_access_control_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_access_control_configuration_request) =
+    let input = Json_serializers.create_access_control_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.CreateAccessControlConfiguration" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.create_access_control_configuration_response_of_yojson
@@ -366,6 +423,13 @@ module CreateDataSource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_data_source_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_data_source_request) =
+    let input = Json_serializers.create_data_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.CreateDataSource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_data_source_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateExperience = struct
@@ -407,6 +471,13 @@ module CreateExperience = struct
     let input = Json_serializers.create_experience_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.CreateExperience"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_experience_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_experience_request) =
+    let input = Json_serializers.create_experience_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.CreateExperience" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_experience_response_of_yojson
       ~error_deserializer
 end
@@ -451,6 +522,12 @@ module CreateFaq = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.CreateFaq" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_faq_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_faq_request) =
+    let input = Json_serializers.create_faq_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.CreateFaq" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_faq_response_of_yojson ~error_deserializer
 end
 
 module CreateFeaturedResultsSet = struct
@@ -491,6 +568,13 @@ module CreateFeaturedResultsSet = struct
   let request context (request : create_featured_results_set_request) =
     let input = Json_serializers.create_featured_results_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.CreateFeaturedResultsSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_featured_results_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_featured_results_set_request) =
+    let input = Json_serializers.create_featured_results_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.CreateFeaturedResultsSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_featured_results_set_response_of_yojson
       ~error_deserializer
@@ -536,6 +620,12 @@ module CreateIndex = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.CreateIndex" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_index_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_index_request) =
+    let input = Json_serializers.create_index_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.CreateIndex" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_index_response_of_yojson ~error_deserializer
 end
 
 module CreateQuerySuggestionsBlockList = struct
@@ -576,6 +666,14 @@ module CreateQuerySuggestionsBlockList = struct
   let request context (request : create_query_suggestions_block_list_request) =
     let input = Json_serializers.create_query_suggestions_block_list_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.CreateQuerySuggestionsBlockList" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.create_query_suggestions_block_list_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_query_suggestions_block_list_request) =
+    let input = Json_serializers.create_query_suggestions_block_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.CreateQuerySuggestionsBlockList" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.create_query_suggestions_block_list_response_of_yojson
@@ -623,6 +721,13 @@ module CreateThesaurus = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_thesaurus_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_thesaurus_request) =
+    let input = Json_serializers.create_thesaurus_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.CreateThesaurus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_thesaurus_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteAccessControlConfiguration = struct
@@ -659,6 +764,14 @@ module DeleteAccessControlConfiguration = struct
   let request context (request : delete_access_control_configuration_request) =
     let input = Json_serializers.delete_access_control_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.DeleteAccessControlConfiguration" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.delete_access_control_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_access_control_configuration_request) =
+    let input = Json_serializers.delete_access_control_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.DeleteAccessControlConfiguration" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.delete_access_control_configuration_response_of_yojson
@@ -702,6 +815,13 @@ module DeleteDataSource = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_data_source_request) =
+    let input = Json_serializers.delete_data_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DeleteDataSource" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteExperience = struct
@@ -739,6 +859,13 @@ module DeleteExperience = struct
     let input = Json_serializers.delete_experience_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.DeleteExperience"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_experience_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_experience_request) =
+    let input = Json_serializers.delete_experience_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DeleteExperience" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_experience_response_of_yojson
       ~error_deserializer
 end
@@ -779,6 +906,13 @@ module DeleteFaq = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.DeleteFaq" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_faq_request) =
+    let input = Json_serializers.delete_faq_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DeleteFaq" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteIndex = struct
@@ -817,6 +951,13 @@ module DeleteIndex = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.DeleteIndex" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_index_request) =
+    let input = Json_serializers.delete_index_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DeleteIndex" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeletePrincipalMapping = struct
@@ -853,6 +994,13 @@ module DeletePrincipalMapping = struct
   let request context (request : delete_principal_mapping_request) =
     let input = Json_serializers.delete_principal_mapping_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.DeletePrincipalMapping" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_principal_mapping_request) =
+    let input = Json_serializers.delete_principal_mapping_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.DeletePrincipalMapping" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -895,6 +1043,13 @@ module DeleteQuerySuggestionsBlockList = struct
       ~shape_name:"AWSKendraFrontendService.DeleteQuerySuggestionsBlockList" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_query_suggestions_block_list_request) =
+    let input = Json_serializers.delete_query_suggestions_block_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DeleteQuerySuggestionsBlockList" ~service ~context
+      ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteThesaurus = struct
@@ -934,6 +1089,13 @@ module DeleteThesaurus = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_thesaurus_request) =
+    let input = Json_serializers.delete_thesaurus_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DeleteThesaurus" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DescribeAccessControlConfiguration = struct
@@ -967,6 +1129,15 @@ module DescribeAccessControlConfiguration = struct
   let request context (request : describe_access_control_configuration_request) =
     let input = Json_serializers.describe_access_control_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.DescribeAccessControlConfiguration" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.describe_access_control_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_access_control_configuration_request) =
+    let input = Json_serializers.describe_access_control_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.DescribeAccessControlConfiguration" ~service ~context
       ~input
       ~output_deserializer:
@@ -1008,6 +1179,13 @@ module DescribeDataSource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_data_source_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_data_source_request) =
+    let input = Json_serializers.describe_data_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DescribeDataSource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_data_source_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeExperience = struct
@@ -1042,6 +1220,13 @@ module DescribeExperience = struct
     let input = Json_serializers.describe_experience_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.DescribeExperience"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_experience_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_experience_request) =
+    let input = Json_serializers.describe_experience_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DescribeExperience" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_experience_response_of_yojson
       ~error_deserializer
 end
@@ -1079,6 +1264,12 @@ module DescribeFaq = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.DescribeFaq" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_faq_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_faq_request) =
+    let input = Json_serializers.describe_faq_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DescribeFaq" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_faq_response_of_yojson ~error_deserializer
 end
 
 module DescribeFeaturedResultsSet = struct
@@ -1112,6 +1303,13 @@ module DescribeFeaturedResultsSet = struct
   let request context (request : describe_featured_results_set_request) =
     let input = Json_serializers.describe_featured_results_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.DescribeFeaturedResultsSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_featured_results_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_featured_results_set_request) =
+    let input = Json_serializers.describe_featured_results_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.DescribeFeaturedResultsSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_featured_results_set_response_of_yojson
       ~error_deserializer
@@ -1150,6 +1348,12 @@ module DescribeIndex = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.DescribeIndex"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_index_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_index_request) =
+    let input = Json_serializers.describe_index_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DescribeIndex" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_index_response_of_yojson ~error_deserializer
 end
 
 module DescribePrincipalMapping = struct
@@ -1183,6 +1387,13 @@ module DescribePrincipalMapping = struct
   let request context (request : describe_principal_mapping_request) =
     let input = Json_serializers.describe_principal_mapping_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.DescribePrincipalMapping" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_principal_mapping_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_principal_mapping_request) =
+    let input = Json_serializers.describe_principal_mapping_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.DescribePrincipalMapping" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_principal_mapping_response_of_yojson
       ~error_deserializer
@@ -1224,6 +1435,15 @@ module DescribeQuerySuggestionsBlockList = struct
       ~output_deserializer:
         Json_deserializers.describe_query_suggestions_block_list_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_query_suggestions_block_list_request) =
+    let input = Json_serializers.describe_query_suggestions_block_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DescribeQuerySuggestionsBlockList" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.describe_query_suggestions_block_list_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeQuerySuggestionsConfig = struct
@@ -1257,6 +1477,13 @@ module DescribeQuerySuggestionsConfig = struct
   let request context (request : describe_query_suggestions_config_request) =
     let input = Json_serializers.describe_query_suggestions_config_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.DescribeQuerySuggestionsConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_query_suggestions_config_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_query_suggestions_config_request) =
+    let input = Json_serializers.describe_query_suggestions_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.DescribeQuerySuggestionsConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_query_suggestions_config_response_of_yojson
       ~error_deserializer
@@ -1294,6 +1521,13 @@ module DescribeThesaurus = struct
     let input = Json_serializers.describe_thesaurus_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.DescribeThesaurus"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_thesaurus_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_thesaurus_request) =
+    let input = Json_serializers.describe_thesaurus_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DescribeThesaurus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_thesaurus_response_of_yojson
       ~error_deserializer
 end
@@ -1334,6 +1568,15 @@ module DisassociateEntitiesFromExperience = struct
       ~output_deserializer:
         Json_deserializers.disassociate_entities_from_experience_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_entities_from_experience_request) =
+    let input = Json_serializers.disassociate_entities_from_experience_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.DisassociateEntitiesFromExperience" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.disassociate_entities_from_experience_response_of_yojson
+      ~error_deserializer
 end
 
 module DisassociatePersonasFromEntities = struct
@@ -1367,6 +1610,14 @@ module DisassociatePersonasFromEntities = struct
   let request context (request : disassociate_personas_from_entities_request) =
     let input = Json_serializers.disassociate_personas_from_entities_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.DisassociatePersonasFromEntities" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.disassociate_personas_from_entities_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_personas_from_entities_request) =
+    let input = Json_serializers.disassociate_personas_from_entities_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.DisassociatePersonasFromEntities" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.disassociate_personas_from_entities_response_of_yojson
@@ -1414,6 +1665,13 @@ module GetQuerySuggestions = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_query_suggestions_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_query_suggestions_request) =
+    let input = Json_serializers.get_query_suggestions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.GetQuerySuggestions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_query_suggestions_response_of_yojson
+      ~error_deserializer
 end
 
 module GetSnapshots = struct
@@ -1447,6 +1705,12 @@ module GetSnapshots = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.GetSnapshots" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_snapshots_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_snapshots_request) =
+    let input = Json_serializers.get_snapshots_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.GetSnapshots" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_snapshots_response_of_yojson ~error_deserializer
 end
 
 module ListAccessControlConfigurations = struct
@@ -1480,6 +1744,14 @@ module ListAccessControlConfigurations = struct
   let request context (request : list_access_control_configurations_request) =
     let input = Json_serializers.list_access_control_configurations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.ListAccessControlConfigurations" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.list_access_control_configurations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_access_control_configurations_request) =
+    let input = Json_serializers.list_access_control_configurations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.ListAccessControlConfigurations" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.list_access_control_configurations_response_of_yojson
@@ -1523,6 +1795,13 @@ module ListDataSourceSyncJobs = struct
       ~shape_name:"AWSKendraFrontendService.ListDataSourceSyncJobs" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_data_source_sync_jobs_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_data_source_sync_jobs_request) =
+    let input = Json_serializers.list_data_source_sync_jobs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ListDataSourceSyncJobs" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_data_source_sync_jobs_response_of_yojson
+      ~error_deserializer
 end
 
 module ListDataSources = struct
@@ -1557,6 +1836,13 @@ module ListDataSources = struct
     let input = Json_serializers.list_data_sources_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.ListDataSources"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_data_sources_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_data_sources_request) =
+    let input = Json_serializers.list_data_sources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ListDataSources" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_data_sources_response_of_yojson
       ~error_deserializer
 end
@@ -1595,6 +1881,13 @@ module ListEntityPersonas = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_entity_personas_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_entity_personas_request) =
+    let input = Json_serializers.list_entity_personas_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ListEntityPersonas" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_entity_personas_response_of_yojson
+      ~error_deserializer
 end
 
 module ListExperienceEntities = struct
@@ -1628,6 +1921,13 @@ module ListExperienceEntities = struct
   let request context (request : list_experience_entities_request) =
     let input = Json_serializers.list_experience_entities_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.ListExperienceEntities" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_experience_entities_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_experience_entities_request) =
+    let input = Json_serializers.list_experience_entities_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.ListExperienceEntities" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_experience_entities_response_of_yojson
       ~error_deserializer
@@ -1667,6 +1967,13 @@ module ListExperiences = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_experiences_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_experiences_request) =
+    let input = Json_serializers.list_experiences_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ListExperiences" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_experiences_response_of_yojson
+      ~error_deserializer
 end
 
 module ListFaqs = struct
@@ -1702,6 +2009,12 @@ module ListFaqs = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.ListFaqs" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_faqs_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_faqs_request) =
+    let input = Json_serializers.list_faqs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ListFaqs" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_faqs_response_of_yojson ~error_deserializer
 end
 
 module ListFeaturedResultsSets = struct
@@ -1735,6 +2048,13 @@ module ListFeaturedResultsSets = struct
   let request context (request : list_featured_results_sets_request) =
     let input = Json_serializers.list_featured_results_sets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.ListFeaturedResultsSets" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_featured_results_sets_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_featured_results_sets_request) =
+    let input = Json_serializers.list_featured_results_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.ListFeaturedResultsSets" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_featured_results_sets_response_of_yojson
       ~error_deserializer
@@ -1777,6 +2097,13 @@ module ListGroupsOlderThanOrderingId = struct
       ~shape_name:"AWSKendraFrontendService.ListGroupsOlderThanOrderingId" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_groups_older_than_ordering_id_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_groups_older_than_ordering_id_request) =
+    let input = Json_serializers.list_groups_older_than_ordering_id_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ListGroupsOlderThanOrderingId" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_groups_older_than_ordering_id_response_of_yojson
+      ~error_deserializer
 end
 
 module ListIndices = struct
@@ -1808,6 +2135,12 @@ module ListIndices = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.ListIndices" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_indices_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_indices_request) =
+    let input = Json_serializers.list_indices_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ListIndices" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_indices_response_of_yojson ~error_deserializer
 end
 
 module ListQuerySuggestionsBlockLists = struct
@@ -1841,6 +2174,13 @@ module ListQuerySuggestionsBlockLists = struct
   let request context (request : list_query_suggestions_block_lists_request) =
     let input = Json_serializers.list_query_suggestions_block_lists_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.ListQuerySuggestionsBlockLists" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_query_suggestions_block_lists_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_query_suggestions_block_lists_request) =
+    let input = Json_serializers.list_query_suggestions_block_lists_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.ListQuerySuggestionsBlockLists" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_query_suggestions_block_lists_response_of_yojson
       ~error_deserializer
@@ -1880,6 +2220,13 @@ module ListTagsForResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module ListThesauri = struct
@@ -1915,6 +2262,12 @@ module ListThesauri = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.ListThesauri" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_thesauri_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_thesauri_request) =
+    let input = Json_serializers.list_thesauri_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.ListThesauri" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_thesauri_response_of_yojson ~error_deserializer
 end
 
 module PutPrincipalMapping = struct
@@ -1956,6 +2309,13 @@ module PutPrincipalMapping = struct
     let input = Json_serializers.put_principal_mapping_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.PutPrincipalMapping"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_principal_mapping_request) =
+    let input = Json_serializers.put_principal_mapping_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.PutPrincipalMapping" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -2000,6 +2360,12 @@ module Query = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.Query" ~service
       ~context ~input ~output_deserializer:Json_deserializers.query_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : query_request) =
+    let input = Json_serializers.query_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSKendraFrontendService.Query"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.query_result_of_yojson
+      ~error_deserializer
 end
 
 module Retrieve = struct
@@ -2042,6 +2408,12 @@ module Retrieve = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.Retrieve" ~service
       ~context ~input ~output_deserializer:Json_deserializers.retrieve_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : retrieve_request) =
+    let input = Json_serializers.retrieve_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.Retrieve" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.retrieve_result_of_yojson ~error_deserializer
 end
 
 module StartDataSourceSyncJob = struct
@@ -2084,6 +2456,13 @@ module StartDataSourceSyncJob = struct
       ~shape_name:"AWSKendraFrontendService.StartDataSourceSyncJob" ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_data_source_sync_job_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_data_source_sync_job_request) =
+    let input = Json_serializers.start_data_source_sync_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.StartDataSourceSyncJob" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_data_source_sync_job_response_of_yojson
+      ~error_deserializer
 end
 
 module StopDataSourceSyncJob = struct
@@ -2118,6 +2497,13 @@ module StopDataSourceSyncJob = struct
     let input = Json_serializers.stop_data_source_sync_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.StopDataSourceSyncJob"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : stop_data_source_sync_job_request) =
+    let input = Json_serializers.stop_data_source_sync_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.StopDataSourceSyncJob" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -2160,6 +2546,13 @@ module SubmitFeedback = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : submit_feedback_request) =
+    let input = Json_serializers.submit_feedback_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.SubmitFeedback" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -2195,6 +2588,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.TagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.TagResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -2229,6 +2628,12 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.UntagResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.UntagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
@@ -2274,6 +2679,14 @@ module UpdateAccessControlConfiguration = struct
       ~input
       ~output_deserializer:Json_deserializers.update_access_control_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_access_control_configuration_request) =
+    let input = Json_serializers.update_access_control_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.UpdateAccessControlConfiguration" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.update_access_control_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateDataSource = struct
@@ -2311,6 +2724,13 @@ module UpdateDataSource = struct
     let input = Json_serializers.update_data_source_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.UpdateDataSource"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_data_source_request) =
+    let input = Json_serializers.update_data_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.UpdateDataSource" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -2352,6 +2772,13 @@ module UpdateExperience = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_experience_request) =
+    let input = Json_serializers.update_experience_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.UpdateExperience" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UpdateFeaturedResultsSet = struct
@@ -2389,6 +2816,13 @@ module UpdateFeaturedResultsSet = struct
   let request context (request : update_featured_results_set_request) =
     let input = Json_serializers.update_featured_results_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.UpdateFeaturedResultsSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_featured_results_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_featured_results_set_request) =
+    let input = Json_serializers.update_featured_results_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.UpdateFeaturedResultsSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_featured_results_set_response_of_yojson
       ~error_deserializer
@@ -2434,6 +2868,13 @@ module UpdateIndex = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.UpdateIndex" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_index_request) =
+    let input = Json_serializers.update_index_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.UpdateIndex" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UpdateQuerySuggestionsBlockList = struct
@@ -2470,6 +2911,13 @@ module UpdateQuerySuggestionsBlockList = struct
   let request context (request : update_query_suggestions_block_list_request) =
     let input = Json_serializers.update_query_suggestions_block_list_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSKendraFrontendService.UpdateQuerySuggestionsBlockList" ~service ~context
+      ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_query_suggestions_block_list_request) =
+    let input = Json_serializers.update_query_suggestions_block_list_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSKendraFrontendService.UpdateQuerySuggestionsBlockList" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -2512,6 +2960,13 @@ module UpdateQuerySuggestionsConfig = struct
       ~shape_name:"AWSKendraFrontendService.UpdateQuerySuggestionsConfig" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_query_suggestions_config_request) =
+    let input = Json_serializers.update_query_suggestions_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.UpdateQuerySuggestionsConfig" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UpdateThesaurus = struct
@@ -2549,6 +3004,13 @@ module UpdateThesaurus = struct
     let input = Json_serializers.update_thesaurus_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSKendraFrontendService.UpdateThesaurus"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_thesaurus_request) =
+    let input = Json_serializers.update_thesaurus_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSKendraFrontendService.UpdateThesaurus" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end

--- a/sdks/kendra/operations.mli
+++ b/sdks/kendra/operations.mli
@@ -34,7 +34,8 @@ module AssociateEntitiesToExperience : sig
       | `ResourceAlreadyExistException of resource_already_exist_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -78,7 +79,8 @@ module AssociatePersonasToEntities : sig
       | `ResourceAlreadyExistException of resource_already_exist_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -122,7 +124,8 @@ module BatchDeleteDocument : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -168,7 +171,8 @@ module BatchDeleteFeaturedResultsSet : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -210,7 +214,8 @@ module BatchGetDocumentStatus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -264,7 +269,8 @@ module BatchPutDocument : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -318,7 +324,8 @@ module ClearQuerySuggestions : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -369,7 +376,8 @@ module CreateAccessControlConfiguration : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -441,7 +449,8 @@ module CreateDataSource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -495,7 +504,8 @@ module CreateExperience : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -541,7 +551,8 @@ module CreateFaq : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -591,7 +602,8 @@ module CreateFeaturedResultsSet : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -640,7 +652,8 @@ module CreateIndex : sig
       | `ResourceAlreadyExistException of resource_already_exist_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -694,7 +707,8 @@ module CreateQuerySuggestionsBlockList : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -753,7 +767,8 @@ module CreateThesaurus : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -797,7 +812,8 @@ module DeleteAccessControlConfiguration : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -840,7 +856,8 @@ module DeleteDataSource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -888,7 +905,8 @@ module DeleteExperience : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -931,7 +949,8 @@ module DeleteFaq : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a FAQ from an index.\n"]
@@ -970,7 +989,8 @@ module DeleteIndex : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1012,7 +1032,8 @@ module DeletePrincipalMapping : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1066,7 +1087,8 @@ module DeleteQuerySuggestionsBlockList : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1112,7 +1134,8 @@ module DeleteThesaurus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an Amazon Kendra thesaurus. \n"]
@@ -1148,7 +1171,8 @@ module DescribeAccessControlConfiguration : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1188,7 +1212,8 @@ module DescribeDataSource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra data source connector.\n"]
@@ -1224,7 +1249,8 @@ module DescribeExperience : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1264,7 +1290,8 @@ module DescribeFaq : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about a FAQ.\n"]
@@ -1300,7 +1327,8 @@ module DescribeFeaturedResultsSet : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1339,7 +1367,8 @@ module DescribeIndex : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra index.\n"]
@@ -1375,7 +1404,8 @@ module DescribePrincipalMapping : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1419,7 +1449,8 @@ module DescribeQuerySuggestionsBlockList : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1461,7 +1492,8 @@ module DescribeQuerySuggestionsConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1503,7 +1535,8 @@ module DescribeThesaurus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra thesaurus.\n"]
@@ -1539,7 +1572,8 @@ module DisassociateEntitiesFromExperience : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1580,7 +1614,8 @@ module DisassociatePersonasFromEntities : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1627,7 +1662,8 @@ module GetQuerySuggestions : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1664,7 +1700,8 @@ module GetSnapshots : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1702,7 +1739,8 @@ module ListAccessControlConfigurations : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1744,7 +1782,8 @@ module ListDataSourceSyncJobs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets statistics about synchronizing a data source connector.\n"]
@@ -1780,7 +1819,8 @@ module ListDataSources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the data source connectors that you have created.\n"]
@@ -1816,7 +1856,8 @@ module ListEntityPersonas : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1853,7 +1894,8 @@ module ListExperienceEntities : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1894,7 +1936,8 @@ module ListExperiences : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1934,7 +1977,8 @@ module ListFaqs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets a list of FAQs associated with an index.\n"]
@@ -1970,7 +2014,8 @@ module ListFeaturedResultsSets : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2012,7 +2057,8 @@ module ListGroupsOlderThanOrderingId : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2050,7 +2096,8 @@ module ListIndices : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the Amazon Kendra indexes that you created.\n"]
@@ -2086,7 +2133,8 @@ module ListQuerySuggestionsBlockLists : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2129,7 +2177,8 @@ module ListTagsForResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceUnavailableException of resource_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2167,7 +2216,8 @@ module ListThesauri : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the thesauri for an index.\n"]
@@ -2209,7 +2259,8 @@ module PutPrincipalMapping : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2267,7 +2318,8 @@ module Query : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2347,7 +2399,8 @@ module Retrieve : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2435,7 +2488,8 @@ module StartDataSourceSyncJob : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2477,7 +2531,8 @@ module StopDataSourceSyncJob : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2518,7 +2573,8 @@ module SubmitFeedback : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourceUnavailableException of resource_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2558,7 +2614,8 @@ module TagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceUnavailableException of resource_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2596,7 +2653,8 @@ module UntagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceUnavailableException of resource_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a tag from an index, FAQ, data source, or other resource.\n"]
@@ -2638,7 +2696,8 @@ module UpdateAccessControlConfiguration : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2702,7 +2761,8 @@ module UpdateDataSource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an Amazon Kendra data source connector.\n"]
@@ -2741,7 +2801,8 @@ module UpdateExperience : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2784,7 +2845,8 @@ module UpdateFeaturedResultsSet : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2830,7 +2892,8 @@ module UpdateIndex : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an Amazon Kendra index.\n"]
@@ -2869,7 +2932,8 @@ module UpdateQuerySuggestionsBlockList : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2922,7 +2986,8 @@ module UpdateQuerySuggestionsConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2977,7 +3042,8 @@ module UpdateThesaurus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a thesaurus for an index.\n"]

--- a/sdks/kendra/operations.mli
+++ b/sdks/kendra/operations.mli
@@ -23,6 +23,19 @@ module AssociateEntitiesToExperience : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_entities_to_experience_request ->
+    ( associate_entities_to_experience_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceAlreadyExistException of resource_already_exist_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Grants users or groups in your IAM Identity Center identity source access to your Amazon Kendra \
@@ -54,6 +67,19 @@ module AssociatePersonasToEntities : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_personas_to_entities_request ->
+    ( associate_personas_to_entities_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceAlreadyExistException of resource_already_exist_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Defines the specific permissions of users or groups in your IAM Identity Center identity source \
@@ -77,6 +103,19 @@ module BatchDeleteDocument : sig
     'http_type Smaws_Lib.Context.t ->
     batch_delete_document_request ->
     ( batch_delete_document_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_delete_document_request ->
+    ( batch_delete_document_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -119,6 +158,18 @@ module BatchDeleteFeaturedResultsSet : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_delete_featured_results_set_request ->
+    ( batch_delete_featured_results_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes one or more sets of featured results. Features results are placed above all other \
@@ -140,6 +191,19 @@ module BatchGetDocumentStatus : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_document_status_request ->
     ( batch_get_document_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_document_status_request ->
+    ( batch_get_document_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -179,6 +243,20 @@ module BatchPutDocument : sig
     'http_type Smaws_Lib.Context.t ->
     batch_put_document_request ->
     ( batch_put_document_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_put_document_request ->
+    ( batch_put_document_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -229,6 +307,19 @@ module ClearQuerySuggestions : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    clear_query_suggestions_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Clears existing query suggestions from an index.\n\n\
@@ -257,6 +348,20 @@ module CreateAccessControlConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     create_access_control_configuration_request ->
     ( create_access_control_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_access_control_configuration_request ->
+    ( create_access_control_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -323,6 +428,21 @@ module CreateDataSource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_data_source_request ->
+    ( create_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceAlreadyExistException of resource_already_exist_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a data source connector that you want to use with an Amazon Kendra index.\n\n\
@@ -363,6 +483,20 @@ module CreateExperience : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_experience_request ->
+    ( create_experience_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an Amazon Kendra experience such as a search application. For more information on \
@@ -386,6 +520,20 @@ module CreateFaq : sig
     'http_type Smaws_Lib.Context.t ->
     create_faq_request ->
     ( create_faq_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_faq_request ->
+    ( create_faq_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -431,6 +579,20 @@ module CreateFeaturedResultsSet : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_featured_results_set_request ->
+    ( create_featured_results_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `FeaturedResultsConflictException of featured_results_conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a set of featured results to display at the top of the search results page. Featured \
@@ -457,6 +619,20 @@ module CreateIndex : sig
     'http_type Smaws_Lib.Context.t ->
     create_index_request ->
     ( create_index_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceAlreadyExistException of resource_already_exist_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_index_request ->
+    ( create_index_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -497,6 +673,20 @@ module CreateQuerySuggestionsBlockList : sig
     'http_type Smaws_Lib.Context.t ->
     create_query_suggestions_block_list_request ->
     ( create_query_suggestions_block_list_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_query_suggestions_block_list_request ->
+    ( create_query_suggestions_block_list_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -551,6 +741,20 @@ module CreateThesaurus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_thesaurus_request ->
+    ( create_thesaurus_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a thesaurus for an index. The thesaurus contains a list of synonyms in Solr format.\n\n\
@@ -582,6 +786,19 @@ module DeleteAccessControlConfiguration : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_access_control_configuration_request ->
+    ( delete_access_control_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an access control configuration that you created for your documents in an index. This \
@@ -604,6 +821,19 @@ module DeleteDataSource : sig
     'http_type Smaws_Lib.Context.t ->
     delete_data_source_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_data_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -647,6 +877,19 @@ module DeleteExperience : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_experience_request ->
+    ( delete_experience_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes your Amazon Kendra experience such as a search application. For more information on \
@@ -669,6 +912,19 @@ module DeleteFaq : sig
     'http_type Smaws_Lib.Context.t ->
     delete_faq_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_faq_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -703,6 +959,19 @@ module DeleteIndex : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_index_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an Amazon Kendra index. An exception is not thrown if the index is already being \
@@ -724,6 +993,19 @@ module DeletePrincipalMapping : sig
     'http_type Smaws_Lib.Context.t ->
     delete_principal_mapping_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_principal_mapping_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -773,6 +1055,19 @@ module DeleteQuerySuggestionsBlockList : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_query_suggestions_block_list_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a block list used for query suggestions for an index.\n\n\
@@ -806,6 +1101,19 @@ module DeleteThesaurus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_thesaurus_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes an Amazon Kendra thesaurus. \n"]
 
@@ -823,6 +1131,18 @@ module DescribeAccessControlConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     describe_access_control_configuration_request ->
     ( describe_access_control_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_access_control_configuration_request ->
+    ( describe_access_control_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -858,6 +1178,18 @@ module DescribeDataSource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_data_source_request ->
+    ( describe_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra data source connector.\n"]
 
@@ -875,6 +1207,18 @@ module DescribeExperience : sig
     'http_type Smaws_Lib.Context.t ->
     describe_experience_request ->
     ( describe_experience_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_experience_request ->
+    ( describe_experience_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -910,6 +1254,18 @@ module DescribeFaq : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_faq_request ->
+    ( describe_faq_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets information about a FAQ.\n"]
 
@@ -927,6 +1283,18 @@ module DescribeFeaturedResultsSet : sig
     'http_type Smaws_Lib.Context.t ->
     describe_featured_results_set_request ->
     ( describe_featured_results_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_featured_results_set_request ->
+    ( describe_featured_results_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -961,6 +1329,18 @@ module DescribeIndex : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_index_request ->
+    ( describe_index_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra index.\n"]
 
@@ -978,6 +1358,18 @@ module DescribePrincipalMapping : sig
     'http_type Smaws_Lib.Context.t ->
     describe_principal_mapping_request ->
     ( describe_principal_mapping_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_principal_mapping_request ->
+    ( describe_principal_mapping_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1017,6 +1409,18 @@ module DescribeQuerySuggestionsBlockList : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_query_suggestions_block_list_request ->
+    ( describe_query_suggestions_block_list_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets information about a block list used for query suggestions for an index.\n\n\
@@ -1040,6 +1444,18 @@ module DescribeQuerySuggestionsConfig : sig
     'http_type Smaws_Lib.Context.t ->
     describe_query_suggestions_config_request ->
     ( describe_query_suggestions_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_query_suggestions_config_request ->
+    ( describe_query_suggestions_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1077,6 +1493,18 @@ module DescribeThesaurus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_thesaurus_request ->
+    ( describe_thesaurus_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets information about an Amazon Kendra thesaurus.\n"]
 
@@ -1094,6 +1522,18 @@ module DisassociateEntitiesFromExperience : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_entities_from_experience_request ->
     ( disassociate_entities_from_experience_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_entities_from_experience_request ->
+    ( disassociate_entities_from_experience_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1123,6 +1563,18 @@ module DisassociatePersonasFromEntities : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_personas_from_entities_request ->
     ( disassociate_personas_from_entities_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_personas_from_entities_request ->
+    ( disassociate_personas_from_entities_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1163,6 +1615,20 @@ module GetQuerySuggestions : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_query_suggestions_request ->
+    ( get_query_suggestions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Fetches the queries that are suggested to your users.\n\n\
@@ -1189,6 +1655,17 @@ module GetSnapshots : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_snapshots_request ->
+    ( get_snapshots_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves search metrics data. The data provides a snapshot of how your users interact with \
@@ -1208,6 +1685,18 @@ module ListAccessControlConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     list_access_control_configurations_request ->
     ( list_access_control_configurations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_access_control_configurations_request ->
+    ( list_access_control_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1244,6 +1733,19 @@ module ListDataSourceSyncJobs : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_data_source_sync_jobs_request ->
+    ( list_data_source_sync_jobs_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets statistics about synchronizing a data source connector.\n"]
 
@@ -1261,6 +1763,18 @@ module ListDataSources : sig
     'http_type Smaws_Lib.Context.t ->
     list_data_sources_request ->
     ( list_data_sources_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_data_sources_request ->
+    ( list_data_sources_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1292,6 +1806,18 @@ module ListEntityPersonas : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_entity_personas_request ->
+    ( list_entity_personas_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists specific permissions of users and groups with access to your Amazon Kendra experience.\n"]
@@ -1310,6 +1836,18 @@ module ListExperienceEntities : sig
     'http_type Smaws_Lib.Context.t ->
     list_experience_entities_request ->
     ( list_experience_entities_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_experience_entities_request ->
+    ( list_experience_entities_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1346,6 +1884,18 @@ module ListExperiences : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_experiences_request ->
+    ( list_experiences_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists one or more Amazon Kendra experiences. You can create an Amazon Kendra experience such as \
@@ -1374,6 +1924,18 @@ module ListFaqs : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_faqs_request ->
+    ( list_faqs_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Gets a list of FAQs associated with an index.\n"]
 
@@ -1391,6 +1953,18 @@ module ListFeaturedResultsSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_featured_results_sets_request ->
     ( list_featured_results_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_featured_results_sets_request ->
+    ( list_featured_results_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1427,6 +2001,19 @@ module ListGroupsOlderThanOrderingId : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_groups_older_than_ordering_id_request ->
+    ( list_groups_older_than_ordering_id_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of groups that are mapped to users before a given ordering or timestamp \
@@ -1454,6 +2041,17 @@ module ListIndices : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_indices_request ->
+    ( list_indices_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the Amazon Kendra indexes that you created.\n"]
 
@@ -1471,6 +2069,18 @@ module ListQuerySuggestionsBlockLists : sig
     'http_type Smaws_Lib.Context.t ->
     list_query_suggestions_block_lists_request ->
     ( list_query_suggestions_block_lists_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_query_suggestions_block_lists_request ->
+    ( list_query_suggestions_block_lists_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1509,6 +2119,18 @@ module ListTagsForResource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets a list of tags associated with a resource. Indexes, FAQs, data sources, and other \
@@ -1535,6 +2157,18 @@ module ListThesauri : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_thesauri_request ->
+    ( list_thesauri_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the thesauri for an index.\n"]
 
@@ -1554,6 +2188,20 @@ module PutPrincipalMapping : sig
     'http_type Smaws_Lib.Context.t ->
     put_principal_mapping_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_principal_mapping_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1598,6 +2246,20 @@ module Query : sig
     'http_type Smaws_Lib.Context.t ->
     query_request ->
     ( query_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    query_request ->
+    ( query_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1664,6 +2326,20 @@ module Retrieve : sig
     'http_type Smaws_Lib.Context.t ->
     retrieve_request ->
     ( retrieve_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    retrieve_request ->
+    ( retrieve_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1747,6 +2423,20 @@ module StartDataSourceSyncJob : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_data_source_sync_job_request ->
+    ( start_data_source_sync_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts a synchronization job for a data source connector. If a synchronization job is already \
@@ -1777,6 +2467,18 @@ module StopDataSourceSyncJob : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_data_source_sync_job_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops a synchronization job that is currently running. You can't stop a scheduled \
@@ -1797,6 +2499,19 @@ module SubmitFeedback : sig
     'http_type Smaws_Lib.Context.t ->
     submit_feedback_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    submit_feedback_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1833,6 +2548,18 @@ module TagResource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds the specified tag to the specified index, FAQ, data source, or other resource. If the tag \
@@ -1859,6 +2586,18 @@ module UntagResource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceUnavailableException of resource_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Removes a tag from an index, FAQ, data source, or other resource.\n"]
 
@@ -1878,6 +2617,20 @@ module UpdateAccessControlConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     update_access_control_configuration_request ->
     ( update_access_control_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_access_control_configuration_request ->
+    ( update_access_control_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1938,6 +2691,19 @@ module UpdateDataSource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_data_source_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates an Amazon Kendra data source connector.\n"]
 
@@ -1956,6 +2722,19 @@ module UpdateExperience : sig
     'http_type Smaws_Lib.Context.t ->
     update_experience_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_experience_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1986,6 +2765,19 @@ module UpdateFeaturedResultsSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_featured_results_set_request ->
     ( update_featured_results_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `FeaturedResultsConflictException of featured_results_conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_featured_results_set_request ->
+    ( update_featured_results_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `FeaturedResultsConflictException of featured_results_conflict_exception
@@ -2026,6 +2818,20 @@ module UpdateIndex : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_index_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates an Amazon Kendra index.\n"]
 
@@ -2044,6 +2850,19 @@ module UpdateQuerySuggestionsBlockList : sig
     'http_type Smaws_Lib.Context.t ->
     update_query_suggestions_block_list_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_query_suggestions_block_list_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2092,6 +2911,19 @@ module UpdateQuerySuggestionsConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_query_suggestions_config_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the settings of query suggestions for an index.\n\n\
@@ -2126,6 +2958,19 @@ module UpdateThesaurus : sig
     'http_type Smaws_Lib.Context.t ->
     update_thesaurus_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_thesaurus_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/keyspaces/Smaws_Client_Keyspaces.mli
+++ b/sdks/keyspaces/Smaws_Client_Keyspaces.mli
@@ -385,6 +385,18 @@ module CreateKeyspace : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_keyspace_request ->
+    ( create_keyspace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "The [CreateKeyspace] operation adds a new keyspace to your account. In an Amazon Web Services \
@@ -412,6 +424,19 @@ module CreateTable : sig
     'http_type Smaws_Lib.Context.t ->
     create_table_request ->
     ( create_table_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_table_request ->
+    ( create_table_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -457,6 +482,19 @@ module CreateType : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_type_request ->
+    ( create_type_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   " The [CreateType] operation creates a new user-defined type in the specified keyspace. \n\n\
@@ -492,6 +530,19 @@ module DeleteKeyspace : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_keyspace_request ->
+    ( delete_keyspace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "The [DeleteKeyspace] operation deletes a keyspace and all of its tables. \n"]
 
@@ -510,6 +561,19 @@ module DeleteTable : sig
     'http_type Smaws_Lib.Context.t ->
     delete_table_request ->
     ( delete_table_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_table_request ->
+    ( delete_table_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -550,6 +614,19 @@ module DeleteType : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_type_request ->
+    ( delete_type_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   " The [DeleteType] operation deletes a user-defined type (UDT). You can only delete a type that \
@@ -573,6 +650,18 @@ module GetKeyspace : sig
     'http_type Smaws_Lib.Context.t ->
     get_keyspace_request ->
     ( get_keyspace_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_keyspace_request ->
+    ( get_keyspace_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -607,6 +696,18 @@ module GetTable : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_table_request ->
+    ( get_table_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the table, including the table's name and current status, the \
@@ -629,6 +730,18 @@ module GetTableAutoScalingSettings : sig
     'http_type Smaws_Lib.Context.t ->
     get_table_auto_scaling_settings_request ->
     ( get_table_auto_scaling_settings_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_table_auto_scaling_settings_request ->
+    ( get_table_auto_scaling_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -684,6 +797,18 @@ module GetType : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_type_request ->
+    ( get_type_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   " The [GetType] operation returns information about the type, for example the field definitions, \
@@ -716,6 +841,18 @@ module ListKeyspaces : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_keyspaces_request ->
+    ( list_keyspaces_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "The [ListKeyspaces] operation returns a list of keyspaces.\n"]
 
@@ -733,6 +870,18 @@ module ListTables : sig
     'http_type Smaws_Lib.Context.t ->
     list_tables_request ->
     ( list_tables_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tables_request ->
+    ( list_tables_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -768,6 +917,18 @@ module ListTagsForResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of all tags associated with the specified Amazon Keyspaces resource.\n\n\
@@ -789,6 +950,18 @@ module ListTypes : sig
     'http_type Smaws_Lib.Context.t ->
     list_types_request ->
     ( list_types_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_types_request ->
+    ( list_types_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -820,6 +993,19 @@ module RestoreTable : sig
     'http_type Smaws_Lib.Context.t ->
     restore_table_request ->
     ( restore_table_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_table_request ->
+    ( restore_table_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -907,6 +1093,19 @@ module TagResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates a set of tags with a Amazon Keyspaces resource. You can then activate these \
@@ -943,6 +1142,19 @@ module UntagResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Removes the association of tags from a Amazon Keyspaces resource.\n"]
 
@@ -961,6 +1173,19 @@ module UpdateKeyspace : sig
     'http_type Smaws_Lib.Context.t ->
     update_keyspace_request ->
     ( update_keyspace_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_keyspace_request ->
+    ( update_keyspace_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1067,6 +1292,19 @@ module UpdateTable : sig
     'http_type Smaws_Lib.Context.t ->
     update_table_request ->
     ( update_table_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_table_request ->
+    ( update_table_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/keyspaces/Smaws_Client_Keyspaces.mli
+++ b/sdks/keyspaces/Smaws_Client_Keyspaces.mli
@@ -395,7 +395,8 @@ module CreateKeyspace : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -443,7 +444,8 @@ module CreateTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -493,7 +495,8 @@ module CreateType : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -541,7 +544,8 @@ module DeleteKeyspace : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The [DeleteKeyspace] operation deletes a keyspace and all of its tables. \n"]
@@ -580,7 +584,8 @@ module DeleteTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -625,7 +630,8 @@ module DeleteType : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -667,7 +673,8 @@ module GetKeyspace : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -706,7 +713,8 @@ module GetTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -747,7 +755,8 @@ module GetTableAutoScalingSettings : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -807,7 +816,8 @@ module GetType : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -851,7 +861,8 @@ module ListKeyspaces : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The [ListKeyspaces] operation returns a list of keyspaces.\n"]
@@ -887,7 +898,8 @@ module ListTables : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -927,7 +939,8 @@ module ListTagsForResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -967,7 +980,8 @@ module ListTypes : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1012,7 +1026,8 @@ module RestoreTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1104,7 +1119,8 @@ module TagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1153,7 +1169,8 @@ module UntagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the association of tags from a Amazon Keyspaces resource.\n"]
@@ -1192,7 +1209,8 @@ module UpdateKeyspace : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1311,7 +1329,8 @@ module UpdateTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/keyspaces/operations.ml
+++ b/sdks/keyspaces/operations.ml
@@ -34,6 +34,12 @@ module CreateKeyspace = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.CreateKeyspace" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_keyspace_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_keyspace_request) =
+    let input = Json_serializers.create_keyspace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.CreateKeyspace"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_keyspace_response_of_yojson ~error_deserializer
 end
 
 module CreateTable = struct
@@ -73,6 +79,12 @@ module CreateTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.CreateTable" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_table_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_table_request) =
+    let input = Json_serializers.create_table_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.CreateTable"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_table_response_of_yojson ~error_deserializer
 end
 
 module CreateType = struct
@@ -112,6 +124,12 @@ module CreateType = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.CreateType" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_type_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_type_request) =
+    let input = Json_serializers.create_type_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.CreateType"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_type_response_of_yojson ~error_deserializer
 end
 
 module DeleteKeyspace = struct
@@ -151,6 +169,12 @@ module DeleteKeyspace = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.DeleteKeyspace" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_keyspace_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_keyspace_request) =
+    let input = Json_serializers.delete_keyspace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.DeleteKeyspace"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_keyspace_response_of_yojson ~error_deserializer
 end
 
 module DeleteTable = struct
@@ -190,6 +214,12 @@ module DeleteTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.DeleteTable" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_table_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_table_request) =
+    let input = Json_serializers.delete_table_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.DeleteTable"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_table_response_of_yojson ~error_deserializer
 end
 
 module DeleteType = struct
@@ -229,6 +259,12 @@ module DeleteType = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.DeleteType" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_type_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_type_request) =
+    let input = Json_serializers.delete_type_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.DeleteType"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_type_response_of_yojson ~error_deserializer
 end
 
 module GetKeyspace = struct
@@ -265,6 +301,12 @@ module GetKeyspace = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.GetKeyspace" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_keyspace_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_keyspace_request) =
+    let input = Json_serializers.get_keyspace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.GetKeyspace"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_keyspace_response_of_yojson ~error_deserializer
 end
 
 module GetTable = struct
@@ -300,6 +342,12 @@ module GetTable = struct
     let input = Json_serializers.get_table_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.GetTable" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_table_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_table_request) =
+    let input = Json_serializers.get_table_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.GetTable"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_table_response_of_yojson
       ~error_deserializer
 end
 
@@ -338,6 +386,13 @@ module GetTableAutoScalingSettings = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_table_auto_scaling_settings_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_table_auto_scaling_settings_request) =
+    let input = Json_serializers.get_table_auto_scaling_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KeyspacesService.GetTableAutoScalingSettings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_table_auto_scaling_settings_response_of_yojson
+      ~error_deserializer
 end
 
 module GetType = struct
@@ -373,6 +428,12 @@ module GetType = struct
     let input = Json_serializers.get_type_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.GetType" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_type_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_type_request) =
+    let input = Json_serializers.get_type_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.GetType"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_type_response_of_yojson
+      ~error_deserializer
 end
 
 module ListKeyspaces = struct
@@ -409,6 +470,12 @@ module ListKeyspaces = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.ListKeyspaces" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_keyspaces_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_keyspaces_request) =
+    let input = Json_serializers.list_keyspaces_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.ListKeyspaces"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_keyspaces_response_of_yojson ~error_deserializer
 end
 
 module ListTables = struct
@@ -445,6 +512,12 @@ module ListTables = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.ListTables" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_tables_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tables_request) =
+    let input = Json_serializers.list_tables_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.ListTables"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tables_response_of_yojson ~error_deserializer
 end
 
 module ListTagsForResource = struct
@@ -482,6 +555,13 @@ module ListTagsForResource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KeyspacesService.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module ListTypes = struct
@@ -517,6 +597,12 @@ module ListTypes = struct
     let input = Json_serializers.list_types_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.ListTypes" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_types_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_types_request) =
+    let input = Json_serializers.list_types_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.ListTypes"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_types_response_of_yojson
       ~error_deserializer
 end
 
@@ -557,6 +643,12 @@ module RestoreTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.RestoreTable" ~service
       ~context ~input ~output_deserializer:Json_deserializers.restore_table_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : restore_table_request) =
+    let input = Json_serializers.restore_table_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.RestoreTable"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.restore_table_response_of_yojson ~error_deserializer
 end
 
 module TagResource = struct
@@ -596,6 +688,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.TagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -635,6 +733,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
 module UpdateKeyspace = struct
@@ -674,6 +778,12 @@ module UpdateKeyspace = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.UpdateKeyspace" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_keyspace_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_keyspace_request) =
+    let input = Json_serializers.update_keyspace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.UpdateKeyspace"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_keyspace_response_of_yojson ~error_deserializer
 end
 
 module UpdateTable = struct
@@ -713,4 +823,10 @@ module UpdateTable = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KeyspacesService.UpdateTable" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_table_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_table_request) =
+    let input = Json_serializers.update_table_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"KeyspacesService.UpdateTable"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_table_response_of_yojson ~error_deserializer
 end

--- a/sdks/keyspaces/operations.mli
+++ b/sdks/keyspaces/operations.mli
@@ -21,6 +21,18 @@ module CreateKeyspace : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_keyspace_request ->
+    ( create_keyspace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "The [CreateKeyspace] operation adds a new keyspace to your account. In an Amazon Web Services \
@@ -48,6 +60,19 @@ module CreateTable : sig
     'http_type Smaws_Lib.Context.t ->
     create_table_request ->
     ( create_table_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_table_request ->
+    ( create_table_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -93,6 +118,19 @@ module CreateType : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_type_request ->
+    ( create_type_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   " The [CreateType] operation creates a new user-defined type in the specified keyspace. \n\n\
@@ -128,6 +166,19 @@ module DeleteKeyspace : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_keyspace_request ->
+    ( delete_keyspace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "The [DeleteKeyspace] operation deletes a keyspace and all of its tables. \n"]
 
@@ -146,6 +197,19 @@ module DeleteTable : sig
     'http_type Smaws_Lib.Context.t ->
     delete_table_request ->
     ( delete_table_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_table_request ->
+    ( delete_table_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -186,6 +250,19 @@ module DeleteType : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_type_request ->
+    ( delete_type_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   " The [DeleteType] operation deletes a user-defined type (UDT). You can only delete a type that \
@@ -209,6 +286,18 @@ module GetKeyspace : sig
     'http_type Smaws_Lib.Context.t ->
     get_keyspace_request ->
     ( get_keyspace_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_keyspace_request ->
+    ( get_keyspace_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -243,6 +332,18 @@ module GetTable : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_table_request ->
+    ( get_table_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the table, including the table's name and current status, the \
@@ -265,6 +366,18 @@ module GetTableAutoScalingSettings : sig
     'http_type Smaws_Lib.Context.t ->
     get_table_auto_scaling_settings_request ->
     ( get_table_auto_scaling_settings_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_table_auto_scaling_settings_request ->
+    ( get_table_auto_scaling_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -320,6 +433,18 @@ module GetType : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_type_request ->
+    ( get_type_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   " The [GetType] operation returns information about the type, for example the field definitions, \
@@ -352,6 +477,18 @@ module ListKeyspaces : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_keyspaces_request ->
+    ( list_keyspaces_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "The [ListKeyspaces] operation returns a list of keyspaces.\n"]
 
@@ -369,6 +506,18 @@ module ListTables : sig
     'http_type Smaws_Lib.Context.t ->
     list_tables_request ->
     ( list_tables_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tables_request ->
+    ( list_tables_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -404,6 +553,18 @@ module ListTagsForResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of all tags associated with the specified Amazon Keyspaces resource.\n\n\
@@ -425,6 +586,18 @@ module ListTypes : sig
     'http_type Smaws_Lib.Context.t ->
     list_types_request ->
     ( list_types_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_types_request ->
+    ( list_types_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -456,6 +629,19 @@ module RestoreTable : sig
     'http_type Smaws_Lib.Context.t ->
     restore_table_request ->
     ( restore_table_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    restore_table_request ->
+    ( restore_table_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -543,6 +729,19 @@ module TagResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates a set of tags with a Amazon Keyspaces resource. You can then activate these \
@@ -579,6 +778,19 @@ module UntagResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Removes the association of tags from a Amazon Keyspaces resource.\n"]
 
@@ -597,6 +809,19 @@ module UpdateKeyspace : sig
     'http_type Smaws_Lib.Context.t ->
     update_keyspace_request ->
     ( update_keyspace_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_keyspace_request ->
+    ( update_keyspace_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -702,6 +927,19 @@ module UpdateTable : sig
     'http_type Smaws_Lib.Context.t ->
     update_table_request ->
     ( update_table_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_table_request ->
+    ( update_table_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/keyspaces/operations.mli
+++ b/sdks/keyspaces/operations.mli
@@ -31,7 +31,8 @@ module CreateKeyspace : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -79,7 +80,8 @@ module CreateTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -129,7 +131,8 @@ module CreateType : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -177,7 +180,8 @@ module DeleteKeyspace : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The [DeleteKeyspace] operation deletes a keyspace and all of its tables. \n"]
@@ -216,7 +220,8 @@ module DeleteTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -261,7 +266,8 @@ module DeleteType : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -303,7 +309,8 @@ module GetKeyspace : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -342,7 +349,8 @@ module GetTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -383,7 +391,8 @@ module GetTableAutoScalingSettings : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -443,7 +452,8 @@ module GetType : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -487,7 +497,8 @@ module ListKeyspaces : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The [ListKeyspaces] operation returns a list of keyspaces.\n"]
@@ -523,7 +534,8 @@ module ListTables : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -563,7 +575,8 @@ module ListTagsForResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -603,7 +616,8 @@ module ListTypes : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -648,7 +662,8 @@ module RestoreTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -740,7 +755,8 @@ module TagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -789,7 +805,8 @@ module UntagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the association of tags from a Amazon Keyspaces resource.\n"]
@@ -828,7 +845,8 @@ module UpdateKeyspace : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -946,7 +964,8 @@ module UpdateTable : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/kinesis-analytics-v2/Smaws_Client_KinesisAnalyticsV2.mli
+++ b/sdks/kinesis-analytics-v2/Smaws_Client_KinesisAnalyticsV2.mli
@@ -1162,7 +1162,8 @@ module AddApplicationCloudWatchLoggingOption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds an Amazon CloudWatch log stream to monitor application configuration errors.\n"]
@@ -1201,7 +1202,8 @@ module AddApplicationInput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1246,7 +1248,8 @@ module AddApplicationInputProcessingConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1286,7 +1289,8 @@ module AddApplicationOutput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1336,7 +1340,8 @@ module AddApplicationReferenceDataSource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1379,7 +1384,8 @@ module AddApplicationVpcConfiguration : sig
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1439,7 +1445,8 @@ module CreateApplication : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1473,7 +1480,8 @@ module CreateApplicationPresignedUrl : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1530,7 +1538,8 @@ module CreateApplicationSnapshot : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a snapshot of the application's state data.\n"]
@@ -1569,7 +1578,8 @@ module DeleteApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1610,7 +1620,8 @@ module DeleteApplicationCloudWatchLoggingOption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1647,7 +1658,8 @@ module DeleteApplicationInputProcessingConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an [InputProcessingConfiguration] from an input.\n"]
@@ -1683,7 +1695,8 @@ module DeleteApplicationOutput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1722,7 +1735,8 @@ module DeleteApplicationReferenceDataSource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1766,7 +1780,8 @@ module DeleteApplicationSnapshot : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a snapshot of application state.\n"]
@@ -1802,7 +1817,8 @@ module DeleteApplicationVpcConfiguration : sig
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a VPC configuration from a Managed Service for Apache Flink application.\n"]
@@ -1832,7 +1848,8 @@ module DescribeApplication : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1866,7 +1883,8 @@ module DescribeApplicationOperation : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1901,7 +1919,8 @@ module DescribeApplicationSnapshot : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a snapshot of application state data.\n"]
@@ -1931,7 +1950,8 @@ module DescribeApplicationVersion : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1978,7 +1998,8 @@ module DiscoverInputSchema : sig
         resource_provisioned_throughput_exceeded_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `UnableToDetectSchemaException of unable_to_detect_schema_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2016,7 +2037,8 @@ module ListApplicationOperations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2051,7 +2073,8 @@ module ListApplicationSnapshots : sig
     ( list_application_snapshots_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists information about the current application snapshots.\n"]
@@ -2081,7 +2104,8 @@ module ListApplicationVersions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2112,7 +2136,7 @@ module ListApplications : sig
     list_applications_request ->
     ( list_applications_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidRequestException of invalid_request_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2147,7 +2171,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2188,7 +2213,8 @@ module RollbackApplication : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2232,7 +2258,8 @@ module StartApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2273,7 +2300,8 @@ module StopApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2316,7 +2344,8 @@ module TagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2356,7 +2385,8 @@ module UntagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2404,7 +2434,8 @@ module UpdateApplication : sig
       | `InvalidRequestException of invalid_request_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2446,7 +2477,8 @@ module UpdateApplicationMaintenanceConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/kinesis-analytics-v2/Smaws_Client_KinesisAnalyticsV2.mli
+++ b/sdks/kinesis-analytics-v2/Smaws_Client_KinesisAnalyticsV2.mli
@@ -1151,6 +1151,19 @@ module AddApplicationCloudWatchLoggingOption : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_cloud_watch_logging_option_request ->
+    ( add_application_cloud_watch_logging_option_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Adds an Amazon CloudWatch log stream to monitor application configuration errors.\n"]
 
@@ -1169,6 +1182,19 @@ module AddApplicationInput : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_input_request ->
     ( add_application_input_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_input_request ->
+    ( add_application_input_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CodeValidationException of code_validation_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -1210,6 +1236,18 @@ module AddApplicationInputProcessingConfiguration : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_input_processing_configuration_request ->
+    ( add_application_input_processing_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds an [InputProcessingConfiguration] to a SQL-based Kinesis Data Analytics application. An \
@@ -1231,6 +1269,18 @@ module AddApplicationOutput : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_output_request ->
     ( add_application_output_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_output_request ->
+    ( add_application_output_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1276,6 +1326,18 @@ module AddApplicationReferenceDataSource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_reference_data_source_request ->
+    ( add_application_reference_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds a reference data source to an existing SQL-based Kinesis Data Analytics application.\n\n\
@@ -1300,6 +1362,18 @@ module AddApplicationVpcConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_vpc_configuration_request ->
     ( add_application_vpc_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_vpc_configuration_request ->
+    ( add_application_vpc_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
@@ -1352,6 +1426,21 @@ module CreateApplication : sig
       | `TooManyTagsException of too_many_tags_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_application_request ->
+    ( create_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a Managed Service for Apache Flink application. For information about creating a \
@@ -1371,6 +1460,16 @@ module CreateApplicationPresignedUrl : sig
     'http_type Smaws_Lib.Context.t ->
     create_application_presigned_url_request ->
     ( create_application_presigned_url_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_application_presigned_url_request ->
+    ( create_application_presigned_url_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
@@ -1419,6 +1518,20 @@ module CreateApplicationSnapshot : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_application_snapshot_request ->
+    ( create_application_snapshot_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Creates a snapshot of the application's state data.\n"]
 
@@ -1437,6 +1550,19 @@ module DeleteApplication : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_request ->
     ( delete_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_request ->
+    ( delete_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
@@ -1473,6 +1599,19 @@ module DeleteApplicationCloudWatchLoggingOption : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_cloud_watch_logging_option_request ->
+    ( delete_application_cloud_watch_logging_option_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an Amazon CloudWatch log stream from an SQL-based Kinesis Data Analytics application. \n"]
@@ -1491,6 +1630,18 @@ module DeleteApplicationInputProcessingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_input_processing_configuration_request ->
     ( delete_application_input_processing_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_input_processing_configuration_request ->
+    ( delete_application_input_processing_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1522,6 +1673,18 @@ module DeleteApplicationOutput : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_output_request ->
+    ( delete_application_output_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the output destination configuration from your SQL-based Kinesis Data Analytics \
@@ -1542,6 +1705,18 @@ module DeleteApplicationReferenceDataSource : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_reference_data_source_request ->
     ( delete_application_reference_data_source_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_reference_data_source_request ->
+    ( delete_application_reference_data_source_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1580,6 +1755,19 @@ module DeleteApplicationSnapshot : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_snapshot_request ->
+    ( delete_application_snapshot_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a snapshot of application state.\n"]
 
@@ -1597,6 +1785,18 @@ module DeleteApplicationVpcConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_vpc_configuration_request ->
     ( delete_application_vpc_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_vpc_configuration_request ->
+    ( delete_application_vpc_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
@@ -1624,6 +1824,16 @@ module DescribeApplication : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_request ->
+    ( describe_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a specific Managed Service for Apache Flink application.\n\n\
@@ -1643,6 +1853,16 @@ module DescribeApplicationOperation : sig
     'http_type Smaws_Lib.Context.t ->
     describe_application_operation_request ->
     ( describe_application_operation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_operation_request ->
+    ( describe_application_operation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1673,6 +1893,16 @@ module DescribeApplicationSnapshot : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_snapshot_request ->
+    ( describe_application_snapshot_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a snapshot of application state data.\n"]
 
@@ -1688,6 +1918,16 @@ module DescribeApplicationVersion : sig
     'http_type Smaws_Lib.Context.t ->
     describe_application_version_request ->
     ( describe_application_version_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_version_request ->
+    ( describe_application_version_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1726,6 +1966,20 @@ module DiscoverInputSchema : sig
       | `UnableToDetectSchemaException of unable_to_detect_schema_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    discover_input_schema_request ->
+    ( discover_input_schema_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceProvisionedThroughputExceededException of
+        resource_provisioned_throughput_exceeded_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `UnableToDetectSchemaException of unable_to_detect_schema_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Infers a schema for a SQL-based Kinesis Data Analytics application by evaluating sample records \
@@ -1749,6 +2003,16 @@ module ListApplicationOperations : sig
     'http_type Smaws_Lib.Context.t ->
     list_application_operations_request ->
     ( list_application_operations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_application_operations_request ->
+    ( list_application_operations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1780,6 +2044,15 @@ module ListApplicationSnapshots : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_application_snapshots_request ->
+    ( list_application_snapshots_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Lists information about the current application snapshots.\n"]
 
@@ -1795,6 +2068,16 @@ module ListApplicationVersions : sig
     'http_type Smaws_Lib.Context.t ->
     list_application_versions_request ->
     ( list_application_versions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_application_versions_request ->
+    ( list_application_versions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1823,6 +2106,14 @@ module ListApplications : sig
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidRequestException of invalid_request_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_applications_request ->
+    ( list_applications_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidRequestException of invalid_request_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Returns a list of Managed Service for Apache Flink applications in your account. For each \
@@ -1848,6 +2139,16 @@ module ListTagsForResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the list of key-value tags assigned to the application. For more information, see \
@@ -1868,6 +2169,19 @@ module RollbackApplication : sig
     'http_type Smaws_Lib.Context.t ->
     rollback_application_request ->
     ( rollback_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    rollback_application_request ->
+    ( rollback_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1908,6 +2222,18 @@ module StartApplication : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_application_request ->
+    ( start_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the specified Managed Service for Apache Flink application. After creating an \
@@ -1928,6 +2254,19 @@ module StopApplication : sig
     'http_type Smaws_Lib.Context.t ->
     stop_application_request ->
     ( stop_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_application_request ->
+    ( stop_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
@@ -1967,6 +2306,18 @@ module TagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more key-value tags to a Managed Service for Apache Flink application. Note that \
@@ -1988,6 +2339,18 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -2028,6 +2391,21 @@ module UpdateApplication : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_application_request ->
+    ( update_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing Managed Service for Apache Flink application. Using this operation, you can \
@@ -2051,6 +2429,18 @@ module UpdateApplicationMaintenanceConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     update_application_maintenance_configuration_request ->
     ( update_application_maintenance_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_application_maintenance_configuration_request ->
+    ( update_application_maintenance_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception

--- a/sdks/kinesis-analytics-v2/operations.ml
+++ b/sdks/kinesis-analytics-v2/operations.ml
@@ -47,6 +47,17 @@ module AddApplicationCloudWatchLoggingOption = struct
       ~output_deserializer:
         Json_deserializers.add_application_cloud_watch_logging_option_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_application_cloud_watch_logging_option_request) =
+    let input =
+      Json_serializers.add_application_cloud_watch_logging_option_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.AddApplicationCloudWatchLoggingOption" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.add_application_cloud_watch_logging_option_response_of_yojson
+      ~error_deserializer
 end
 
 module AddApplicationInput = struct
@@ -88,6 +99,13 @@ module AddApplicationInput = struct
     let input = Json_serializers.add_application_input_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20180523.AddApplicationInput"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.add_application_input_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : add_application_input_request) =
+    let input = Json_serializers.add_application_input_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.AddApplicationInput" ~service ~context ~input
       ~output_deserializer:Json_deserializers.add_application_input_response_of_yojson
       ~error_deserializer
 end
@@ -133,6 +151,18 @@ module AddApplicationInputProcessingConfiguration = struct
       ~output_deserializer:
         Json_deserializers.add_application_input_processing_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : add_application_input_processing_configuration_request) =
+    let input =
+      Json_serializers.add_application_input_processing_configuration_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.AddApplicationInputProcessingConfiguration" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.add_application_input_processing_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module AddApplicationOutput = struct
@@ -170,6 +200,13 @@ module AddApplicationOutput = struct
     let input = Json_serializers.add_application_output_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20180523.AddApplicationOutput"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.add_application_output_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : add_application_output_request) =
+    let input = Json_serializers.add_application_output_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.AddApplicationOutput" ~service ~context ~input
       ~output_deserializer:Json_deserializers.add_application_output_response_of_yojson
       ~error_deserializer
 end
@@ -213,6 +250,15 @@ module AddApplicationReferenceDataSource = struct
       ~output_deserializer:
         Json_deserializers.add_application_reference_data_source_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_application_reference_data_source_request) =
+    let input = Json_serializers.add_application_reference_data_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.AddApplicationReferenceDataSource" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.add_application_reference_data_source_response_of_yojson
+      ~error_deserializer
 end
 
 module AddApplicationVpcConfiguration = struct
@@ -250,6 +296,14 @@ module AddApplicationVpcConfiguration = struct
   let request context (request : add_application_vpc_configuration_request) =
     let input = Json_serializers.add_application_vpc_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20180523.AddApplicationVpcConfiguration" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.add_application_vpc_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : add_application_vpc_configuration_request) =
+    let input = Json_serializers.add_application_vpc_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20180523.AddApplicationVpcConfiguration" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.add_application_vpc_configuration_response_of_yojson
@@ -304,6 +358,13 @@ module CreateApplication = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_application_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_application_request) =
+    let input = Json_serializers.create_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.CreateApplication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_application_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateApplicationPresignedUrl = struct
@@ -331,6 +392,13 @@ module CreateApplicationPresignedUrl = struct
   let request context (request : create_application_presigned_url_request) =
     let input = Json_serializers.create_application_presigned_url_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20180523.CreateApplicationPresignedUrl" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_application_presigned_url_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_application_presigned_url_request) =
+    let input = Json_serializers.create_application_presigned_url_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20180523.CreateApplicationPresignedUrl" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_application_presigned_url_response_of_yojson
       ~error_deserializer
@@ -381,6 +449,13 @@ module CreateApplicationSnapshot = struct
       ~shape_name:"KinesisAnalytics_20180523.CreateApplicationSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_application_snapshot_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_application_snapshot_request) =
+    let input = Json_serializers.create_application_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.CreateApplicationSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_application_snapshot_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteApplication = struct
@@ -423,6 +498,13 @@ module DeleteApplication = struct
     let input = Json_serializers.delete_application_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20180523.DeleteApplication"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_application_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_application_request) =
+    let input = Json_serializers.delete_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.DeleteApplication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_application_response_of_yojson
       ~error_deserializer
 end
@@ -473,6 +555,18 @@ module DeleteApplicationCloudWatchLoggingOption = struct
       ~output_deserializer:
         Json_deserializers.delete_application_cloud_watch_logging_option_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : delete_application_cloud_watch_logging_option_request) =
+    let input =
+      Json_serializers.delete_application_cloud_watch_logging_option_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationCloudWatchLoggingOption" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.delete_application_cloud_watch_logging_option_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteApplicationInputProcessingConfiguration = struct
@@ -511,6 +605,18 @@ module DeleteApplicationInputProcessingConfiguration = struct
       Json_serializers.delete_application_input_processing_configuration_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationInputProcessingConfiguration" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.delete_application_input_processing_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context
+      (request : delete_application_input_processing_configuration_request) =
+    let input =
+      Json_serializers.delete_application_input_processing_configuration_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationInputProcessingConfiguration" ~service
       ~context ~input
       ~output_deserializer:
@@ -555,6 +661,13 @@ module DeleteApplicationOutput = struct
       ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationOutput" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_application_output_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_application_output_request) =
+    let input = Json_serializers.delete_application_output_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationOutput" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_application_output_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteApplicationReferenceDataSource = struct
@@ -593,6 +706,17 @@ module DeleteApplicationReferenceDataSource = struct
       Json_serializers.delete_application_reference_data_source_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationReferenceDataSource" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.delete_application_reference_data_source_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_application_reference_data_source_request) =
+    let input =
+      Json_serializers.delete_application_reference_data_source_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationReferenceDataSource" ~service ~context
       ~input
       ~output_deserializer:
@@ -642,6 +766,13 @@ module DeleteApplicationSnapshot = struct
       ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_application_snapshot_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_application_snapshot_request) =
+    let input = Json_serializers.delete_application_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_application_snapshot_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteApplicationVpcConfiguration = struct
@@ -684,6 +815,15 @@ module DeleteApplicationVpcConfiguration = struct
       ~output_deserializer:
         Json_deserializers.delete_application_vpc_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_application_vpc_configuration_request) =
+    let input = Json_serializers.delete_application_vpc_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.DeleteApplicationVpcConfiguration" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.delete_application_vpc_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeApplication = struct
@@ -715,6 +855,13 @@ module DescribeApplication = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_application_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_application_request) =
+    let input = Json_serializers.describe_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.DescribeApplication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_application_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeApplicationOperation = struct
@@ -744,6 +891,13 @@ module DescribeApplicationOperation = struct
   let request context (request : describe_application_operation_request) =
     let input = Json_serializers.describe_application_operation_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20180523.DescribeApplicationOperation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_application_operation_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_application_operation_request) =
+    let input = Json_serializers.describe_application_operation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20180523.DescribeApplicationOperation" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_application_operation_response_of_yojson
       ~error_deserializer
@@ -779,6 +933,13 @@ module DescribeApplicationSnapshot = struct
       ~shape_name:"KinesisAnalytics_20180523.DescribeApplicationSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_application_snapshot_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_application_snapshot_request) =
+    let input = Json_serializers.describe_application_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.DescribeApplicationSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_application_snapshot_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeApplicationVersion = struct
@@ -808,6 +969,13 @@ module DescribeApplicationVersion = struct
   let request context (request : describe_application_version_request) =
     let input = Json_serializers.describe_application_version_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20180523.DescribeApplicationVersion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_application_version_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_application_version_request) =
+    let input = Json_serializers.describe_application_version_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20180523.DescribeApplicationVersion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_application_version_response_of_yojson
       ~error_deserializer
@@ -859,6 +1027,13 @@ module DiscoverInputSchema = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.discover_input_schema_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : discover_input_schema_request) =
+    let input = Json_serializers.discover_input_schema_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.DiscoverInputSchema" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.discover_input_schema_response_of_yojson
+      ~error_deserializer
 end
 
 module ListApplicationOperations = struct
@@ -891,6 +1066,13 @@ module ListApplicationOperations = struct
       ~shape_name:"KinesisAnalytics_20180523.ListApplicationOperations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_application_operations_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_application_operations_request) =
+    let input = Json_serializers.list_application_operations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.ListApplicationOperations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_application_operations_response_of_yojson
+      ~error_deserializer
 end
 
 module ListApplicationSnapshots = struct
@@ -916,6 +1098,13 @@ module ListApplicationSnapshots = struct
   let request context (request : list_application_snapshots_request) =
     let input = Json_serializers.list_application_snapshots_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20180523.ListApplicationSnapshots" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_application_snapshots_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_application_snapshots_request) =
+    let input = Json_serializers.list_application_snapshots_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20180523.ListApplicationSnapshots" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_application_snapshots_response_of_yojson
       ~error_deserializer
@@ -951,6 +1140,13 @@ module ListApplicationVersions = struct
       ~shape_name:"KinesisAnalytics_20180523.ListApplicationVersions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_application_versions_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_application_versions_request) =
+    let input = Json_serializers.list_application_versions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.ListApplicationVersions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_application_versions_response_of_yojson
+      ~error_deserializer
 end
 
 module ListApplications = struct
@@ -972,6 +1168,13 @@ module ListApplications = struct
     let input = Json_serializers.list_applications_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20180523.ListApplications"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_applications_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_applications_request) =
+    let input = Json_serializers.list_applications_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.ListApplications" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_applications_response_of_yojson
       ~error_deserializer
 end
@@ -1004,6 +1207,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20180523.ListTagsForResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
 end
@@ -1050,6 +1260,13 @@ module RollbackApplication = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.rollback_application_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : rollback_application_request) =
+    let input = Json_serializers.rollback_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.RollbackApplication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.rollback_application_response_of_yojson
+      ~error_deserializer
 end
 
 module StartApplication = struct
@@ -1087,6 +1304,13 @@ module StartApplication = struct
     let input = Json_serializers.start_application_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20180523.StartApplication"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_application_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_application_request) =
+    let input = Json_serializers.start_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.StartApplication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_application_response_of_yojson
       ~error_deserializer
 end
@@ -1133,6 +1357,13 @@ module StopApplication = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.stop_application_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : stop_application_request) =
+    let input = Json_serializers.stop_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.StopApplication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_application_response_of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -1170,6 +1401,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20180523.TagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.TagResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1206,6 +1443,12 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20180523.UntagResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.UntagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
@@ -1258,6 +1501,13 @@ module UpdateApplication = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_application_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_application_request) =
+    let input = Json_serializers.update_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20180523.UpdateApplication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_application_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateApplicationMaintenanceConfiguration = struct
@@ -1297,6 +1547,18 @@ module UpdateApplicationMaintenanceConfiguration = struct
       Json_serializers.update_application_maintenance_configuration_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20180523.UpdateApplicationMaintenanceConfiguration" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.update_application_maintenance_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_application_maintenance_configuration_request)
+      =
+    let input =
+      Json_serializers.update_application_maintenance_configuration_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20180523.UpdateApplicationMaintenanceConfiguration" ~service
       ~context ~input
       ~output_deserializer:

--- a/sdks/kinesis-analytics-v2/operations.mli
+++ b/sdks/kinesis-analytics-v2/operations.mli
@@ -34,7 +34,8 @@ module AddApplicationCloudWatchLoggingOption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds an Amazon CloudWatch log stream to monitor application configuration errors.\n"]
@@ -73,7 +74,8 @@ module AddApplicationInput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -118,7 +120,8 @@ module AddApplicationInputProcessingConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -158,7 +161,8 @@ module AddApplicationOutput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -208,7 +212,8 @@ module AddApplicationReferenceDataSource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -251,7 +256,8 @@ module AddApplicationVpcConfiguration : sig
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -311,7 +317,8 @@ module CreateApplication : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `TooManyTagsException of too_many_tags_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -345,7 +352,8 @@ module CreateApplicationPresignedUrl : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -402,7 +410,8 @@ module CreateApplicationSnapshot : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a snapshot of the application's state data.\n"]
@@ -441,7 +450,8 @@ module DeleteApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -482,7 +492,8 @@ module DeleteApplicationCloudWatchLoggingOption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -519,7 +530,8 @@ module DeleteApplicationInputProcessingConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an [InputProcessingConfiguration] from an input.\n"]
@@ -555,7 +567,8 @@ module DeleteApplicationOutput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -594,7 +607,8 @@ module DeleteApplicationReferenceDataSource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -638,7 +652,8 @@ module DeleteApplicationSnapshot : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a snapshot of application state.\n"]
@@ -674,7 +689,8 @@ module DeleteApplicationVpcConfiguration : sig
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a VPC configuration from a Managed Service for Apache Flink application.\n"]
@@ -704,7 +720,8 @@ module DescribeApplication : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -738,7 +755,8 @@ module DescribeApplicationOperation : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -773,7 +791,8 @@ module DescribeApplicationSnapshot : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a snapshot of application state data.\n"]
@@ -803,7 +822,8 @@ module DescribeApplicationVersion : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -850,7 +870,8 @@ module DiscoverInputSchema : sig
         resource_provisioned_throughput_exceeded_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `UnableToDetectSchemaException of unable_to_detect_schema_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -888,7 +909,8 @@ module ListApplicationOperations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -923,7 +945,8 @@ module ListApplicationSnapshots : sig
     ( list_application_snapshots_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists information about the current application snapshots.\n"]
@@ -953,7 +976,8 @@ module ListApplicationVersions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -984,7 +1008,7 @@ module ListApplications : sig
     list_applications_request ->
     ( list_applications_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidRequestException of invalid_request_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1019,7 +1043,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1060,7 +1085,8 @@ module RollbackApplication : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1104,7 +1130,8 @@ module StartApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1145,7 +1172,8 @@ module StopApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `InvalidRequestException of invalid_request_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1188,7 +1216,8 @@ module TagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1228,7 +1257,8 @@ module UntagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1276,7 +1306,8 @@ module UpdateApplication : sig
       | `InvalidRequestException of invalid_request_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1317,7 +1348,8 @@ module UpdateApplicationMaintenanceConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/kinesis-analytics-v2/operations.mli
+++ b/sdks/kinesis-analytics-v2/operations.mli
@@ -23,6 +23,19 @@ module AddApplicationCloudWatchLoggingOption : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_cloud_watch_logging_option_request ->
+    ( add_application_cloud_watch_logging_option_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Adds an Amazon CloudWatch log stream to monitor application configuration errors.\n"]
 
@@ -41,6 +54,19 @@ module AddApplicationInput : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_input_request ->
     ( add_application_input_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_input_request ->
+    ( add_application_input_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CodeValidationException of code_validation_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -82,6 +108,18 @@ module AddApplicationInputProcessingConfiguration : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_input_processing_configuration_request ->
+    ( add_application_input_processing_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds an [InputProcessingConfiguration] to a SQL-based Kinesis Data Analytics application. An \
@@ -103,6 +141,18 @@ module AddApplicationOutput : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_output_request ->
     ( add_application_output_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_output_request ->
+    ( add_application_output_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -148,6 +198,18 @@ module AddApplicationReferenceDataSource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_reference_data_source_request ->
+    ( add_application_reference_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds a reference data source to an existing SQL-based Kinesis Data Analytics application.\n\n\
@@ -172,6 +234,18 @@ module AddApplicationVpcConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_vpc_configuration_request ->
     ( add_application_vpc_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_vpc_configuration_request ->
+    ( add_application_vpc_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
@@ -224,6 +298,21 @@ module CreateApplication : sig
       | `TooManyTagsException of too_many_tags_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_application_request ->
+    ( create_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `TooManyTagsException of too_many_tags_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a Managed Service for Apache Flink application. For information about creating a \
@@ -243,6 +332,16 @@ module CreateApplicationPresignedUrl : sig
     'http_type Smaws_Lib.Context.t ->
     create_application_presigned_url_request ->
     ( create_application_presigned_url_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_application_presigned_url_request ->
+    ( create_application_presigned_url_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
@@ -291,6 +390,20 @@ module CreateApplicationSnapshot : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_application_snapshot_request ->
+    ( create_application_snapshot_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Creates a snapshot of the application's state data.\n"]
 
@@ -309,6 +422,19 @@ module DeleteApplication : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_request ->
     ( delete_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_request ->
+    ( delete_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
@@ -345,6 +471,19 @@ module DeleteApplicationCloudWatchLoggingOption : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_cloud_watch_logging_option_request ->
+    ( delete_application_cloud_watch_logging_option_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an Amazon CloudWatch log stream from an SQL-based Kinesis Data Analytics application. \n"]
@@ -363,6 +502,18 @@ module DeleteApplicationInputProcessingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_input_processing_configuration_request ->
     ( delete_application_input_processing_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_input_processing_configuration_request ->
+    ( delete_application_input_processing_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -394,6 +545,18 @@ module DeleteApplicationOutput : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_output_request ->
+    ( delete_application_output_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the output destination configuration from your SQL-based Kinesis Data Analytics \
@@ -414,6 +577,18 @@ module DeleteApplicationReferenceDataSource : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_reference_data_source_request ->
     ( delete_application_reference_data_source_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_reference_data_source_request ->
+    ( delete_application_reference_data_source_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -452,6 +627,19 @@ module DeleteApplicationSnapshot : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_snapshot_request ->
+    ( delete_application_snapshot_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a snapshot of application state.\n"]
 
@@ -469,6 +657,18 @@ module DeleteApplicationVpcConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_vpc_configuration_request ->
     ( delete_application_vpc_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_vpc_configuration_request ->
+    ( delete_application_vpc_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
@@ -496,6 +696,16 @@ module DescribeApplication : sig
       | `InvalidRequestException of invalid_request_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_request ->
+    ( describe_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a specific Managed Service for Apache Flink application.\n\n\
@@ -515,6 +725,16 @@ module DescribeApplicationOperation : sig
     'http_type Smaws_Lib.Context.t ->
     describe_application_operation_request ->
     ( describe_application_operation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_operation_request ->
+    ( describe_application_operation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -545,6 +765,16 @@ module DescribeApplicationSnapshot : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_snapshot_request ->
+    ( describe_application_snapshot_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a snapshot of application state data.\n"]
 
@@ -560,6 +790,16 @@ module DescribeApplicationVersion : sig
     'http_type Smaws_Lib.Context.t ->
     describe_application_version_request ->
     ( describe_application_version_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_version_request ->
+    ( describe_application_version_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -598,6 +838,20 @@ module DiscoverInputSchema : sig
       | `UnableToDetectSchemaException of unable_to_detect_schema_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    discover_input_schema_request ->
+    ( discover_input_schema_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceProvisionedThroughputExceededException of
+        resource_provisioned_throughput_exceeded_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `UnableToDetectSchemaException of unable_to_detect_schema_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Infers a schema for a SQL-based Kinesis Data Analytics application by evaluating sample records \
@@ -621,6 +875,16 @@ module ListApplicationOperations : sig
     'http_type Smaws_Lib.Context.t ->
     list_application_operations_request ->
     ( list_application_operations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_application_operations_request ->
+    ( list_application_operations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -652,6 +916,15 @@ module ListApplicationSnapshots : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_application_snapshots_request ->
+    ( list_application_snapshots_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Lists information about the current application snapshots.\n"]
 
@@ -667,6 +940,16 @@ module ListApplicationVersions : sig
     'http_type Smaws_Lib.Context.t ->
     list_application_versions_request ->
     ( list_application_versions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_application_versions_request ->
+    ( list_application_versions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -695,6 +978,14 @@ module ListApplications : sig
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidRequestException of invalid_request_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_applications_request ->
+    ( list_applications_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidRequestException of invalid_request_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Returns a list of Managed Service for Apache Flink applications in your account. For each \
@@ -720,6 +1011,16 @@ module ListTagsForResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the list of key-value tags assigned to the application. For more information, see \
@@ -740,6 +1041,19 @@ module RollbackApplication : sig
     'http_type Smaws_Lib.Context.t ->
     rollback_application_request ->
     ( rollback_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    rollback_application_request ->
+    ( rollback_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -780,6 +1094,18 @@ module StartApplication : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_application_request ->
+    ( start_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts the specified Managed Service for Apache Flink application. After creating an \
@@ -800,6 +1126,19 @@ module StopApplication : sig
     'http_type Smaws_Lib.Context.t ->
     stop_application_request ->
     ( stop_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_application_request ->
+    ( stop_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
@@ -839,6 +1178,18 @@ module TagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more key-value tags to a Managed Service for Apache Flink application. Note that \
@@ -860,6 +1211,18 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -900,6 +1263,21 @@ module UpdateApplication : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_application_request ->
+    ( update_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `InvalidRequestException of invalid_request_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing Managed Service for Apache Flink application. Using this operation, you can \
@@ -922,6 +1300,18 @@ module UpdateApplicationMaintenanceConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     update_application_maintenance_configuration_request ->
     ( update_application_maintenance_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_application_maintenance_configuration_request ->
+    ( update_application_maintenance_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception

--- a/sdks/kinesis-analytics/Smaws_Client_KinesisAnalytics.mli
+++ b/sdks/kinesis-analytics/Smaws_Client_KinesisAnalytics.mli
@@ -518,7 +518,8 @@ module AddApplicationCloudWatchLoggingOption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -567,7 +568,8 @@ module AddApplicationInput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -624,7 +626,8 @@ module AddApplicationInputProcessingConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -671,7 +674,8 @@ module AddApplicationOutput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -738,7 +742,8 @@ module AddApplicationReferenceDataSource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -798,7 +803,8 @@ module CreateApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -862,7 +868,8 @@ module DeleteApplication : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -910,7 +917,8 @@ module DeleteApplicationCloudWatchLoggingOption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -956,7 +964,8 @@ module DeleteApplicationInputProcessingConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1001,7 +1010,8 @@ module DeleteApplicationOutput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1049,7 +1059,8 @@ module DeleteApplicationReferenceDataSource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1091,7 +1102,8 @@ module DescribeApplication : sig
     ( describe_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1142,7 +1154,8 @@ module DiscoverInputSchema : sig
       | `ResourceProvisionedThroughputExceededException of
         resource_provisioned_throughput_exceeded_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `UnableToDetectSchemaException of unable_to_detect_schema_exception ] )
+      | `UnableToDetectSchemaException of unable_to_detect_schema_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1178,7 +1191,9 @@ module ListApplications : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     list_applications_request ->
-    (list_applications_response Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( list_applications_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -1224,7 +1239,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1262,7 +1278,8 @@ module StartApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1316,7 +1333,8 @@ module StopApplication : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1366,7 +1384,8 @@ module TagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1406,7 +1425,8 @@ module UntagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1448,7 +1468,8 @@ module UpdateApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/kinesis-analytics/Smaws_Client_KinesisAnalytics.mli
+++ b/sdks/kinesis-analytics/Smaws_Client_KinesisAnalytics.mli
@@ -508,6 +508,18 @@ module AddApplicationCloudWatchLoggingOption : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_cloud_watch_logging_option_request ->
+    ( add_application_cloud_watch_logging_option_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -536,6 +548,19 @@ module AddApplicationInput : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_input_request ->
     ( add_application_input_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_input_request ->
+    ( add_application_input_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CodeValidationException of code_validation_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -589,6 +614,18 @@ module AddApplicationInputProcessingConfiguration : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_input_processing_configuration_request ->
+    ( add_application_input_processing_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -617,6 +654,18 @@ module AddApplicationOutput : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_output_request ->
     ( add_application_output_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_output_request ->
+    ( add_application_output_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -679,6 +728,18 @@ module AddApplicationReferenceDataSource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_reference_data_source_request ->
+    ( add_application_reference_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -718,6 +779,19 @@ module CreateApplication : sig
     'http_type Smaws_Lib.Context.t ->
     create_application_request ->
     ( create_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_application_request ->
+    ( create_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CodeValidationException of code_validation_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -779,6 +853,17 @@ module DeleteApplication : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_request ->
+    ( delete_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -808,6 +893,18 @@ module DeleteApplicationCloudWatchLoggingOption : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_cloud_watch_logging_option_request ->
     ( delete_application_cloud_watch_logging_option_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_cloud_watch_logging_option_request ->
+    ( delete_application_cloud_watch_logging_option_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -849,6 +946,18 @@ module DeleteApplicationInputProcessingConfiguration : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_input_processing_configuration_request ->
+    ( delete_application_input_processing_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -875,6 +984,18 @@ module DeleteApplicationOutput : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_output_request ->
     ( delete_application_output_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_output_request ->
+    ( delete_application_output_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -918,6 +1039,18 @@ module DeleteApplicationReferenceDataSource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_reference_data_source_request ->
+    ( delete_application_reference_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -947,6 +1080,15 @@ module DescribeApplication : sig
     'http_type Smaws_Lib.Context.t ->
     describe_application_request ->
     ( describe_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_request ->
+    ( describe_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
@@ -990,6 +1132,18 @@ module DiscoverInputSchema : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `UnableToDetectSchemaException of unable_to_detect_schema_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    discover_input_schema_request ->
+    ( discover_input_schema_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceProvisionedThroughputExceededException of
+        resource_provisioned_throughput_exceeded_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `UnableToDetectSchemaException of unable_to_detect_schema_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -1020,6 +1174,11 @@ module ListApplications : sig
     'http_type Smaws_Lib.Context.t ->
     list_applications_request ->
     (list_applications_response, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_applications_request ->
+    (list_applications_response Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -1057,6 +1216,16 @@ module ListTagsForResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the list of key-value tags assigned to the application. For more information, see \
@@ -1076,6 +1245,18 @@ module StartApplication : sig
     'http_type Smaws_Lib.Context.t ->
     start_application_request ->
     ( start_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_application_request ->
+    ( start_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1127,6 +1308,16 @@ module StopApplication : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_application_request ->
+    ( stop_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -1165,6 +1356,18 @@ module TagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more key-value tags to a Kinesis Analytics application. Note that the maximum \
@@ -1193,6 +1396,18 @@ module UntagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes one or more tags from a Kinesis Analytics application. For more information, see \
@@ -1214,6 +1429,19 @@ module UpdateApplication : sig
     'http_type Smaws_Lib.Context.t ->
     update_application_request ->
     ( update_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_application_request ->
+    ( update_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CodeValidationException of code_validation_exception
       | `ConcurrentModificationException of concurrent_modification_exception

--- a/sdks/kinesis-analytics/operations.ml
+++ b/sdks/kinesis-analytics/operations.ml
@@ -43,6 +43,17 @@ module AddApplicationCloudWatchLoggingOption = struct
       ~output_deserializer:
         Json_deserializers.add_application_cloud_watch_logging_option_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_application_cloud_watch_logging_option_request) =
+    let input =
+      Json_serializers.add_application_cloud_watch_logging_option_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.AddApplicationCloudWatchLoggingOption" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.add_application_cloud_watch_logging_option_response_of_yojson
+      ~error_deserializer
 end
 
 module AddApplicationInput = struct
@@ -85,6 +96,13 @@ module AddApplicationInput = struct
     let input = Json_serializers.add_application_input_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20150814.AddApplicationInput"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.add_application_input_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : add_application_input_request) =
+    let input = Json_serializers.add_application_input_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.AddApplicationInput" ~service ~context ~input
       ~output_deserializer:Json_deserializers.add_application_input_response_of_yojson
       ~error_deserializer
 end
@@ -131,6 +149,18 @@ module AddApplicationInputProcessingConfiguration = struct
       ~output_deserializer:
         Json_deserializers.add_application_input_processing_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : add_application_input_processing_configuration_request) =
+    let input =
+      Json_serializers.add_application_input_processing_configuration_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.AddApplicationInputProcessingConfiguration" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.add_application_input_processing_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module AddApplicationOutput = struct
@@ -171,6 +201,13 @@ module AddApplicationOutput = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.add_application_output_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_application_output_request) =
+    let input = Json_serializers.add_application_output_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.AddApplicationOutput" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.add_application_output_response_of_yojson
+      ~error_deserializer
 end
 
 module AddApplicationReferenceDataSource = struct
@@ -208,6 +245,15 @@ module AddApplicationReferenceDataSource = struct
   let request context (request : add_application_reference_data_source_request) =
     let input = Json_serializers.add_application_reference_data_source_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20150814.AddApplicationReferenceDataSource" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.add_application_reference_data_source_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : add_application_reference_data_source_request) =
+    let input = Json_serializers.add_application_reference_data_source_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20150814.AddApplicationReferenceDataSource" ~service ~context
       ~input
       ~output_deserializer:
@@ -254,6 +300,13 @@ module CreateApplication = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_application_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_application_request) =
+    let input = Json_serializers.create_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.CreateApplication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_application_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteApplication = struct
@@ -288,6 +341,13 @@ module DeleteApplication = struct
     let input = Json_serializers.delete_application_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20150814.DeleteApplication"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_application_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_application_request) =
+    let input = Json_serializers.delete_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.DeleteApplication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_application_response_of_yojson
       ~error_deserializer
 end
@@ -329,6 +389,18 @@ module DeleteApplicationCloudWatchLoggingOption = struct
       Json_serializers.delete_application_cloud_watch_logging_option_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20150814.DeleteApplicationCloudWatchLoggingOption" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.delete_application_cloud_watch_logging_option_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context
+      (request : delete_application_cloud_watch_logging_option_request) =
+    let input =
+      Json_serializers.delete_application_cloud_watch_logging_option_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20150814.DeleteApplicationCloudWatchLoggingOption" ~service
       ~context ~input
       ~output_deserializer:
@@ -378,6 +450,18 @@ module DeleteApplicationInputProcessingConfiguration = struct
       ~output_deserializer:
         Json_deserializers.delete_application_input_processing_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : delete_application_input_processing_configuration_request) =
+    let input =
+      Json_serializers.delete_application_input_processing_configuration_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.DeleteApplicationInputProcessingConfiguration" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.delete_application_input_processing_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteApplicationOutput = struct
@@ -415,6 +499,13 @@ module DeleteApplicationOutput = struct
   let request context (request : delete_application_output_request) =
     let input = Json_serializers.delete_application_output_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"KinesisAnalytics_20150814.DeleteApplicationOutput" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_application_output_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_application_output_request) =
+    let input = Json_serializers.delete_application_output_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"KinesisAnalytics_20150814.DeleteApplicationOutput" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_application_output_response_of_yojson
       ~error_deserializer
@@ -462,6 +553,17 @@ module DeleteApplicationReferenceDataSource = struct
       ~output_deserializer:
         Json_deserializers.delete_application_reference_data_source_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_application_reference_data_source_request) =
+    let input =
+      Json_serializers.delete_application_reference_data_source_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.DeleteApplicationReferenceDataSource" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.delete_application_reference_data_source_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeApplication = struct
@@ -488,6 +590,13 @@ module DescribeApplication = struct
     let input = Json_serializers.describe_application_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20150814.DescribeApplication"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_application_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_application_request) =
+    let input = Json_serializers.describe_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.DescribeApplication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_application_response_of_yojson
       ~error_deserializer
 end
@@ -528,6 +637,13 @@ module DiscoverInputSchema = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.discover_input_schema_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : discover_input_schema_request) =
+    let input = Json_serializers.discover_input_schema_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.DiscoverInputSchema" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.discover_input_schema_response_of_yojson
+      ~error_deserializer
 end
 
 module ListApplications = struct
@@ -542,6 +658,13 @@ module ListApplications = struct
     let input = Json_serializers.list_applications_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20150814.ListApplications"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_applications_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_applications_request) =
+    let input = Json_serializers.list_applications_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.ListApplications" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_applications_response_of_yojson
       ~error_deserializer
 end
@@ -574,6 +697,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20150814.ListTagsForResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
 end
@@ -616,6 +746,13 @@ module StartApplication = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_application_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_application_request) =
+    let input = Json_serializers.start_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.StartApplication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_application_response_of_yojson
+      ~error_deserializer
 end
 
 module StopApplication = struct
@@ -645,6 +782,13 @@ module StopApplication = struct
     let input = Json_serializers.stop_application_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20150814.StopApplication"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_application_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : stop_application_request) =
+    let input = Json_serializers.stop_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.StopApplication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.stop_application_response_of_yojson
       ~error_deserializer
 end
@@ -684,6 +828,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20150814.TagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.TagResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -720,6 +870,12 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20150814.UntagResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.UntagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
@@ -763,6 +919,13 @@ module UpdateApplication = struct
     let input = Json_serializers.update_application_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"KinesisAnalytics_20150814.UpdateApplication"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_application_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_application_request) =
+    let input = Json_serializers.update_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"KinesisAnalytics_20150814.UpdateApplication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_application_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/kinesis-analytics/operations.mli
+++ b/sdks/kinesis-analytics/operations.mli
@@ -21,6 +21,18 @@ module AddApplicationCloudWatchLoggingOption : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_cloud_watch_logging_option_request ->
+    ( add_application_cloud_watch_logging_option_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -49,6 +61,19 @@ module AddApplicationInput : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_input_request ->
     ( add_application_input_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_input_request ->
+    ( add_application_input_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CodeValidationException of code_validation_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -102,6 +127,18 @@ module AddApplicationInputProcessingConfiguration : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_input_processing_configuration_request ->
+    ( add_application_input_processing_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -130,6 +167,18 @@ module AddApplicationOutput : sig
     'http_type Smaws_Lib.Context.t ->
     add_application_output_request ->
     ( add_application_output_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_output_request ->
+    ( add_application_output_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -192,6 +241,18 @@ module AddApplicationReferenceDataSource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_application_reference_data_source_request ->
+    ( add_application_reference_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -231,6 +292,19 @@ module CreateApplication : sig
     'http_type Smaws_Lib.Context.t ->
     create_application_request ->
     ( create_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_application_request ->
+    ( create_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CodeValidationException of code_validation_exception
       | `ConcurrentModificationException of concurrent_modification_exception
@@ -292,6 +366,17 @@ module DeleteApplication : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_request ->
+    ( delete_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -321,6 +406,18 @@ module DeleteApplicationCloudWatchLoggingOption : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_cloud_watch_logging_option_request ->
     ( delete_application_cloud_watch_logging_option_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_cloud_watch_logging_option_request ->
+    ( delete_application_cloud_watch_logging_option_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -362,6 +459,18 @@ module DeleteApplicationInputProcessingConfiguration : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_input_processing_configuration_request ->
+    ( delete_application_input_processing_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -388,6 +497,18 @@ module DeleteApplicationOutput : sig
     'http_type Smaws_Lib.Context.t ->
     delete_application_output_request ->
     ( delete_application_output_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_output_request ->
+    ( delete_application_output_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -431,6 +552,18 @@ module DeleteApplicationReferenceDataSource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_application_reference_data_source_request ->
+    ( delete_application_reference_data_source_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -460,6 +593,15 @@ module DescribeApplication : sig
     'http_type Smaws_Lib.Context.t ->
     describe_application_request ->
     ( describe_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_request ->
+    ( describe_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
@@ -503,6 +645,18 @@ module DiscoverInputSchema : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `UnableToDetectSchemaException of unable_to_detect_schema_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    discover_input_schema_request ->
+    ( discover_input_schema_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceProvisionedThroughputExceededException of
+        resource_provisioned_throughput_exceeded_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `UnableToDetectSchemaException of unable_to_detect_schema_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -533,6 +687,11 @@ module ListApplications : sig
     'http_type Smaws_Lib.Context.t ->
     list_applications_request ->
     (list_applications_response, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_applications_request ->
+    (list_applications_response Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -570,6 +729,16 @@ module ListTagsForResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the list of key-value tags assigned to the application. For more information, see \
@@ -589,6 +758,18 @@ module StartApplication : sig
     'http_type Smaws_Lib.Context.t ->
     start_application_request ->
     ( start_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_application_request ->
+    ( start_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidApplicationConfigurationException of invalid_application_configuration_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -640,6 +821,16 @@ module StopApplication : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_application_request ->
+    ( stop_application_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -678,6 +869,18 @@ module TagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more key-value tags to a Kinesis Analytics application. Note that the maximum \
@@ -706,6 +909,18 @@ module UntagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes one or more tags from a Kinesis Analytics application. For more information, see \
@@ -726,6 +941,19 @@ module UpdateApplication : sig
     'http_type Smaws_Lib.Context.t ->
     update_application_request ->
     ( update_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CodeValidationException of code_validation_exception
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_application_request ->
+    ( update_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CodeValidationException of code_validation_exception
       | `ConcurrentModificationException of concurrent_modification_exception

--- a/sdks/kinesis-analytics/operations.mli
+++ b/sdks/kinesis-analytics/operations.mli
@@ -31,7 +31,8 @@ module AddApplicationCloudWatchLoggingOption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -80,7 +81,8 @@ module AddApplicationInput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -137,7 +139,8 @@ module AddApplicationInputProcessingConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -184,7 +187,8 @@ module AddApplicationOutput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -251,7 +255,8 @@ module AddApplicationReferenceDataSource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -311,7 +316,8 @@ module CreateApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -375,7 +381,8 @@ module DeleteApplication : sig
       | `ConcurrentModificationException of concurrent_modification_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -423,7 +430,8 @@ module DeleteApplicationCloudWatchLoggingOption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -469,7 +477,8 @@ module DeleteApplicationInputProcessingConfiguration : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -514,7 +523,8 @@ module DeleteApplicationOutput : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -562,7 +572,8 @@ module DeleteApplicationReferenceDataSource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -604,7 +615,8 @@ module DescribeApplication : sig
     ( describe_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -655,7 +667,8 @@ module DiscoverInputSchema : sig
       | `ResourceProvisionedThroughputExceededException of
         resource_provisioned_throughput_exceeded_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `UnableToDetectSchemaException of unable_to_detect_schema_exception ] )
+      | `UnableToDetectSchemaException of unable_to_detect_schema_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -691,7 +704,9 @@ module ListApplications : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     list_applications_request ->
-    (list_applications_response Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( list_applications_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   " This documentation is for version 1 of the Amazon Kinesis Data Analytics API, which only \
@@ -737,7 +752,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `InvalidArgumentException of invalid_argument_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -775,7 +791,8 @@ module StartApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -829,7 +846,8 @@ module StopApplication : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -879,7 +897,8 @@ module TagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -919,7 +938,8 @@ module UntagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -960,7 +980,8 @@ module UpdateApplication : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/kinesis/Smaws_Client_Kinesis.mli
+++ b/sdks/kinesis/Smaws_Client_Kinesis.mli
@@ -575,6 +575,18 @@ module AddTagsToStream : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_to_stream_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or updates tags for the specified Kinesis data stream. You can assign up to 50 tags to a \
@@ -601,6 +613,17 @@ module CreateStream : sig
     'http_type Smaws_Lib.Context.t ->
     create_stream_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_stream_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -691,6 +714,18 @@ module DecreaseStreamRetentionPeriod : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    decrease_stream_retention_period_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Decreases the Kinesis data stream's retention period, which is the length of time data records \
@@ -718,6 +753,18 @@ module DeleteResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_resource_policy_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_policy_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -754,6 +801,18 @@ module DeleteStream : sig
     'http_type Smaws_Lib.Context.t ->
     delete_stream_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_stream_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -803,6 +862,16 @@ module DeregisterStreamConsumer : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_stream_consumer_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "To deregister a consumer, provide its ARN. Alternatively, you can provide the ARN of the data \
@@ -823,6 +892,14 @@ module DescribeAccountSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_account_settings_input ->
     ( describe_account_settings_output,
+      [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_account_settings_input ->
+    ( describe_account_settings_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
     )
     result
@@ -847,6 +924,14 @@ module DescribeLimits : sig
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_limits_input ->
+    ( describe_limits_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Describes the shard limits and usage for the account.\n\n\
@@ -868,6 +953,17 @@ module DescribeStream : sig
     'http_type Smaws_Lib.Context.t ->
     describe_stream_input ->
     ( describe_stream_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_stream_input ->
+    ( describe_stream_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -920,6 +1016,16 @@ module DescribeStreamConsumer : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_stream_consumer_input ->
+    ( describe_stream_consumer_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "To get the description of a registered consumer, provide the ARN of the consumer. \
@@ -948,6 +1054,17 @@ module DescribeStreamSummary : sig
     'http_type Smaws_Lib.Context.t ->
     describe_stream_summary_input ->
     ( describe_stream_summary_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_stream_summary_input ->
+    ( describe_stream_summary_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -988,6 +1105,18 @@ module DisableEnhancedMonitoring : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_enhanced_monitoring_input ->
+    ( enhanced_monitoring_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disables enhanced monitoring.\n\n\
@@ -1010,6 +1139,18 @@ module EnableEnhancedMonitoring : sig
     'http_type Smaws_Lib.Context.t ->
     enable_enhanced_monitoring_input ->
     ( enhanced_monitoring_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_enhanced_monitoring_input ->
+    ( enhanced_monitoring_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1046,6 +1187,25 @@ module GetRecords : sig
     'http_type Smaws_Lib.Context.t ->
     get_records_input ->
     ( get_records_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ExpiredIteratorException of expired_iterator_exception
+      | `InternalFailureException of internal_failure_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `KMSAccessDeniedException of kms_access_denied_exception
+      | `KMSDisabledException of kms_disabled_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `KMSNotFoundException of kms_not_found_exception
+      | `KMSOptInRequired of kms_opt_in_required
+      | `KMSThrottlingException of kms_throttling_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_records_input ->
+    ( get_records_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ExpiredIteratorException of expired_iterator_exception
@@ -1141,6 +1301,18 @@ module GetResourcePolicy : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_policy_input ->
+    ( get_resource_policy_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a policy attached to the specified data stream or consumer. Request patterns can be one \
@@ -1170,6 +1342,18 @@ module GetShardIterator : sig
     'http_type Smaws_Lib.Context.t ->
     get_shard_iterator_input ->
     ( get_shard_iterator_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalFailureException of internal_failure_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_shard_iterator_input ->
+    ( get_shard_iterator_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalFailureException of internal_failure_exception
@@ -1240,6 +1424,18 @@ module IncreaseStreamRetentionPeriod : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    increase_stream_retention_period_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Increases the Kinesis data stream's retention period, which is the length of time data records \
@@ -1271,6 +1467,19 @@ module ListShards : sig
     'http_type Smaws_Lib.Context.t ->
     list_shards_input ->
     ( list_shards_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ExpiredNextTokenException of expired_next_token_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_shards_input ->
+    ( list_shards_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ExpiredNextTokenException of expired_next_token_exception
@@ -1319,6 +1528,18 @@ module ListStreamConsumers : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_stream_consumers_input ->
+    ( list_stream_consumers_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExpiredNextTokenException of expired_next_token_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the consumers registered to receive data from a stream using enhanced fan-out, and \
@@ -1338,6 +1559,16 @@ module ListStreams : sig
     'http_type Smaws_Lib.Context.t ->
     list_streams_input ->
     ( list_streams_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExpiredNextTokenException of expired_next_token_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_streams_input ->
+    ( list_streams_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExpiredNextTokenException of expired_next_token_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1381,6 +1612,18 @@ module ListTagsForResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "List all tags added to the specified Kinesis resource. Each tag is a label consisting of a \
@@ -1404,6 +1647,17 @@ module ListTagsForStream : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_stream_input ->
     ( list_tags_for_stream_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_stream_input ->
+    ( list_tags_for_stream_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1434,6 +1688,19 @@ module MergeShards : sig
     'http_type Smaws_Lib.Context.t ->
     merge_shards_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    merge_shards_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1516,6 +1783,24 @@ module PutRecord : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_record_input ->
+    ( put_record_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalFailureException of internal_failure_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `KMSAccessDeniedException of kms_access_denied_exception
+      | `KMSDisabledException of kms_disabled_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `KMSNotFoundException of kms_not_found_exception
+      | `KMSOptInRequired of kms_opt_in_required
+      | `KMSThrottlingException of kms_throttling_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Writes a single data record into an Amazon Kinesis data stream. Call [PutRecord] to send data \
@@ -1585,6 +1870,24 @@ module PutRecords : sig
     'http_type Smaws_Lib.Context.t ->
     put_records_input ->
     ( put_records_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalFailureException of internal_failure_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `KMSAccessDeniedException of kms_access_denied_exception
+      | `KMSDisabledException of kms_disabled_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `KMSNotFoundException of kms_not_found_exception
+      | `KMSOptInRequired of kms_opt_in_required
+      | `KMSThrottlingException of kms_throttling_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_records_input ->
+    ( put_records_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalFailureException of internal_failure_exception
@@ -1688,6 +1991,18 @@ module PutResourcePolicy : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_policy_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attaches a resource-based policy to a data stream or registered consumer. If you are using an \
@@ -1726,6 +2041,17 @@ module RegisterStreamConsumer : sig
     'http_type Smaws_Lib.Context.t ->
     register_stream_consumer_input ->
     ( register_stream_consumer_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_stream_consumer_input ->
+    ( register_stream_consumer_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -1780,6 +2106,18 @@ module RemoveTagsFromStream : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_from_stream_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes tags from the specified Kinesis data stream. Removed tags are deleted and cannot be \
@@ -1807,6 +2145,19 @@ module SplitShard : sig
     'http_type Smaws_Lib.Context.t ->
     split_shard_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    split_shard_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1899,6 +2250,24 @@ module StartStreamEncryption : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_stream_encryption_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `KMSAccessDeniedException of kms_access_denied_exception
+      | `KMSDisabledException of kms_disabled_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `KMSNotFoundException of kms_not_found_exception
+      | `KMSOptInRequired of kms_opt_in_required
+      | `KMSThrottlingException of kms_throttling_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables or updates server-side encryption using an Amazon Web Services KMS key for a specified \
@@ -1935,6 +2304,18 @@ module StopStreamEncryption : sig
     'http_type Smaws_Lib.Context.t ->
     stop_stream_encryption_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_stream_encryption_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1979,6 +2360,18 @@ module SubscribeToShard : sig
     'http_type Smaws_Lib.Context.t ->
     subscribe_to_shard_input ->
     ( subscribe_to_shard_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    subscribe_to_shard_input ->
+    ( subscribe_to_shard_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -2034,6 +2427,18 @@ module TagResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or updates tags for the specified Kinesis resource. Each tag is a label consisting of a \
@@ -2061,6 +2466,18 @@ module UntagResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes tags from the specified Kinesis resource. Removed tags are deleted and can't be \
@@ -2078,6 +2495,16 @@ module UpdateAccountSettings : sig
     'http_type Smaws_Lib.Context.t ->
     update_account_settings_input ->
     ( update_account_settings_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_account_settings_input ->
+    ( update_account_settings_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -2127,6 +2554,19 @@ module UpdateMaxRecordSize : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_max_record_size_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "This allows you to update the [MaxRecordSize] of a single record that you can write to, and \
@@ -2147,6 +2587,19 @@ module UpdateShardCount : sig
     'http_type Smaws_Lib.Context.t ->
     update_shard_count_input ->
     ( update_shard_count_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_shard_count_input ->
+    ( update_shard_count_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -2232,6 +2685,18 @@ module UpdateStreamMode : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_stream_mode_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Updates the capacity mode of the data stream. Currently, in Kinesis Data Streams, you can \
@@ -2260,6 +2725,19 @@ module UpdateStreamWarmThroughput : sig
     'http_type Smaws_Lib.Context.t ->
     update_stream_warm_throughput_input ->
     ( update_stream_warm_throughput_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_stream_warm_throughput_input ->
+    ( update_stream_warm_throughput_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception

--- a/sdks/kinesis/Smaws_Client_Kinesis.mli
+++ b/sdks/kinesis/Smaws_Client_Kinesis.mli
@@ -585,7 +585,8 @@ module AddTagsToStream : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -628,7 +629,8 @@ module CreateStream : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -724,7 +726,8 @@ module DecreaseStreamRetentionPeriod : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -770,7 +773,8 @@ module DeleteResourcePolicy : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -818,7 +822,8 @@ module DeleteStream : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -870,7 +875,8 @@ module DeregisterStreamConsumer : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -901,7 +907,7 @@ module DescribeAccountSettings : sig
     describe_account_settings_input ->
     ( describe_account_settings_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -930,7 +936,7 @@ module DescribeLimits : sig
     describe_limits_input ->
     ( describe_limits_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -968,7 +974,8 @@ module DescribeStream : sig
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1024,7 +1031,8 @@ module DescribeStreamConsumer : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1069,7 +1077,8 @@ module DescribeStreamSummary : sig
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1115,7 +1124,8 @@ module DisableEnhancedMonitoring : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1156,7 +1166,8 @@ module EnableEnhancedMonitoring : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1218,7 +1229,8 @@ module GetRecords : sig
       | `KMSOptInRequired of kms_opt_in_required
       | `KMSThrottlingException of kms_throttling_exception
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1311,7 +1323,8 @@ module GetResourcePolicy : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1359,7 +1372,8 @@ module GetShardIterator : sig
       | `InternalFailureException of internal_failure_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1434,7 +1448,8 @@ module IncreaseStreamRetentionPeriod : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1486,7 +1501,8 @@ module ListShards : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1538,7 +1554,8 @@ module ListStreamConsumers : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1572,7 +1589,8 @@ module ListStreams : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExpiredNextTokenException of expired_next_token_exception
       | `InvalidArgumentException of invalid_argument_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1622,7 +1640,8 @@ module ListTagsForResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1662,7 +1681,8 @@ module ListTagsForStream : sig
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1707,7 +1727,8 @@ module MergeShards : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1799,7 +1820,8 @@ module PutRecord : sig
       | `KMSOptInRequired of kms_opt_in_required
       | `KMSThrottlingException of kms_throttling_exception
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1899,7 +1921,8 @@ module PutRecords : sig
       | `KMSOptInRequired of kms_opt_in_required
       | `KMSThrottlingException of kms_throttling_exception
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2001,7 +2024,8 @@ module PutResourcePolicy : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2056,7 +2080,8 @@ module RegisterStreamConsumer : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2116,7 +2141,8 @@ module RemoveTagsFromStream : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2164,7 +2190,8 @@ module SplitShard : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2266,7 +2293,8 @@ module StartStreamEncryption : sig
       | `KMSThrottlingException of kms_throttling_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2321,7 +2349,8 @@ module StopStreamEncryption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2377,7 +2406,8 @@ module SubscribeToShard : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2437,7 +2467,8 @@ module TagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2476,7 +2507,8 @@ module UntagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2508,7 +2540,8 @@ module UpdateAccountSettings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2565,7 +2598,8 @@ module UpdateMaxRecordSize : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2606,7 +2640,8 @@ module UpdateShardCount : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2695,7 +2730,8 @@ module UpdateStreamMode : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2744,7 +2780,8 @@ module UpdateStreamWarmThroughput : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/kinesis/operations.ml
+++ b/sdks/kinesis/operations.ml
@@ -34,6 +34,13 @@ module AddTagsToStream = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.AddTagsToStream" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_tags_to_stream_input) =
+    let input = Json_serializers.add_tags_to_stream_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.AddTagsToStream"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module CreateStream = struct
@@ -64,6 +71,13 @@ module CreateStream = struct
     let input = Json_serializers.create_stream_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.CreateStream" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_stream_input) =
+    let input = Json_serializers.create_stream_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.CreateStream"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -101,6 +115,13 @@ module DecreaseStreamRetentionPeriod = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : decrease_stream_retention_period_input) =
+    let input = Json_serializers.decrease_stream_retention_period_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.DecreaseStreamRetentionPeriod" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteResourcePolicy = struct
@@ -135,6 +156,13 @@ module DeleteResourcePolicy = struct
     let input = Json_serializers.delete_resource_policy_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.DeleteResourcePolicy" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_resource_policy_input) =
+    let input = Json_serializers.delete_resource_policy_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.DeleteResourcePolicy" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -171,6 +199,13 @@ module DeleteStream = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.DeleteStream" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_stream_input) =
+    let input = Json_serializers.delete_stream_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.DeleteStream"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeregisterStreamConsumer = struct
@@ -201,6 +236,13 @@ module DeregisterStreamConsumer = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deregister_stream_consumer_input) =
+    let input = Json_serializers.deregister_stream_consumer_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.DeregisterStreamConsumer" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DescribeAccountSettings = struct
@@ -221,6 +263,13 @@ module DescribeAccountSettings = struct
     let input = Json_serializers.describe_account_settings_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.DescribeAccountSettings"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_account_settings_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_account_settings_input) =
+    let input = Json_serializers.describe_account_settings_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.DescribeAccountSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_account_settings_output_of_yojson
       ~error_deserializer
 end
@@ -244,6 +293,12 @@ module DescribeLimits = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.DescribeLimits" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_limits_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_limits_input) =
+    let input = Json_serializers.describe_limits_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.DescribeLimits"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_limits_output_of_yojson ~error_deserializer
 end
 
 module DescribeStream = struct
@@ -276,6 +331,12 @@ module DescribeStream = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.DescribeStream" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_stream_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_stream_input) =
+    let input = Json_serializers.describe_stream_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.DescribeStream"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_stream_output_of_yojson ~error_deserializer
 end
 
 module DescribeStreamConsumer = struct
@@ -304,6 +365,13 @@ module DescribeStreamConsumer = struct
     let input = Json_serializers.describe_stream_consumer_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.DescribeStreamConsumer"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_stream_consumer_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_stream_consumer_input) =
+    let input = Json_serializers.describe_stream_consumer_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.DescribeStreamConsumer" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_stream_consumer_output_of_yojson
       ~error_deserializer
 end
@@ -337,6 +405,13 @@ module DescribeStreamSummary = struct
     let input = Json_serializers.describe_stream_summary_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.DescribeStreamSummary"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_stream_summary_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_stream_summary_input) =
+    let input = Json_serializers.describe_stream_summary_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.DescribeStreamSummary" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_stream_summary_output_of_yojson
       ~error_deserializer
 end
@@ -375,6 +450,13 @@ module DisableEnhancedMonitoring = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.enhanced_monitoring_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disable_enhanced_monitoring_input) =
+    let input = Json_serializers.disable_enhanced_monitoring_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.DisableEnhancedMonitoring" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enhanced_monitoring_output_of_yojson
+      ~error_deserializer
 end
 
 module EnableEnhancedMonitoring = struct
@@ -409,6 +491,13 @@ module EnableEnhancedMonitoring = struct
     let input = Json_serializers.enable_enhanced_monitoring_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.EnableEnhancedMonitoring"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enhanced_monitoring_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : enable_enhanced_monitoring_input) =
+    let input = Json_serializers.enable_enhanced_monitoring_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.EnableEnhancedMonitoring" ~service ~context ~input
       ~output_deserializer:Json_deserializers.enhanced_monitoring_output_of_yojson
       ~error_deserializer
 end
@@ -473,6 +562,12 @@ module GetRecords = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.GetRecords" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_records_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_records_input) =
+    let input = Json_serializers.get_records_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.GetRecords"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_records_output_of_yojson
+      ~error_deserializer
 end
 
 module GetResourcePolicy = struct
@@ -507,6 +602,13 @@ module GetResourcePolicy = struct
     let input = Json_serializers.get_resource_policy_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.GetResourcePolicy" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_resource_policy_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_policy_input) =
+    let input = Json_serializers.get_resource_policy_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.GetResourcePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_policy_output_of_yojson
       ~error_deserializer
 end
 
@@ -546,6 +648,13 @@ module GetShardIterator = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.GetShardIterator" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_shard_iterator_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_shard_iterator_input) =
+    let input = Json_serializers.get_shard_iterator_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.GetShardIterator" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_shard_iterator_output_of_yojson
+      ~error_deserializer
 end
 
 module IncreaseStreamRetentionPeriod = struct
@@ -580,6 +689,13 @@ module IncreaseStreamRetentionPeriod = struct
     let input = Json_serializers.increase_stream_retention_period_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.IncreaseStreamRetentionPeriod"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : increase_stream_retention_period_input) =
+    let input = Json_serializers.increase_stream_retention_period_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.IncreaseStreamRetentionPeriod" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -621,6 +737,12 @@ module ListShards = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.ListShards" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_shards_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_shards_input) =
+    let input = Json_serializers.list_shards_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.ListShards"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_shards_output_of_yojson
+      ~error_deserializer
 end
 
 module ListStreamConsumers = struct
@@ -657,6 +779,13 @@ module ListStreamConsumers = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.ListStreamConsumers" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_stream_consumers_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_stream_consumers_input) =
+    let input = Json_serializers.list_stream_consumers_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.ListStreamConsumers" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_stream_consumers_output_of_yojson
+      ~error_deserializer
 end
 
 module ListStreams = struct
@@ -685,6 +814,12 @@ module ListStreams = struct
     let input = Json_serializers.list_streams_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.ListStreams" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_streams_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_streams_input) =
+    let input = Json_serializers.list_streams_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.ListStreams"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_streams_output_of_yojson
       ~error_deserializer
 end
 
@@ -722,6 +857,13 @@ module ListTagsForResource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_input) =
+    let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
+      ~error_deserializer
 end
 
 module ListTagsForStream = struct
@@ -753,6 +895,13 @@ module ListTagsForStream = struct
     let input = Json_serializers.list_tags_for_stream_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.ListTagsForStream" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_tags_for_stream_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_stream_input) =
+    let input = Json_serializers.list_tags_for_stream_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.ListTagsForStream" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_stream_output_of_yojson
       ~error_deserializer
 end
 
@@ -791,6 +940,13 @@ module MergeShards = struct
     let input = Json_serializers.merge_shards_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.MergeShards" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : merge_shards_input) =
+    let input = Json_serializers.merge_shards_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.MergeShards"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -849,6 +1005,12 @@ module PutRecord = struct
     let input = Json_serializers.put_record_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.PutRecord" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_record_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : put_record_input) =
+    let input = Json_serializers.put_record_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.PutRecord"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.put_record_output_of_yojson
+      ~error_deserializer
 end
 
 module PutRecords = struct
@@ -907,6 +1069,12 @@ module PutRecords = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.PutRecords" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_records_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_records_input) =
+    let input = Json_serializers.put_records_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.PutRecords"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.put_records_output_of_yojson
+      ~error_deserializer
 end
 
 module PutResourcePolicy = struct
@@ -942,6 +1110,13 @@ module PutResourcePolicy = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.PutResourcePolicy" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_resource_policy_input) =
+    let input = Json_serializers.put_resource_policy_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.PutResourcePolicy" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module RegisterStreamConsumer = struct
@@ -973,6 +1148,13 @@ module RegisterStreamConsumer = struct
     let input = Json_serializers.register_stream_consumer_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.RegisterStreamConsumer"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.register_stream_consumer_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : register_stream_consumer_input) =
+    let input = Json_serializers.register_stream_consumer_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.RegisterStreamConsumer" ~service ~context ~input
       ~output_deserializer:Json_deserializers.register_stream_consumer_output_of_yojson
       ~error_deserializer
 end
@@ -1009,6 +1191,13 @@ module RemoveTagsFromStream = struct
     let input = Json_serializers.remove_tags_from_stream_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.RemoveTagsFromStream" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : remove_tags_from_stream_input) =
+    let input = Json_serializers.remove_tags_from_stream_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.RemoveTagsFromStream" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1047,6 +1236,13 @@ module SplitShard = struct
     let input = Json_serializers.split_shard_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.SplitShard" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : split_shard_input) =
+    let input = Json_serializers.split_shard_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.SplitShard"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1104,6 +1300,13 @@ module StartStreamEncryption = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_stream_encryption_input) =
+    let input = Json_serializers.start_stream_encryption_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.StartStreamEncryption" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module StopStreamEncryption = struct
@@ -1138,6 +1341,13 @@ module StopStreamEncryption = struct
     let input = Json_serializers.stop_stream_encryption_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.StopStreamEncryption" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : stop_stream_encryption_input) =
+    let input = Json_serializers.stop_stream_encryption_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.StopStreamEncryption" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1174,6 +1384,13 @@ module SubscribeToShard = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.SubscribeToShard" ~service
       ~context ~input ~output_deserializer:Json_deserializers.subscribe_to_shard_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : subscribe_to_shard_input) =
+    let input = Json_serializers.subscribe_to_shard_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.SubscribeToShard" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.subscribe_to_shard_output_of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -1208,6 +1425,13 @@ module TagResource = struct
     let input = Json_serializers.tag_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.TagResource" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_input) =
+    let input = Json_serializers.tag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1244,6 +1468,13 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.UntagResource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_input) =
+    let input = Json_serializers.untag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Kinesis_20131202.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UpdateAccountSettings = struct
@@ -1271,6 +1502,13 @@ module UpdateAccountSettings = struct
     let input = Json_serializers.update_account_settings_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.UpdateAccountSettings"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_account_settings_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_account_settings_input) =
+    let input = Json_serializers.update_account_settings_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.UpdateAccountSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_account_settings_output_of_yojson
       ~error_deserializer
 end
@@ -1311,6 +1549,13 @@ module UpdateMaxRecordSize = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.UpdateMaxRecordSize" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_max_record_size_input) =
+    let input = Json_serializers.update_max_record_size_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.UpdateMaxRecordSize" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UpdateShardCount = struct
@@ -1349,6 +1594,13 @@ module UpdateShardCount = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.UpdateShardCount" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_shard_count_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_shard_count_input) =
+    let input = Json_serializers.update_shard_count_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.UpdateShardCount" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_shard_count_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateStreamMode = struct
@@ -1383,6 +1635,13 @@ module UpdateStreamMode = struct
     let input = Json_serializers.update_stream_mode_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.UpdateStreamMode" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_stream_mode_input) =
+    let input = Json_serializers.update_stream_mode_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.UpdateStreamMode" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1421,6 +1680,13 @@ module UpdateStreamWarmThroughput = struct
     let input = Json_serializers.update_stream_warm_throughput_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Kinesis_20131202.UpdateStreamWarmThroughput"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_stream_warm_throughput_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_stream_warm_throughput_input) =
+    let input = Json_serializers.update_stream_warm_throughput_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Kinesis_20131202.UpdateStreamWarmThroughput" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_stream_warm_throughput_output_of_yojson
       ~error_deserializer
 end

--- a/sdks/kinesis/operations.mli
+++ b/sdks/kinesis/operations.mli
@@ -21,6 +21,18 @@ module AddTagsToStream : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_to_stream_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or updates tags for the specified Kinesis data stream. You can assign up to 50 tags to a \
@@ -47,6 +59,17 @@ module CreateStream : sig
     'http_type Smaws_Lib.Context.t ->
     create_stream_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_stream_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -137,6 +160,18 @@ module DecreaseStreamRetentionPeriod : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    decrease_stream_retention_period_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Decreases the Kinesis data stream's retention period, which is the length of time data records \
@@ -164,6 +199,18 @@ module DeleteResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_resource_policy_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_policy_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -200,6 +247,18 @@ module DeleteStream : sig
     'http_type Smaws_Lib.Context.t ->
     delete_stream_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_stream_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -249,6 +308,16 @@ module DeregisterStreamConsumer : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_stream_consumer_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "To deregister a consumer, provide its ARN. Alternatively, you can provide the ARN of the data \
@@ -269,6 +338,14 @@ module DescribeAccountSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_account_settings_input ->
     ( describe_account_settings_output,
+      [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_account_settings_input ->
+    ( describe_account_settings_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
     )
     result
@@ -293,6 +370,14 @@ module DescribeLimits : sig
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_limits_input ->
+    ( describe_limits_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Describes the shard limits and usage for the account.\n\n\
@@ -314,6 +399,17 @@ module DescribeStream : sig
     'http_type Smaws_Lib.Context.t ->
     describe_stream_input ->
     ( describe_stream_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_stream_input ->
+    ( describe_stream_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -366,6 +462,16 @@ module DescribeStreamConsumer : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_stream_consumer_input ->
+    ( describe_stream_consumer_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "To get the description of a registered consumer, provide the ARN of the consumer. \
@@ -394,6 +500,17 @@ module DescribeStreamSummary : sig
     'http_type Smaws_Lib.Context.t ->
     describe_stream_summary_input ->
     ( describe_stream_summary_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_stream_summary_input ->
+    ( describe_stream_summary_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -434,6 +551,18 @@ module DisableEnhancedMonitoring : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_enhanced_monitoring_input ->
+    ( enhanced_monitoring_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disables enhanced monitoring.\n\n\
@@ -456,6 +585,18 @@ module EnableEnhancedMonitoring : sig
     'http_type Smaws_Lib.Context.t ->
     enable_enhanced_monitoring_input ->
     ( enhanced_monitoring_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_enhanced_monitoring_input ->
+    ( enhanced_monitoring_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -492,6 +633,25 @@ module GetRecords : sig
     'http_type Smaws_Lib.Context.t ->
     get_records_input ->
     ( get_records_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ExpiredIteratorException of expired_iterator_exception
+      | `InternalFailureException of internal_failure_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `KMSAccessDeniedException of kms_access_denied_exception
+      | `KMSDisabledException of kms_disabled_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `KMSNotFoundException of kms_not_found_exception
+      | `KMSOptInRequired of kms_opt_in_required
+      | `KMSThrottlingException of kms_throttling_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_records_input ->
+    ( get_records_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ExpiredIteratorException of expired_iterator_exception
@@ -587,6 +747,18 @@ module GetResourcePolicy : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_policy_input ->
+    ( get_resource_policy_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a policy attached to the specified data stream or consumer. Request patterns can be one \
@@ -616,6 +788,18 @@ module GetShardIterator : sig
     'http_type Smaws_Lib.Context.t ->
     get_shard_iterator_input ->
     ( get_shard_iterator_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalFailureException of internal_failure_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_shard_iterator_input ->
+    ( get_shard_iterator_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalFailureException of internal_failure_exception
@@ -686,6 +870,18 @@ module IncreaseStreamRetentionPeriod : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    increase_stream_retention_period_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Increases the Kinesis data stream's retention period, which is the length of time data records \
@@ -717,6 +913,19 @@ module ListShards : sig
     'http_type Smaws_Lib.Context.t ->
     list_shards_input ->
     ( list_shards_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ExpiredNextTokenException of expired_next_token_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_shards_input ->
+    ( list_shards_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ExpiredNextTokenException of expired_next_token_exception
@@ -765,6 +974,18 @@ module ListStreamConsumers : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_stream_consumers_input ->
+    ( list_stream_consumers_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExpiredNextTokenException of expired_next_token_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the consumers registered to receive data from a stream using enhanced fan-out, and \
@@ -784,6 +1005,16 @@ module ListStreams : sig
     'http_type Smaws_Lib.Context.t ->
     list_streams_input ->
     ( list_streams_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExpiredNextTokenException of expired_next_token_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_streams_input ->
+    ( list_streams_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExpiredNextTokenException of expired_next_token_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -827,6 +1058,18 @@ module ListTagsForResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "List all tags added to the specified Kinesis resource. Each tag is a label consisting of a \
@@ -850,6 +1093,17 @@ module ListTagsForStream : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_stream_input ->
     ( list_tags_for_stream_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_stream_input ->
+    ( list_tags_for_stream_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -880,6 +1134,19 @@ module MergeShards : sig
     'http_type Smaws_Lib.Context.t ->
     merge_shards_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    merge_shards_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -962,6 +1229,24 @@ module PutRecord : sig
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_record_input ->
+    ( put_record_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalFailureException of internal_failure_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `KMSAccessDeniedException of kms_access_denied_exception
+      | `KMSDisabledException of kms_disabled_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `KMSNotFoundException of kms_not_found_exception
+      | `KMSOptInRequired of kms_opt_in_required
+      | `KMSThrottlingException of kms_throttling_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Writes a single data record into an Amazon Kinesis data stream. Call [PutRecord] to send data \
@@ -1031,6 +1316,24 @@ module PutRecords : sig
     'http_type Smaws_Lib.Context.t ->
     put_records_input ->
     ( put_records_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalFailureException of internal_failure_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `KMSAccessDeniedException of kms_access_denied_exception
+      | `KMSDisabledException of kms_disabled_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `KMSNotFoundException of kms_not_found_exception
+      | `KMSOptInRequired of kms_opt_in_required
+      | `KMSThrottlingException of kms_throttling_exception
+      | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_records_input ->
+    ( put_records_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalFailureException of internal_failure_exception
@@ -1134,6 +1437,18 @@ module PutResourcePolicy : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_policy_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attaches a resource-based policy to a data stream or registered consumer. If you are using an \
@@ -1172,6 +1487,17 @@ module RegisterStreamConsumer : sig
     'http_type Smaws_Lib.Context.t ->
     register_stream_consumer_input ->
     ( register_stream_consumer_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_stream_consumer_input ->
+    ( register_stream_consumer_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -1226,6 +1552,18 @@ module RemoveTagsFromStream : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_from_stream_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes tags from the specified Kinesis data stream. Removed tags are deleted and cannot be \
@@ -1253,6 +1591,19 @@ module SplitShard : sig
     'http_type Smaws_Lib.Context.t ->
     split_shard_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    split_shard_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1345,6 +1696,24 @@ module StartStreamEncryption : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_stream_encryption_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `KMSAccessDeniedException of kms_access_denied_exception
+      | `KMSDisabledException of kms_disabled_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `KMSNotFoundException of kms_not_found_exception
+      | `KMSOptInRequired of kms_opt_in_required
+      | `KMSThrottlingException of kms_throttling_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables or updates server-side encryption using an Amazon Web Services KMS key for a specified \
@@ -1381,6 +1750,18 @@ module StopStreamEncryption : sig
     'http_type Smaws_Lib.Context.t ->
     stop_stream_encryption_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_stream_encryption_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1425,6 +1806,18 @@ module SubscribeToShard : sig
     'http_type Smaws_Lib.Context.t ->
     subscribe_to_shard_input ->
     ( subscribe_to_shard_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    subscribe_to_shard_input ->
+    ( subscribe_to_shard_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1480,6 +1873,18 @@ module TagResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or updates tags for the specified Kinesis resource. Each tag is a label consisting of a \
@@ -1507,6 +1912,18 @@ module UntagResource : sig
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes tags from the specified Kinesis resource. Removed tags are deleted and can't be \
@@ -1524,6 +1941,16 @@ module UpdateAccountSettings : sig
     'http_type Smaws_Lib.Context.t ->
     update_account_settings_input ->
     ( update_account_settings_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_account_settings_input ->
+    ( update_account_settings_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -1573,6 +2000,19 @@ module UpdateMaxRecordSize : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_max_record_size_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "This allows you to update the [MaxRecordSize] of a single record that you can write to, and \
@@ -1593,6 +2033,19 @@ module UpdateShardCount : sig
     'http_type Smaws_Lib.Context.t ->
     update_shard_count_input ->
     ( update_shard_count_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_shard_count_input ->
+    ( update_shard_count_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
@@ -1678,6 +2131,18 @@ module UpdateStreamMode : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_stream_mode_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   " Updates the capacity mode of the data stream. Currently, in Kinesis Data Streams, you can \
@@ -1705,6 +2170,19 @@ module UpdateStreamWarmThroughput : sig
     'http_type Smaws_Lib.Context.t ->
     update_stream_warm_throughput_input ->
     ( update_stream_warm_throughput_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidArgumentException of invalid_argument_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `ResourceInUseException of resource_in_use_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_stream_warm_throughput_input ->
+    ( update_stream_warm_throughput_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception

--- a/sdks/kinesis/operations.mli
+++ b/sdks/kinesis/operations.mli
@@ -31,7 +31,8 @@ module AddTagsToStream : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -74,7 +75,8 @@ module CreateStream : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -170,7 +172,8 @@ module DecreaseStreamRetentionPeriod : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -216,7 +219,8 @@ module DeleteResourcePolicy : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -264,7 +268,8 @@ module DeleteStream : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -316,7 +321,8 @@ module DeregisterStreamConsumer : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -347,7 +353,7 @@ module DescribeAccountSettings : sig
     describe_account_settings_input ->
     ( describe_account_settings_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -376,7 +382,7 @@ module DescribeLimits : sig
     describe_limits_input ->
     ( describe_limits_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `LimitExceededException of limit_exceeded_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -414,7 +420,8 @@ module DescribeStream : sig
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -470,7 +477,8 @@ module DescribeStreamConsumer : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -515,7 +523,8 @@ module DescribeStreamSummary : sig
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -561,7 +570,8 @@ module DisableEnhancedMonitoring : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -602,7 +612,8 @@ module EnableEnhancedMonitoring : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -664,7 +675,8 @@ module GetRecords : sig
       | `KMSOptInRequired of kms_opt_in_required
       | `KMSThrottlingException of kms_throttling_exception
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -757,7 +769,8 @@ module GetResourcePolicy : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -805,7 +818,8 @@ module GetShardIterator : sig
       | `InternalFailureException of internal_failure_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -880,7 +894,8 @@ module IncreaseStreamRetentionPeriod : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -932,7 +947,8 @@ module ListShards : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -984,7 +1000,8 @@ module ListStreamConsumers : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1018,7 +1035,8 @@ module ListStreams : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExpiredNextTokenException of expired_next_token_exception
       | `InvalidArgumentException of invalid_argument_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1068,7 +1086,8 @@ module ListTagsForResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1108,7 +1127,8 @@ module ListTagsForStream : sig
       | `AccessDeniedException of access_denied_exception
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1153,7 +1173,8 @@ module MergeShards : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1245,7 +1266,8 @@ module PutRecord : sig
       | `KMSOptInRequired of kms_opt_in_required
       | `KMSThrottlingException of kms_throttling_exception
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1345,7 +1367,8 @@ module PutRecords : sig
       | `KMSOptInRequired of kms_opt_in_required
       | `KMSThrottlingException of kms_throttling_exception
       | `ProvisionedThroughputExceededException of provisioned_throughput_exceeded_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1447,7 +1470,8 @@ module PutResourcePolicy : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1502,7 +1526,8 @@ module RegisterStreamConsumer : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1562,7 +1587,8 @@ module RemoveTagsFromStream : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1610,7 +1636,8 @@ module SplitShard : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1712,7 +1739,8 @@ module StartStreamEncryption : sig
       | `KMSThrottlingException of kms_throttling_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1767,7 +1795,8 @@ module StopStreamEncryption : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1823,7 +1852,8 @@ module SubscribeToShard : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1883,7 +1913,8 @@ module TagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1922,7 +1953,8 @@ module UntagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1954,7 +1986,8 @@ module UpdateAccountSettings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArgumentException of invalid_argument_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2011,7 +2044,8 @@ module UpdateMaxRecordSize : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2052,7 +2086,8 @@ module UpdateShardCount : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2141,7 +2176,8 @@ module UpdateStreamMode : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2189,7 +2225,8 @@ module UpdateStreamWarmThroughput : sig
       | `LimitExceededException of limit_exceeded_exception
       | `ResourceInUseException of resource_in_use_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/kms/Smaws_Client_KMS.mli
+++ b/sdks/kms/Smaws_Client_KMS.mli
@@ -779,7 +779,8 @@ module CancelKeyDeletion : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -842,7 +843,8 @@ module ConnectCustomKeyStore : sig
       | `CloudHsmClusterNotActiveException of cloud_hsm_cluster_not_active_exception
       | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -983,7 +985,8 @@ module CreateAlias : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1134,7 +1137,8 @@ module CreateCustomKeyStore : sig
       | `XksProxyVpcEndpointServiceInvalidConfigurationException of
         xks_proxy_vpc_endpoint_service_invalid_configuration_exception
       | `XksProxyVpcEndpointServiceNotFoundException of
-        xks_proxy_vpc_endpoint_service_not_found_exception ] )
+        xks_proxy_vpc_endpoint_service_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1276,7 +1280,8 @@ module CreateGrant : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1411,7 +1416,8 @@ module CreateKey : sig
       | `UnsupportedOperationException of unsupported_operation_exception
       | `XksKeyAlreadyInUseException of xks_key_already_in_use_exception
       | `XksKeyInvalidConfigurationException of xks_key_invalid_configuration_exception
-      | `XksKeyNotFoundException of xks_key_not_found_exception ] )
+      | `XksKeyNotFoundException of xks_key_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1650,7 +1656,8 @@ module Decrypt : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1787,7 +1794,8 @@ module DeleteAlias : sig
       | `DependencyTimeoutException of dependency_timeout_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1872,7 +1880,8 @@ module DeleteCustomKeyStore : sig
       | `CustomKeyStoreHasCMKsException of custom_key_store_has_cm_ks_exception
       | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1976,7 +1985,8 @@ module DeleteImportedKeyMaterial : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2074,7 +2084,8 @@ module DeriveSharedSecret : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2194,7 +2205,8 @@ module DescribeCustomKeyStores : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
       | `InvalidMarkerException of invalid_marker_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2290,7 +2302,8 @@ module DescribeKey : sig
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2409,7 +2422,8 @@ module DisableKey : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2474,7 +2488,8 @@ module DisableKeyRotation : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2563,7 +2578,8 @@ module DisconnectCustomKeyStore : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2657,7 +2673,8 @@ module EnableKey : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2720,7 +2737,8 @@ module EnableKeyRotation : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2849,7 +2867,8 @@ module Encrypt : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3007,7 +3026,8 @@ module GenerateDataKey : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3174,7 +3194,8 @@ module GenerateDataKeyPair : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3316,7 +3337,8 @@ module GenerateDataKeyPairWithoutPlaintext : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3431,7 +3453,8 @@ module GenerateDataKeyWithoutPlaintext : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3556,7 +3579,8 @@ module GenerateMac : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3629,7 +3653,8 @@ module GenerateRandom : sig
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
       | `DependencyTimeoutException of dependency_timeout_exception
       | `KMSInternalException of kms_internal_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3698,7 +3723,8 @@ module GetKeyLastUsage : sig
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3799,7 +3825,8 @@ module GetKeyPolicy : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3854,7 +3881,8 @@ module GetKeyRotationStatus : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3972,7 +4000,8 @@ module GetParametersForImport : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4105,7 +4134,8 @@ module GetPublicKey : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4224,7 +4254,8 @@ module ImportKeyMaterial : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4408,7 +4439,8 @@ module ListAliases : sig
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4500,7 +4532,8 @@ module ListGrants : sig
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4589,7 +4622,8 @@ module ListKeyPolicies : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4654,7 +4688,8 @@ module ListKeyRotations : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4728,7 +4763,8 @@ module ListKeys : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidMarkerException of invalid_marker_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4790,7 +4826,8 @@ module ListResourceTags : sig
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4861,7 +4898,8 @@ module ListRetirableGrants : sig
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4960,7 +4998,8 @@ module PutKeyPolicy : sig
       | `LimitExceededException of limit_exceeded_exception
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5040,7 +5079,8 @@ module ReEncrypt : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5205,7 +5245,8 @@ module ReplicateKey : sig
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `NotFoundException of not_found_exception
       | `TagException of tag_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5338,7 +5379,8 @@ module RetireGrant : sig
       | `InvalidGrantTokenException of invalid_grant_token_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5426,7 +5468,8 @@ module RevokeGrant : sig
       | `InvalidGrantIdException of invalid_grant_id_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5519,7 +5562,8 @@ module RotateKeyOnDemand : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5633,7 +5677,8 @@ module ScheduleKeyDeletion : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5748,7 +5793,8 @@ module Sign : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5850,7 +5896,8 @@ module TagResource : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception
-      | `TagException of tag_exception ] )
+      | `TagException of tag_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5948,7 +5995,8 @@ module UntagResource : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `TagException of tag_exception ] )
+      | `TagException of tag_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6033,7 +6081,8 @@ module UpdateAlias : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6185,7 +6234,8 @@ module UpdateCustomKeyStore : sig
       | `XksProxyVpcEndpointServiceInvalidConfigurationException of
         xks_proxy_vpc_endpoint_service_invalid_configuration_exception
       | `XksProxyVpcEndpointServiceNotFoundException of
-        xks_proxy_vpc_endpoint_service_not_found_exception ] )
+        xks_proxy_vpc_endpoint_service_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6314,7 +6364,8 @@ module UpdateKeyDescription : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6380,7 +6431,8 @@ module UpdatePrimaryRegion : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6513,7 +6565,8 @@ module Verify : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidSignatureException of kms_invalid_signature_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6615,7 +6668,8 @@ module VerifyMac : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidMacException of kms_invalid_mac_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/kms/Smaws_Client_KMS.mli
+++ b/sdks/kms/Smaws_Client_KMS.mli
@@ -769,6 +769,18 @@ module CancelKeyDeletion : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_key_deletion_request ->
+    ( cancel_key_deletion_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Cancels the deletion of a KMS key. When this operation succeeds, the key state of the KMS key \
@@ -811,6 +823,19 @@ module ConnectCustomKeyStore : sig
     'http_type Smaws_Lib.Context.t ->
     connect_custom_key_store_request ->
     ( connect_custom_key_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudHsmClusterInvalidConfigurationException of
+        cloud_hsm_cluster_invalid_configuration_exception
+      | `CloudHsmClusterNotActiveException of cloud_hsm_cluster_not_active_exception
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    connect_custom_key_store_request ->
+    ( connect_custom_key_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudHsmClusterInvalidConfigurationException of
         cloud_hsm_cluster_invalid_configuration_exception
@@ -946,6 +971,20 @@ module CreateAlias : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_alias_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AlreadyExistsException of already_exists_exception
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidAliasNameException of invalid_alias_name_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a friendly name for a KMS key. \n\n\
@@ -1046,6 +1085,34 @@ module CreateCustomKeyStore : sig
     'http_type Smaws_Lib.Context.t ->
     create_custom_key_store_request ->
     ( create_custom_key_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudHsmClusterInUseException of cloud_hsm_cluster_in_use_exception
+      | `CloudHsmClusterInvalidConfigurationException of
+        cloud_hsm_cluster_invalid_configuration_exception
+      | `CloudHsmClusterNotActiveException of cloud_hsm_cluster_not_active_exception
+      | `CloudHsmClusterNotFoundException of cloud_hsm_cluster_not_found_exception
+      | `CustomKeyStoreNameInUseException of custom_key_store_name_in_use_exception
+      | `IncorrectTrustAnchorException of incorrect_trust_anchor_exception
+      | `KMSInternalException of kms_internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `XksProxyIncorrectAuthenticationCredentialException of
+        xks_proxy_incorrect_authentication_credential_exception
+      | `XksProxyInvalidConfigurationException of xks_proxy_invalid_configuration_exception
+      | `XksProxyInvalidResponseException of xks_proxy_invalid_response_exception
+      | `XksProxyUriEndpointInUseException of xks_proxy_uri_endpoint_in_use_exception
+      | `XksProxyUriInUseException of xks_proxy_uri_in_use_exception
+      | `XksProxyUriUnreachableException of xks_proxy_uri_unreachable_exception
+      | `XksProxyVpcEndpointServiceInUseException of xks_proxy_vpc_endpoint_service_in_use_exception
+      | `XksProxyVpcEndpointServiceInvalidConfigurationException of
+        xks_proxy_vpc_endpoint_service_invalid_configuration_exception
+      | `XksProxyVpcEndpointServiceNotFoundException of
+        xks_proxy_vpc_endpoint_service_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_custom_key_store_request ->
+    ( create_custom_key_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudHsmClusterInUseException of cloud_hsm_cluster_in_use_exception
       | `CloudHsmClusterInvalidConfigurationException of
@@ -1195,6 +1262,22 @@ module CreateGrant : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_grant_request ->
+    ( create_grant_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds a grant to a KMS key. \n\n\
@@ -1293,6 +1376,27 @@ module CreateKey : sig
     'http_type Smaws_Lib.Context.t ->
     create_key_request ->
     ( create_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudHsmClusterInvalidConfigurationException of
+        cloud_hsm_cluster_invalid_configuration_exception
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `TagException of tag_exception
+      | `UnsupportedOperationException of unsupported_operation_exception
+      | `XksKeyAlreadyInUseException of xks_key_already_in_use_exception
+      | `XksKeyInvalidConfigurationException of xks_key_invalid_configuration_exception
+      | `XksKeyNotFoundException of xks_key_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_key_request ->
+    ( create_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudHsmClusterInvalidConfigurationException of
         cloud_hsm_cluster_invalid_configuration_exception
@@ -1530,6 +1634,24 @@ module Decrypt : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    decrypt_request ->
+    ( decrypt_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `IncorrectKeyException of incorrect_key_exception
+      | `InvalidCiphertextException of invalid_ciphertext_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Decrypts ciphertext that was encrypted by a KMS key using any of the following operations:\n\n\
@@ -1656,6 +1778,17 @@ module DeleteAlias : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_alias_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified alias. \n\n\
@@ -1724,6 +1857,17 @@ module DeleteCustomKeyStore : sig
     'http_type Smaws_Lib.Context.t ->
     delete_custom_key_store_request ->
     ( delete_custom_key_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomKeyStoreHasCMKsException of custom_key_store_has_cm_ks_exception
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_custom_key_store_request ->
+    ( delete_custom_key_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CustomKeyStoreHasCMKsException of custom_key_store_has_cm_ks_exception
       | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
@@ -1821,6 +1965,19 @@ module DeleteImportedKeyMaterial : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_imported_key_material_request ->
+    ( delete_imported_key_material_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes key material that was previously imported. This operation makes the specified KMS key \
@@ -1892,6 +2049,22 @@ module DeriveSharedSecret : sig
     'http_type Smaws_Lib.Context.t ->
     derive_shared_secret_request ->
     ( derive_shared_secret_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    derive_shared_secret_request ->
+    ( derive_shared_secret_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -2013,6 +2186,16 @@ module DescribeCustomKeyStores : sig
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_custom_key_stores_request ->
+    ( describe_custom_key_stores_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets information about \
@@ -2092,6 +2275,17 @@ module DescribeKey : sig
     'http_type Smaws_Lib.Context.t ->
     describe_key_request ->
     ( describe_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_key_request ->
+    ( describe_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -2205,6 +2399,18 @@ module DisableKey : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_key_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the state of a KMS key to disabled. This change temporarily prevents use of the KMS key \
@@ -2247,6 +2453,20 @@ module DisableKeyRotation : sig
     'http_type Smaws_Lib.Context.t ->
     disable_key_rotation_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_key_rotation_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -2335,6 +2555,16 @@ module DisconnectCustomKeyStore : sig
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
       | `KMSInternalException of kms_internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disconnect_custom_key_store_request ->
+    ( disconnect_custom_key_store_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disconnects the \
@@ -2416,6 +2646,19 @@ module EnableKey : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_key_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the key state of a KMS key to enabled. This allows you to use the KMS key for \
@@ -2456,6 +2699,20 @@ module EnableKeyRotation : sig
     'http_type Smaws_Lib.Context.t ->
     enable_key_rotation_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_key_rotation_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -2567,6 +2824,22 @@ module Encrypt : sig
     'http_type Smaws_Lib.Context.t ->
     encrypt_request ->
     ( encrypt_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    encrypt_request ->
+    ( encrypt_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -2709,6 +2982,22 @@ module GenerateDataKey : sig
     'http_type Smaws_Lib.Context.t ->
     generate_data_key_request ->
     ( generate_data_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_data_key_request ->
+    ( generate_data_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -2870,6 +3159,23 @@ module GenerateDataKeyPair : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_data_key_pair_request ->
+    ( generate_data_key_pair_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a unique asymmetric data key pair for use outside of KMS. This operation returns a \
@@ -2995,6 +3301,23 @@ module GenerateDataKeyPairWithoutPlaintext : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_data_key_pair_without_plaintext_request ->
+    ( generate_data_key_pair_without_plaintext_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a unique asymmetric data key pair for use outside of KMS. This operation returns a \
@@ -3083,6 +3406,22 @@ module GenerateDataKeyWithoutPlaintext : sig
     'http_type Smaws_Lib.Context.t ->
     generate_data_key_without_plaintext_request ->
     ( generate_data_key_without_plaintext_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_data_key_without_plaintext_request ->
+    ( generate_data_key_without_plaintext_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -3204,6 +3543,21 @@ module GenerateMac : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_mac_request ->
+    ( generate_mac_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Generates a hash-based message authentication code (HMAC) for a message using an HMAC KMS key \
@@ -3265,6 +3619,18 @@ module GenerateRandom : sig
       | `KMSInternalException of kms_internal_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_random_request ->
+    ( generate_random_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `KMSInternalException of kms_internal_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a random byte string that is cryptographically secure.\n\n\
@@ -3317,6 +3683,17 @@ module GetKeyLastUsage : sig
     'http_type Smaws_Lib.Context.t ->
     get_key_last_usage_request ->
     ( get_key_last_usage_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_last_usage_request ->
+    ( get_key_last_usage_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -3412,6 +3789,18 @@ module GetKeyPolicy : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_policy_request ->
+    ( get_key_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets a key policy attached to the specified KMS key.\n\n\
@@ -3446,6 +3835,19 @@ module GetKeyRotationStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_key_rotation_status_request ->
     ( get_key_rotation_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_rotation_status_request ->
+    ( get_key_rotation_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -3551,6 +3953,19 @@ module GetParametersForImport : sig
     'http_type Smaws_Lib.Context.t ->
     get_parameters_for_import_request ->
     ( get_parameters_for_import_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameters_for_import_request ->
+    ( get_parameters_for_import_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -3675,6 +4090,23 @@ module GetPublicKey : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_public_key_request ->
+    ( get_public_key_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the public key of an asymmetric KMS key. Unlike the private key of a asymmetric KMS \
@@ -3765,6 +4197,23 @@ module ImportKeyMaterial : sig
     'http_type Smaws_Lib.Context.t ->
     import_key_material_request ->
     ( import_key_material_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `ExpiredImportTokenException of expired_import_token_exception
+      | `IncorrectKeyMaterialException of incorrect_key_material_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidCiphertextException of invalid_ciphertext_exception
+      | `InvalidImportTokenException of invalid_import_token_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_key_material_request ->
+    ( import_key_material_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `ExpiredImportTokenException of expired_import_token_exception
@@ -3949,6 +4398,18 @@ module ListAliases : sig
       | `KMSInternalException of kms_internal_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_aliases_request ->
+    ( list_aliases_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets a list of aliases in the caller's Amazon Web Services account and region. For more \
@@ -4018,6 +4479,20 @@ module ListGrants : sig
     'http_type Smaws_Lib.Context.t ->
     list_grants_request ->
     ( list_grants_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantIdException of invalid_grant_id_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_grants_request ->
+    ( list_grants_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -4104,6 +4579,18 @@ module ListKeyPolicies : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_key_policies_request ->
+    ( list_key_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets the names of the key policies that are attached to a KMS key. This operation is designed \
@@ -4148,6 +4635,19 @@ module ListKeyRotations : sig
     'http_type Smaws_Lib.Context.t ->
     list_key_rotations_request ->
     ( list_key_rotations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_key_rotations_request ->
+    ( list_key_rotations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
@@ -4220,6 +4720,16 @@ module ListKeys : sig
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_keys_request ->
+    ( list_keys_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets a list of all KMS keys in the caller's Amazon Web Services account and Region.\n\n\
@@ -4265,6 +4775,17 @@ module ListResourceTags : sig
     'http_type Smaws_Lib.Context.t ->
     list_resource_tags_request ->
     ( list_resource_tags_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_tags_request ->
+    ( list_resource_tags_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
@@ -4323,6 +4844,18 @@ module ListRetirableGrants : sig
     'http_type Smaws_Lib.Context.t ->
     list_retirable_grants_request ->
     ( list_grants_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_retirable_grants_request ->
+    ( list_grants_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -4414,6 +4947,21 @@ module PutKeyPolicy : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_key_policy_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attaches a key policy to the specified KMS key. \n\n\
@@ -4463,6 +5011,24 @@ module ReEncrypt : sig
     'http_type Smaws_Lib.Context.t ->
     re_encrypt_request ->
     ( re_encrypt_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `IncorrectKeyException of incorrect_key_exception
+      | `InvalidCiphertextException of invalid_ciphertext_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    re_encrypt_request ->
+    ( re_encrypt_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -4624,6 +5190,23 @@ module ReplicateKey : sig
       | `TagException of tag_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    replicate_key_request ->
+    ( replicate_key_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AlreadyExistsException of already_exists_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `NotFoundException of not_found_exception
+      | `TagException of tag_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Replicates a multi-Region key into the specified Region. This operation creates a multi-Region \
@@ -4742,6 +5325,21 @@ module RetireGrant : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    retire_grant_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantIdException of invalid_grant_id_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a grant. Typically, you retire a grant when you no longer need its permissions. To \
@@ -4807,6 +5405,20 @@ module RevokeGrant : sig
     'http_type Smaws_Lib.Context.t ->
     revoke_grant_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantIdException of invalid_grant_id_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    revoke_grant_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DryRunOperationException of dry_run_operation_exception
@@ -4882,6 +5494,22 @@ module RotateKeyOnDemand : sig
     'http_type Smaws_Lib.Context.t ->
     rotate_key_on_demand_request ->
     ( rotate_key_on_demand_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    rotate_key_on_demand_request ->
+    ( rotate_key_on_demand_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `DependencyTimeoutException of dependency_timeout_exception
@@ -4995,6 +5623,18 @@ module ScheduleKeyDeletion : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    schedule_key_deletion_request ->
+    ( schedule_key_deletion_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Schedules the deletion of a KMS key. By default, KMS applies a waiting period of 30 days, but \
@@ -5083,6 +5723,22 @@ module Sign : sig
     'http_type Smaws_Lib.Context.t ->
     sign_request ->
     ( sign_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    sign_request ->
+    ( sign_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -5183,6 +5839,19 @@ module TagResource : sig
       | `NotFoundException of not_found_exception
       | `TagException of tag_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception
+      | `TagException of tag_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or edits tags on a \
@@ -5269,6 +5938,18 @@ module UntagResource : sig
       | `NotFoundException of not_found_exception
       | `TagException of tag_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `TagException of tag_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes tags from a \
@@ -5335,6 +6016,18 @@ module UpdateAlias : sig
     'http_type Smaws_Lib.Context.t ->
     update_alias_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_alias_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `KMSInternalException of kms_internal_exception
@@ -5443,6 +6136,34 @@ module UpdateCustomKeyStore : sig
     'http_type Smaws_Lib.Context.t ->
     update_custom_key_store_request ->
     ( update_custom_key_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudHsmClusterInvalidConfigurationException of
+        cloud_hsm_cluster_invalid_configuration_exception
+      | `CloudHsmClusterNotActiveException of cloud_hsm_cluster_not_active_exception
+      | `CloudHsmClusterNotFoundException of cloud_hsm_cluster_not_found_exception
+      | `CloudHsmClusterNotRelatedException of cloud_hsm_cluster_not_related_exception
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNameInUseException of custom_key_store_name_in_use_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `KMSInternalException of kms_internal_exception
+      | `XksProxyIncorrectAuthenticationCredentialException of
+        xks_proxy_incorrect_authentication_credential_exception
+      | `XksProxyInvalidConfigurationException of xks_proxy_invalid_configuration_exception
+      | `XksProxyInvalidResponseException of xks_proxy_invalid_response_exception
+      | `XksProxyUriEndpointInUseException of xks_proxy_uri_endpoint_in_use_exception
+      | `XksProxyUriInUseException of xks_proxy_uri_in_use_exception
+      | `XksProxyUriUnreachableException of xks_proxy_uri_unreachable_exception
+      | `XksProxyVpcEndpointServiceInUseException of xks_proxy_vpc_endpoint_service_in_use_exception
+      | `XksProxyVpcEndpointServiceInvalidConfigurationException of
+        xks_proxy_vpc_endpoint_service_invalid_configuration_exception
+      | `XksProxyVpcEndpointServiceNotFoundException of
+        xks_proxy_vpc_endpoint_service_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_custom_key_store_request ->
+    ( update_custom_key_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudHsmClusterInvalidConfigurationException of
         cloud_hsm_cluster_invalid_configuration_exception
@@ -5583,6 +6304,18 @@ module UpdateKeyDescription : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_key_description_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the description of a KMS key. To see the description of a KMS key, use [DescribeKey]. \n\n\
@@ -5628,6 +6361,19 @@ module UpdatePrimaryRegion : sig
     'http_type Smaws_Lib.Context.t ->
     update_primary_region_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_primary_region_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DisabledException of disabled_exception
       | `InvalidArnException of invalid_arn_exception
@@ -5752,6 +6498,23 @@ module Verify : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    verify_request ->
+    ( verify_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidSignatureException of kms_invalid_signature_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Verifies a digital signature that was generated by the [Sign] operation. \n\n\
@@ -5827,6 +6590,22 @@ module VerifyMac : sig
     'http_type Smaws_Lib.Context.t ->
     verify_mac_request ->
     ( verify_mac_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidMacException of kms_invalid_mac_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    verify_mac_request ->
+    ( verify_mac_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DisabledException of disabled_exception
       | `DryRunOperationException of dry_run_operation_exception

--- a/sdks/kms/operations.ml
+++ b/sdks/kms/operations.ml
@@ -34,6 +34,13 @@ module CancelKeyDeletion = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.CancelKeyDeletion" ~service
       ~context ~input ~output_deserializer:Json_deserializers.cancel_key_deletion_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : cancel_key_deletion_request) =
+    let input = Json_serializers.cancel_key_deletion_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.CancelKeyDeletion"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_key_deletion_response_of_yojson
+      ~error_deserializer
 end
 
 module ConnectCustomKeyStore = struct
@@ -73,6 +80,13 @@ module ConnectCustomKeyStore = struct
     let input = Json_serializers.connect_custom_key_store_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ConnectCustomKeyStore" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.connect_custom_key_store_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : connect_custom_key_store_request) =
+    let input = Json_serializers.connect_custom_key_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.ConnectCustomKeyStore" ~service ~context ~input
       ~output_deserializer:Json_deserializers.connect_custom_key_store_response_of_yojson
       ~error_deserializer
 end
@@ -116,6 +130,13 @@ module CreateAlias = struct
     let input = Json_serializers.create_alias_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.CreateAlias" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_alias_request) =
+    let input = Json_serializers.create_alias_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.CreateAlias"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -212,6 +233,13 @@ module CreateCustomKeyStore = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_custom_key_store_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_custom_key_store_request) =
+    let input = Json_serializers.create_custom_key_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.CreateCustomKeyStore" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_custom_key_store_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateGrant = struct
@@ -261,6 +289,12 @@ module CreateGrant = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.CreateGrant" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_grant_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_grant_request) =
+    let input = Json_serializers.create_grant_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.CreateGrant"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_grant_response_of_yojson ~error_deserializer
 end
 
 module CreateKey = struct
@@ -330,6 +364,12 @@ module CreateKey = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.CreateKey" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_key_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_key_request) =
+    let input = Json_serializers.create_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.CreateKey" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.create_key_response_of_yojson
+      ~error_deserializer
 end
 
 module Decrypt = struct
@@ -387,6 +427,12 @@ module Decrypt = struct
     let input = Json_serializers.decrypt_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.Decrypt" ~service ~context ~input
       ~output_deserializer:Json_deserializers.decrypt_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : decrypt_request) =
+    let input = Json_serializers.decrypt_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.Decrypt" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.decrypt_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteAlias = struct
@@ -418,6 +464,13 @@ module DeleteAlias = struct
     let input = Json_serializers.delete_alias_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.DeleteAlias" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_alias_request) =
+    let input = Json_serializers.delete_alias_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.DeleteAlias"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -452,6 +505,13 @@ module DeleteCustomKeyStore = struct
     let input = Json_serializers.delete_custom_key_store_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.DeleteCustomKeyStore" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.delete_custom_key_store_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_custom_key_store_request) =
+    let input = Json_serializers.delete_custom_key_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.DeleteCustomKeyStore" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_custom_key_store_response_of_yojson
       ~error_deserializer
 end
@@ -492,6 +552,13 @@ module DeleteImportedKeyMaterial = struct
     let input = Json_serializers.delete_imported_key_material_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.DeleteImportedKeyMaterial"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_imported_key_material_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_imported_key_material_request) =
+    let input = Json_serializers.delete_imported_key_material_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.DeleteImportedKeyMaterial" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_imported_key_material_response_of_yojson
       ~error_deserializer
 end
@@ -546,6 +613,13 @@ module DeriveSharedSecret = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.derive_shared_secret_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : derive_shared_secret_request) =
+    let input = Json_serializers.derive_shared_secret_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.DeriveSharedSecret"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.derive_shared_secret_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeCustomKeyStores = struct
@@ -573,6 +647,13 @@ module DescribeCustomKeyStores = struct
     let input = Json_serializers.describe_custom_key_stores_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.DescribeCustomKeyStores" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_custom_key_stores_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_custom_key_stores_request) =
+    let input = Json_serializers.describe_custom_key_stores_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.DescribeCustomKeyStores" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_custom_key_stores_response_of_yojson
       ~error_deserializer
 end
@@ -606,6 +687,12 @@ module DescribeKey = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.DescribeKey" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_key_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_key_request) =
+    let input = Json_serializers.describe_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.DescribeKey"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_key_response_of_yojson ~error_deserializer
 end
 
 module DisableKey = struct
@@ -640,6 +727,12 @@ module DisableKey = struct
     let input = Json_serializers.disable_key_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.DisableKey" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disable_key_request) =
+    let input = Json_serializers.disable_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.DisableKey" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -683,6 +776,13 @@ module DisableKeyRotation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.DisableKeyRotation" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disable_key_rotation_request) =
+    let input = Json_serializers.disable_key_rotation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.DisableKeyRotation"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DisconnectCustomKeyStore = struct
@@ -712,6 +812,13 @@ module DisconnectCustomKeyStore = struct
     let input = Json_serializers.disconnect_custom_key_store_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.DisconnectCustomKeyStore" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.disconnect_custom_key_store_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disconnect_custom_key_store_request) =
+    let input = Json_serializers.disconnect_custom_key_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.DisconnectCustomKeyStore" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disconnect_custom_key_store_response_of_yojson
       ~error_deserializer
 end
@@ -751,6 +858,12 @@ module EnableKey = struct
     let input = Json_serializers.enable_key_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.EnableKey" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : enable_key_request) =
+    let input = Json_serializers.enable_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.EnableKey" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -793,6 +906,13 @@ module EnableKeyRotation = struct
     let input = Json_serializers.enable_key_rotation_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.EnableKeyRotation" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : enable_key_rotation_request) =
+    let input = Json_serializers.enable_key_rotation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.EnableKeyRotation"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -844,6 +964,12 @@ module Encrypt = struct
     let input = Json_serializers.encrypt_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.Encrypt" ~service ~context ~input
       ~output_deserializer:Json_deserializers.encrypt_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : encrypt_request) =
+    let input = Json_serializers.encrypt_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.Encrypt" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.encrypt_response_of_yojson
+      ~error_deserializer
 end
 
 module GenerateDataKey = struct
@@ -894,6 +1020,13 @@ module GenerateDataKey = struct
     let input = Json_serializers.generate_data_key_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.GenerateDataKey" ~service ~context
       ~input ~output_deserializer:Json_deserializers.generate_data_key_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : generate_data_key_request) =
+    let input = Json_serializers.generate_data_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.GenerateDataKey"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.generate_data_key_response_of_yojson
       ~error_deserializer
 end
 
@@ -949,6 +1082,13 @@ module GenerateDataKeyPair = struct
     let input = Json_serializers.generate_data_key_pair_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.GenerateDataKeyPair" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.generate_data_key_pair_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : generate_data_key_pair_request) =
+    let input = Json_serializers.generate_data_key_pair_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.GenerateDataKeyPair"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.generate_data_key_pair_response_of_yojson
       ~error_deserializer
 end
@@ -1010,6 +1150,16 @@ module GenerateDataKeyPairWithoutPlaintext = struct
       ~output_deserializer:
         Json_deserializers.generate_data_key_pair_without_plaintext_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : generate_data_key_pair_without_plaintext_request) =
+    let input =
+      Json_serializers.generate_data_key_pair_without_plaintext_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.GenerateDataKeyPairWithoutPlaintext" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.generate_data_key_pair_without_plaintext_response_of_yojson
+      ~error_deserializer
 end
 
 module GenerateDataKeyWithoutPlaintext = struct
@@ -1062,6 +1212,13 @@ module GenerateDataKeyWithoutPlaintext = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.generate_data_key_without_plaintext_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : generate_data_key_without_plaintext_request) =
+    let input = Json_serializers.generate_data_key_without_plaintext_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.GenerateDataKeyWithoutPlaintext" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.generate_data_key_without_plaintext_response_of_yojson
+      ~error_deserializer
 end
 
 module GenerateMac = struct
@@ -1109,6 +1266,12 @@ module GenerateMac = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.GenerateMac" ~service ~context
       ~input ~output_deserializer:Json_deserializers.generate_mac_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : generate_mac_request) =
+    let input = Json_serializers.generate_mac_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.GenerateMac"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.generate_mac_response_of_yojson ~error_deserializer
 end
 
 module GenerateRandom = struct
@@ -1147,6 +1310,12 @@ module GenerateRandom = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.GenerateRandom" ~service ~context
       ~input ~output_deserializer:Json_deserializers.generate_random_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : generate_random_request) =
+    let input = Json_serializers.generate_random_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.GenerateRandom"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.generate_random_response_of_yojson ~error_deserializer
 end
 
 module GetKeyLastUsage = struct
@@ -1177,6 +1346,13 @@ module GetKeyLastUsage = struct
     let input = Json_serializers.get_key_last_usage_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.GetKeyLastUsage" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_key_last_usage_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_key_last_usage_request) =
+    let input = Json_serializers.get_key_last_usage_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.GetKeyLastUsage"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_key_last_usage_response_of_yojson
       ~error_deserializer
 end
 
@@ -1213,6 +1389,12 @@ module GetKeyPolicy = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.GetKeyPolicy" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_key_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_key_policy_request) =
+    let input = Json_serializers.get_key_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.GetKeyPolicy"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_key_policy_response_of_yojson ~error_deserializer
 end
 
 module GetKeyRotationStatus = struct
@@ -1253,6 +1435,13 @@ module GetKeyRotationStatus = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_key_rotation_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_key_rotation_status_request) =
+    let input = Json_serializers.get_key_rotation_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.GetKeyRotationStatus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_key_rotation_status_response_of_yojson
+      ~error_deserializer
 end
 
 module GetParametersForImport = struct
@@ -1291,6 +1480,13 @@ module GetParametersForImport = struct
     let input = Json_serializers.get_parameters_for_import_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.GetParametersForImport" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_parameters_for_import_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_parameters_for_import_request) =
+    let input = Json_serializers.get_parameters_for_import_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.GetParametersForImport" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_parameters_for_import_response_of_yojson
       ~error_deserializer
 end
@@ -1347,6 +1543,12 @@ module GetPublicKey = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.GetPublicKey" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_public_key_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_public_key_request) =
+    let input = Json_serializers.get_public_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.GetPublicKey"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_public_key_response_of_yojson ~error_deserializer
 end
 
 module ImportKeyMaterial = struct
@@ -1402,6 +1604,13 @@ module ImportKeyMaterial = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ImportKeyMaterial" ~service
       ~context ~input ~output_deserializer:Json_deserializers.import_key_material_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : import_key_material_request) =
+    let input = Json_serializers.import_key_material_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ImportKeyMaterial"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.import_key_material_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAliases = struct
@@ -1436,6 +1645,12 @@ module ListAliases = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ListAliases" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_aliases_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_aliases_request) =
+    let input = Json_serializers.list_aliases_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ListAliases"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_aliases_response_of_yojson ~error_deserializer
 end
 
 module ListGrants = struct
@@ -1478,6 +1693,12 @@ module ListGrants = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ListGrants" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_grants_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_grants_request) =
+    let input = Json_serializers.list_grants_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ListGrants" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_grants_response_of_yojson
+      ~error_deserializer
 end
 
 module ListKeyPolicies = struct
@@ -1512,6 +1733,13 @@ module ListKeyPolicies = struct
     let input = Json_serializers.list_key_policies_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ListKeyPolicies" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_key_policies_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_key_policies_request) =
+    let input = Json_serializers.list_key_policies_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ListKeyPolicies"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_key_policies_response_of_yojson
       ~error_deserializer
 end
 
@@ -1551,6 +1779,13 @@ module ListKeyRotations = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ListKeyRotations" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_key_rotations_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_key_rotations_request) =
+    let input = Json_serializers.list_key_rotations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ListKeyRotations"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_key_rotations_response_of_yojson
+      ~error_deserializer
 end
 
 module ListKeys = struct
@@ -1578,6 +1813,12 @@ module ListKeys = struct
     let input = Json_serializers.list_keys_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ListKeys" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_keys_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_keys_request) =
+    let input = Json_serializers.list_keys_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ListKeys" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_keys_response_of_yojson
+      ~error_deserializer
 end
 
 module ListResourceTags = struct
@@ -1607,6 +1848,13 @@ module ListResourceTags = struct
     let input = Json_serializers.list_resource_tags_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ListResourceTags" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_resource_tags_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_resource_tags_request) =
+    let input = Json_serializers.list_resource_tags_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ListResourceTags"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resource_tags_response_of_yojson
       ~error_deserializer
 end
 
@@ -1642,6 +1890,12 @@ module ListRetirableGrants = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ListRetirableGrants" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_grants_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_retirable_grants_request) =
+    let input = Json_serializers.list_retirable_grants_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ListRetirableGrants"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_grants_response_of_yojson ~error_deserializer
 end
 
 module PutKeyPolicy = struct
@@ -1687,6 +1941,13 @@ module PutKeyPolicy = struct
     let input = Json_serializers.put_key_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.PutKeyPolicy" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_key_policy_request) =
+    let input = Json_serializers.put_key_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.PutKeyPolicy"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1746,6 +2007,12 @@ module ReEncrypt = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ReEncrypt" ~service ~context
       ~input ~output_deserializer:Json_deserializers.re_encrypt_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : re_encrypt_request) =
+    let input = Json_serializers.re_encrypt_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ReEncrypt" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.re_encrypt_response_of_yojson
+      ~error_deserializer
 end
 
 module ReplicateKey = struct
@@ -1796,6 +2063,12 @@ module ReplicateKey = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ReplicateKey" ~service ~context
       ~input ~output_deserializer:Json_deserializers.replicate_key_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : replicate_key_request) =
+    let input = Json_serializers.replicate_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ReplicateKey"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.replicate_key_response_of_yojson ~error_deserializer
 end
 
 module RetireGrant = struct
@@ -1843,6 +2116,13 @@ module RetireGrant = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.RetireGrant" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : retire_grant_request) =
+    let input = Json_serializers.retire_grant_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.RetireGrant"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module RevokeGrant = struct
@@ -1885,6 +2165,13 @@ module RevokeGrant = struct
     let input = Json_serializers.revoke_grant_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.RevokeGrant" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : revoke_grant_request) =
+    let input = Json_serializers.revoke_grant_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.RevokeGrant"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -1935,6 +2222,13 @@ module RotateKeyOnDemand = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.rotate_key_on_demand_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : rotate_key_on_demand_request) =
+    let input = Json_serializers.rotate_key_on_demand_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.RotateKeyOnDemand"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.rotate_key_on_demand_response_of_yojson
+      ~error_deserializer
 end
 
 module ScheduleKeyDeletion = struct
@@ -1969,6 +2263,13 @@ module ScheduleKeyDeletion = struct
     let input = Json_serializers.schedule_key_deletion_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.ScheduleKeyDeletion" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.schedule_key_deletion_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : schedule_key_deletion_request) =
+    let input = Json_serializers.schedule_key_deletion_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.ScheduleKeyDeletion"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.schedule_key_deletion_response_of_yojson
       ~error_deserializer
 end
@@ -2021,6 +2322,12 @@ module Sign = struct
     let input = Json_serializers.sign_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.Sign" ~service ~context ~input
       ~output_deserializer:Json_deserializers.sign_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : sign_request) =
+    let input = Json_serializers.sign_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.Sign" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.sign_response_of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -2057,6 +2364,13 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.TagResource" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -2089,6 +2403,13 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.UntagResource" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -2124,6 +2445,13 @@ module UpdateAlias = struct
     let input = Json_serializers.update_alias_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.UpdateAlias" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_alias_request) =
+    let input = Json_serializers.update_alias_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.UpdateAlias"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -2223,6 +2551,13 @@ module UpdateCustomKeyStore = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_custom_key_store_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_custom_key_store_request) =
+    let input = Json_serializers.update_custom_key_store_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.UpdateCustomKeyStore" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_custom_key_store_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateKeyDescription = struct
@@ -2257,6 +2592,13 @@ module UpdateKeyDescription = struct
     let input = Json_serializers.update_key_description_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.UpdateKeyDescription" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_key_description_request) =
+    let input = Json_serializers.update_key_description_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"TrentService.UpdateKeyDescription" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -2295,6 +2637,13 @@ module UpdatePrimaryRegion = struct
     let input = Json_serializers.update_primary_region_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.UpdatePrimaryRegion" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_primary_region_request) =
+    let input = Json_serializers.update_primary_region_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.UpdatePrimaryRegion"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -2350,6 +2699,12 @@ module Verify = struct
     let input = Json_serializers.verify_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.Verify" ~service ~context ~input
       ~output_deserializer:Json_deserializers.verify_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : verify_request) =
+    let input = Json_serializers.verify_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.Verify" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.verify_response_of_yojson
+      ~error_deserializer
 end
 
 module VerifyMac = struct
@@ -2399,5 +2754,11 @@ module VerifyMac = struct
     let input = Json_serializers.verify_mac_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"TrentService.VerifyMac" ~service ~context
       ~input ~output_deserializer:Json_deserializers.verify_mac_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : verify_mac_request) =
+    let input = Json_serializers.verify_mac_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"TrentService.VerifyMac" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.verify_mac_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/kms/operations.mli
+++ b/sdks/kms/operations.mli
@@ -21,6 +21,18 @@ module CancelKeyDeletion : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_key_deletion_request ->
+    ( cancel_key_deletion_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Cancels the deletion of a KMS key. When this operation succeeds, the key state of the KMS key \
@@ -63,6 +75,19 @@ module ConnectCustomKeyStore : sig
     'http_type Smaws_Lib.Context.t ->
     connect_custom_key_store_request ->
     ( connect_custom_key_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudHsmClusterInvalidConfigurationException of
+        cloud_hsm_cluster_invalid_configuration_exception
+      | `CloudHsmClusterNotActiveException of cloud_hsm_cluster_not_active_exception
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    connect_custom_key_store_request ->
+    ( connect_custom_key_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudHsmClusterInvalidConfigurationException of
         cloud_hsm_cluster_invalid_configuration_exception
@@ -198,6 +223,20 @@ module CreateAlias : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_alias_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AlreadyExistsException of already_exists_exception
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidAliasNameException of invalid_alias_name_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a friendly name for a KMS key. \n\n\
@@ -298,6 +337,34 @@ module CreateCustomKeyStore : sig
     'http_type Smaws_Lib.Context.t ->
     create_custom_key_store_request ->
     ( create_custom_key_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudHsmClusterInUseException of cloud_hsm_cluster_in_use_exception
+      | `CloudHsmClusterInvalidConfigurationException of
+        cloud_hsm_cluster_invalid_configuration_exception
+      | `CloudHsmClusterNotActiveException of cloud_hsm_cluster_not_active_exception
+      | `CloudHsmClusterNotFoundException of cloud_hsm_cluster_not_found_exception
+      | `CustomKeyStoreNameInUseException of custom_key_store_name_in_use_exception
+      | `IncorrectTrustAnchorException of incorrect_trust_anchor_exception
+      | `KMSInternalException of kms_internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `XksProxyIncorrectAuthenticationCredentialException of
+        xks_proxy_incorrect_authentication_credential_exception
+      | `XksProxyInvalidConfigurationException of xks_proxy_invalid_configuration_exception
+      | `XksProxyInvalidResponseException of xks_proxy_invalid_response_exception
+      | `XksProxyUriEndpointInUseException of xks_proxy_uri_endpoint_in_use_exception
+      | `XksProxyUriInUseException of xks_proxy_uri_in_use_exception
+      | `XksProxyUriUnreachableException of xks_proxy_uri_unreachable_exception
+      | `XksProxyVpcEndpointServiceInUseException of xks_proxy_vpc_endpoint_service_in_use_exception
+      | `XksProxyVpcEndpointServiceInvalidConfigurationException of
+        xks_proxy_vpc_endpoint_service_invalid_configuration_exception
+      | `XksProxyVpcEndpointServiceNotFoundException of
+        xks_proxy_vpc_endpoint_service_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_custom_key_store_request ->
+    ( create_custom_key_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudHsmClusterInUseException of cloud_hsm_cluster_in_use_exception
       | `CloudHsmClusterInvalidConfigurationException of
@@ -447,6 +514,22 @@ module CreateGrant : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_grant_request ->
+    ( create_grant_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds a grant to a KMS key. \n\n\
@@ -545,6 +628,27 @@ module CreateKey : sig
     'http_type Smaws_Lib.Context.t ->
     create_key_request ->
     ( create_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudHsmClusterInvalidConfigurationException of
+        cloud_hsm_cluster_invalid_configuration_exception
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `TagException of tag_exception
+      | `UnsupportedOperationException of unsupported_operation_exception
+      | `XksKeyAlreadyInUseException of xks_key_already_in_use_exception
+      | `XksKeyInvalidConfigurationException of xks_key_invalid_configuration_exception
+      | `XksKeyNotFoundException of xks_key_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_key_request ->
+    ( create_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudHsmClusterInvalidConfigurationException of
         cloud_hsm_cluster_invalid_configuration_exception
@@ -782,6 +886,24 @@ module Decrypt : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    decrypt_request ->
+    ( decrypt_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `IncorrectKeyException of incorrect_key_exception
+      | `InvalidCiphertextException of invalid_ciphertext_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Decrypts ciphertext that was encrypted by a KMS key using any of the following operations:\n\n\
@@ -908,6 +1030,17 @@ module DeleteAlias : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_alias_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified alias. \n\n\
@@ -976,6 +1109,17 @@ module DeleteCustomKeyStore : sig
     'http_type Smaws_Lib.Context.t ->
     delete_custom_key_store_request ->
     ( delete_custom_key_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomKeyStoreHasCMKsException of custom_key_store_has_cm_ks_exception
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_custom_key_store_request ->
+    ( delete_custom_key_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CustomKeyStoreHasCMKsException of custom_key_store_has_cm_ks_exception
       | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
@@ -1073,6 +1217,19 @@ module DeleteImportedKeyMaterial : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_imported_key_material_request ->
+    ( delete_imported_key_material_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes key material that was previously imported. This operation makes the specified KMS key \
@@ -1144,6 +1301,22 @@ module DeriveSharedSecret : sig
     'http_type Smaws_Lib.Context.t ->
     derive_shared_secret_request ->
     ( derive_shared_secret_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    derive_shared_secret_request ->
+    ( derive_shared_secret_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -1265,6 +1438,16 @@ module DescribeCustomKeyStores : sig
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_custom_key_stores_request ->
+    ( describe_custom_key_stores_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets information about \
@@ -1344,6 +1527,17 @@ module DescribeKey : sig
     'http_type Smaws_Lib.Context.t ->
     describe_key_request ->
     ( describe_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_key_request ->
+    ( describe_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -1457,6 +1651,18 @@ module DisableKey : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_key_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the state of a KMS key to disabled. This change temporarily prevents use of the KMS key \
@@ -1499,6 +1705,20 @@ module DisableKeyRotation : sig
     'http_type Smaws_Lib.Context.t ->
     disable_key_rotation_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_key_rotation_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -1587,6 +1807,16 @@ module DisconnectCustomKeyStore : sig
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
       | `KMSInternalException of kms_internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disconnect_custom_key_store_request ->
+    ( disconnect_custom_key_store_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disconnects the \
@@ -1668,6 +1898,19 @@ module EnableKey : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_key_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the key state of a KMS key to enabled. This allows you to use the KMS key for \
@@ -1708,6 +1951,20 @@ module EnableKeyRotation : sig
     'http_type Smaws_Lib.Context.t ->
     enable_key_rotation_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_key_rotation_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -1819,6 +2076,22 @@ module Encrypt : sig
     'http_type Smaws_Lib.Context.t ->
     encrypt_request ->
     ( encrypt_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    encrypt_request ->
+    ( encrypt_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -1961,6 +2234,22 @@ module GenerateDataKey : sig
     'http_type Smaws_Lib.Context.t ->
     generate_data_key_request ->
     ( generate_data_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_data_key_request ->
+    ( generate_data_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -2122,6 +2411,23 @@ module GenerateDataKeyPair : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_data_key_pair_request ->
+    ( generate_data_key_pair_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a unique asymmetric data key pair for use outside of KMS. This operation returns a \
@@ -2247,6 +2553,23 @@ module GenerateDataKeyPairWithoutPlaintext : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_data_key_pair_without_plaintext_request ->
+    ( generate_data_key_pair_without_plaintext_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a unique asymmetric data key pair for use outside of KMS. This operation returns a \
@@ -2335,6 +2658,22 @@ module GenerateDataKeyWithoutPlaintext : sig
     'http_type Smaws_Lib.Context.t ->
     generate_data_key_without_plaintext_request ->
     ( generate_data_key_without_plaintext_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_data_key_without_plaintext_request ->
+    ( generate_data_key_without_plaintext_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -2456,6 +2795,21 @@ module GenerateMac : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_mac_request ->
+    ( generate_mac_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Generates a hash-based message authentication code (HMAC) for a message using an HMAC KMS key \
@@ -2517,6 +2871,18 @@ module GenerateRandom : sig
       | `KMSInternalException of kms_internal_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_random_request ->
+    ( generate_random_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `KMSInternalException of kms_internal_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a random byte string that is cryptographically secure.\n\n\
@@ -2569,6 +2935,17 @@ module GetKeyLastUsage : sig
     'http_type Smaws_Lib.Context.t ->
     get_key_last_usage_request ->
     ( get_key_last_usage_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_last_usage_request ->
+    ( get_key_last_usage_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -2664,6 +3041,18 @@ module GetKeyPolicy : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_policy_request ->
+    ( get_key_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets a key policy attached to the specified KMS key.\n\n\
@@ -2698,6 +3087,19 @@ module GetKeyRotationStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_key_rotation_status_request ->
     ( get_key_rotation_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_rotation_status_request ->
+    ( get_key_rotation_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -2803,6 +3205,19 @@ module GetParametersForImport : sig
     'http_type Smaws_Lib.Context.t ->
     get_parameters_for_import_request ->
     ( get_parameters_for_import_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameters_for_import_request ->
+    ( get_parameters_for_import_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -2927,6 +3342,23 @@ module GetPublicKey : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_public_key_request ->
+    ( get_public_key_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the public key of an asymmetric KMS key. Unlike the private key of a asymmetric KMS \
@@ -3017,6 +3449,23 @@ module ImportKeyMaterial : sig
     'http_type Smaws_Lib.Context.t ->
     import_key_material_request ->
     ( import_key_material_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `ExpiredImportTokenException of expired_import_token_exception
+      | `IncorrectKeyMaterialException of incorrect_key_material_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidCiphertextException of invalid_ciphertext_exception
+      | `InvalidImportTokenException of invalid_import_token_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_key_material_request ->
+    ( import_key_material_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `ExpiredImportTokenException of expired_import_token_exception
@@ -3201,6 +3650,18 @@ module ListAliases : sig
       | `KMSInternalException of kms_internal_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_aliases_request ->
+    ( list_aliases_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets a list of aliases in the caller's Amazon Web Services account and region. For more \
@@ -3270,6 +3731,20 @@ module ListGrants : sig
     'http_type Smaws_Lib.Context.t ->
     list_grants_request ->
     ( list_grants_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantIdException of invalid_grant_id_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_grants_request ->
+    ( list_grants_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -3356,6 +3831,18 @@ module ListKeyPolicies : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_key_policies_request ->
+    ( list_key_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets the names of the key policies that are attached to a KMS key. This operation is designed \
@@ -3400,6 +3887,19 @@ module ListKeyRotations : sig
     'http_type Smaws_Lib.Context.t ->
     list_key_rotations_request ->
     ( list_key_rotations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_key_rotations_request ->
+    ( list_key_rotations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
@@ -3472,6 +3972,16 @@ module ListKeys : sig
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_keys_request ->
+    ( list_keys_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets a list of all KMS keys in the caller's Amazon Web Services account and Region.\n\n\
@@ -3517,6 +4027,17 @@ module ListResourceTags : sig
     'http_type Smaws_Lib.Context.t ->
     list_resource_tags_request ->
     ( list_resource_tags_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_tags_request ->
+    ( list_resource_tags_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
@@ -3575,6 +4096,18 @@ module ListRetirableGrants : sig
     'http_type Smaws_Lib.Context.t ->
     list_retirable_grants_request ->
     ( list_grants_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidMarkerException of invalid_marker_exception
+      | `KMSInternalException of kms_internal_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_retirable_grants_request ->
+    ( list_grants_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
@@ -3666,6 +4199,21 @@ module PutKeyPolicy : sig
       | `NotFoundException of not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_key_policy_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attaches a key policy to the specified KMS key. \n\n\
@@ -3715,6 +4263,24 @@ module ReEncrypt : sig
     'http_type Smaws_Lib.Context.t ->
     re_encrypt_request ->
     ( re_encrypt_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `IncorrectKeyException of incorrect_key_exception
+      | `InvalidCiphertextException of invalid_ciphertext_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    re_encrypt_request ->
+    ( re_encrypt_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -3876,6 +4442,23 @@ module ReplicateKey : sig
       | `TagException of tag_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    replicate_key_request ->
+    ( replicate_key_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AlreadyExistsException of already_exists_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `NotFoundException of not_found_exception
+      | `TagException of tag_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Replicates a multi-Region key into the specified Region. This operation creates a multi-Region \
@@ -3994,6 +4577,21 @@ module RetireGrant : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    retire_grant_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantIdException of invalid_grant_id_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a grant. Typically, you retire a grant when you no longer need its permissions. To \
@@ -4059,6 +4657,20 @@ module RevokeGrant : sig
     'http_type Smaws_Lib.Context.t ->
     revoke_grant_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `InvalidGrantIdException of invalid_grant_id_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    revoke_grant_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DryRunOperationException of dry_run_operation_exception
@@ -4134,6 +4746,22 @@ module RotateKeyOnDemand : sig
     'http_type Smaws_Lib.Context.t ->
     rotate_key_on_demand_request ->
     ( rotate_key_on_demand_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    rotate_key_on_demand_request ->
+    ( rotate_key_on_demand_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `DependencyTimeoutException of dependency_timeout_exception
@@ -4247,6 +4875,18 @@ module ScheduleKeyDeletion : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    schedule_key_deletion_request ->
+    ( schedule_key_deletion_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Schedules the deletion of a KMS key. By default, KMS applies a waiting period of 30 days, but \
@@ -4335,6 +4975,22 @@ module Sign : sig
     'http_type Smaws_Lib.Context.t ->
     sign_request ->
     ( sign_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    sign_request ->
+    ( sign_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `DisabledException of disabled_exception
@@ -4435,6 +5091,19 @@ module TagResource : sig
       | `NotFoundException of not_found_exception
       | `TagException of tag_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception
+      | `TagException of tag_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds or edits tags on a \
@@ -4521,6 +5190,18 @@ module UntagResource : sig
       | `NotFoundException of not_found_exception
       | `TagException of tag_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `TagException of tag_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes tags from a \
@@ -4587,6 +5268,18 @@ module UpdateAlias : sig
     'http_type Smaws_Lib.Context.t ->
     update_alias_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_alias_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `KMSInternalException of kms_internal_exception
@@ -4695,6 +5388,34 @@ module UpdateCustomKeyStore : sig
     'http_type Smaws_Lib.Context.t ->
     update_custom_key_store_request ->
     ( update_custom_key_store_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CloudHsmClusterInvalidConfigurationException of
+        cloud_hsm_cluster_invalid_configuration_exception
+      | `CloudHsmClusterNotActiveException of cloud_hsm_cluster_not_active_exception
+      | `CloudHsmClusterNotFoundException of cloud_hsm_cluster_not_found_exception
+      | `CloudHsmClusterNotRelatedException of cloud_hsm_cluster_not_related_exception
+      | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
+      | `CustomKeyStoreNameInUseException of custom_key_store_name_in_use_exception
+      | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
+      | `KMSInternalException of kms_internal_exception
+      | `XksProxyIncorrectAuthenticationCredentialException of
+        xks_proxy_incorrect_authentication_credential_exception
+      | `XksProxyInvalidConfigurationException of xks_proxy_invalid_configuration_exception
+      | `XksProxyInvalidResponseException of xks_proxy_invalid_response_exception
+      | `XksProxyUriEndpointInUseException of xks_proxy_uri_endpoint_in_use_exception
+      | `XksProxyUriInUseException of xks_proxy_uri_in_use_exception
+      | `XksProxyUriUnreachableException of xks_proxy_uri_unreachable_exception
+      | `XksProxyVpcEndpointServiceInUseException of xks_proxy_vpc_endpoint_service_in_use_exception
+      | `XksProxyVpcEndpointServiceInvalidConfigurationException of
+        xks_proxy_vpc_endpoint_service_invalid_configuration_exception
+      | `XksProxyVpcEndpointServiceNotFoundException of
+        xks_proxy_vpc_endpoint_service_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_custom_key_store_request ->
+    ( update_custom_key_store_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CloudHsmClusterInvalidConfigurationException of
         cloud_hsm_cluster_invalid_configuration_exception
@@ -4835,6 +5556,18 @@ module UpdateKeyDescription : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_key_description_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the description of a KMS key. To see the description of a KMS key, use [DescribeKey]. \n\n\
@@ -4880,6 +5613,19 @@ module UpdatePrimaryRegion : sig
     'http_type Smaws_Lib.Context.t ->
     update_primary_region_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DisabledException of disabled_exception
+      | `InvalidArnException of invalid_arn_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_primary_region_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DisabledException of disabled_exception
       | `InvalidArnException of invalid_arn_exception
@@ -5004,6 +5750,23 @@ module Verify : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    verify_request ->
+    ( verify_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DependencyTimeoutException of dependency_timeout_exception
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidSignatureException of kms_invalid_signature_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Verifies a digital signature that was generated by the [Sign] operation. \n\n\
@@ -5078,6 +5841,22 @@ module VerifyMac : sig
     'http_type Smaws_Lib.Context.t ->
     verify_mac_request ->
     ( verify_mac_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DisabledException of disabled_exception
+      | `DryRunOperationException of dry_run_operation_exception
+      | `InvalidGrantTokenException of invalid_grant_token_exception
+      | `InvalidKeyUsageException of invalid_key_usage_exception
+      | `KeyUnavailableException of key_unavailable_exception
+      | `KMSInternalException of kms_internal_exception
+      | `KMSInvalidMacException of kms_invalid_mac_exception
+      | `KMSInvalidStateException of kms_invalid_state_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    verify_mac_request ->
+    ( verify_mac_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DisabledException of disabled_exception
       | `DryRunOperationException of dry_run_operation_exception

--- a/sdks/kms/operations.mli
+++ b/sdks/kms/operations.mli
@@ -31,7 +31,8 @@ module CancelKeyDeletion : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -94,7 +95,8 @@ module ConnectCustomKeyStore : sig
       | `CloudHsmClusterNotActiveException of cloud_hsm_cluster_not_active_exception
       | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -235,7 +237,8 @@ module CreateAlias : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -386,7 +389,8 @@ module CreateCustomKeyStore : sig
       | `XksProxyVpcEndpointServiceInvalidConfigurationException of
         xks_proxy_vpc_endpoint_service_invalid_configuration_exception
       | `XksProxyVpcEndpointServiceNotFoundException of
-        xks_proxy_vpc_endpoint_service_not_found_exception ] )
+        xks_proxy_vpc_endpoint_service_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -528,7 +532,8 @@ module CreateGrant : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -663,7 +668,8 @@ module CreateKey : sig
       | `UnsupportedOperationException of unsupported_operation_exception
       | `XksKeyAlreadyInUseException of xks_key_already_in_use_exception
       | `XksKeyInvalidConfigurationException of xks_key_invalid_configuration_exception
-      | `XksKeyNotFoundException of xks_key_not_found_exception ] )
+      | `XksKeyNotFoundException of xks_key_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -902,7 +908,8 @@ module Decrypt : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1039,7 +1046,8 @@ module DeleteAlias : sig
       | `DependencyTimeoutException of dependency_timeout_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1124,7 +1132,8 @@ module DeleteCustomKeyStore : sig
       | `CustomKeyStoreHasCMKsException of custom_key_store_has_cm_ks_exception
       | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1228,7 +1237,8 @@ module DeleteImportedKeyMaterial : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1326,7 +1336,8 @@ module DeriveSharedSecret : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1446,7 +1457,8 @@ module DescribeCustomKeyStores : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
       | `InvalidMarkerException of invalid_marker_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1542,7 +1554,8 @@ module DescribeKey : sig
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1661,7 +1674,8 @@ module DisableKey : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1726,7 +1740,8 @@ module DisableKeyRotation : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1815,7 +1830,8 @@ module DisconnectCustomKeyStore : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CustomKeyStoreInvalidStateException of custom_key_store_invalid_state_exception
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1909,7 +1925,8 @@ module EnableKey : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1972,7 +1989,8 @@ module EnableKeyRotation : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2101,7 +2119,8 @@ module Encrypt : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2259,7 +2278,8 @@ module GenerateDataKey : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2426,7 +2446,8 @@ module GenerateDataKeyPair : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2568,7 +2589,8 @@ module GenerateDataKeyPairWithoutPlaintext : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2683,7 +2705,8 @@ module GenerateDataKeyWithoutPlaintext : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2808,7 +2831,8 @@ module GenerateMac : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2881,7 +2905,8 @@ module GenerateRandom : sig
       | `CustomKeyStoreNotFoundException of custom_key_store_not_found_exception
       | `DependencyTimeoutException of dependency_timeout_exception
       | `KMSInternalException of kms_internal_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2950,7 +2975,8 @@ module GetKeyLastUsage : sig
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3051,7 +3077,8 @@ module GetKeyPolicy : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3106,7 +3133,8 @@ module GetKeyRotationStatus : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3224,7 +3252,8 @@ module GetParametersForImport : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3357,7 +3386,8 @@ module GetPublicKey : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3476,7 +3506,8 @@ module ImportKeyMaterial : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3660,7 +3691,8 @@ module ListAliases : sig
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3752,7 +3784,8 @@ module ListGrants : sig
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3841,7 +3874,8 @@ module ListKeyPolicies : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3906,7 +3940,8 @@ module ListKeyRotations : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3980,7 +4015,8 @@ module ListKeys : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DependencyTimeoutException of dependency_timeout_exception
       | `InvalidMarkerException of invalid_marker_exception
-      | `KMSInternalException of kms_internal_exception ] )
+      | `KMSInternalException of kms_internal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4042,7 +4078,8 @@ module ListResourceTags : sig
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4113,7 +4150,8 @@ module ListRetirableGrants : sig
       | `InvalidArnException of invalid_arn_exception
       | `InvalidMarkerException of invalid_marker_exception
       | `KMSInternalException of kms_internal_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4212,7 +4250,8 @@ module PutKeyPolicy : sig
       | `LimitExceededException of limit_exceeded_exception
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4292,7 +4331,8 @@ module ReEncrypt : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4457,7 +4497,8 @@ module ReplicateKey : sig
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `NotFoundException of not_found_exception
       | `TagException of tag_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4590,7 +4631,8 @@ module RetireGrant : sig
       | `InvalidGrantTokenException of invalid_grant_token_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4678,7 +4720,8 @@ module RevokeGrant : sig
       | `InvalidGrantIdException of invalid_grant_id_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4771,7 +4814,8 @@ module RotateKeyOnDemand : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4885,7 +4929,8 @@ module ScheduleKeyDeletion : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5000,7 +5045,8 @@ module Sign : sig
       | `KeyUnavailableException of key_unavailable_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5102,7 +5148,8 @@ module TagResource : sig
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception
-      | `TagException of tag_exception ] )
+      | `TagException of tag_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5200,7 +5247,8 @@ module UntagResource : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `TagException of tag_exception ] )
+      | `TagException of tag_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5285,7 +5333,8 @@ module UpdateAlias : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5437,7 +5486,8 @@ module UpdateCustomKeyStore : sig
       | `XksProxyVpcEndpointServiceInvalidConfigurationException of
         xks_proxy_vpc_endpoint_service_invalid_configuration_exception
       | `XksProxyVpcEndpointServiceNotFoundException of
-        xks_proxy_vpc_endpoint_service_not_found_exception ] )
+        xks_proxy_vpc_endpoint_service_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5566,7 +5616,8 @@ module UpdateKeyDescription : sig
       | `InvalidArnException of invalid_arn_exception
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5632,7 +5683,8 @@ module UpdatePrimaryRegion : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
       | `NotFoundException of not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5765,7 +5817,8 @@ module Verify : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidSignatureException of kms_invalid_signature_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5866,7 +5919,8 @@ module VerifyMac : sig
       | `KMSInternalException of kms_internal_exception
       | `KMSInvalidMacException of kms_invalid_mac_exception
       | `KMSInvalidStateException of kms_invalid_state_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/lightsail/Smaws_Client_Lightsail.mli
+++ b/sdks/lightsail/Smaws_Client_Lightsail.mli
@@ -1954,7 +1954,8 @@ module AllocateStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Allocates a static IP address.\n"]
@@ -1993,7 +1994,8 @@ module AttachCertificateToDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2052,7 +2054,8 @@ module AttachDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2104,7 +2107,8 @@ module AttachInstancesToLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2159,7 +2163,8 @@ module AttachLoadBalancerTlsCertificate : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2217,7 +2222,8 @@ module AttachStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Attaches a static IP address to a specific Amazon Lightsail instance.\n"]
@@ -2262,7 +2268,8 @@ module CloseInstancePublicPorts : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2313,7 +2320,8 @@ module CopySnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2361,7 +2369,8 @@ module CreateBucket : sig
       | `InvalidInputException of invalid_input_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2407,7 +2416,8 @@ module CreateBucketAccessKey : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2462,7 +2472,8 @@ module CreateCertificate : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2519,7 +2530,8 @@ module CreateCloudFormationStack : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2569,7 +2581,8 @@ module CreateContactMethod : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2622,7 +2635,8 @@ module CreateContainerService : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2667,7 +2681,8 @@ module CreateContainerServiceDeployment : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2719,7 +2734,8 @@ module CreateContainerServiceRegistryLogin : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2785,7 +2801,8 @@ module CreateDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2837,7 +2854,8 @@ module CreateDiskFromSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2890,7 +2908,8 @@ module CreateDiskSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2953,7 +2972,8 @@ module CreateDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3005,7 +3025,8 @@ module CreateDomain : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3056,7 +3077,8 @@ module CreateDomainEntry : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3103,7 +3125,8 @@ module CreateGUISessionAccessDetails : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3154,7 +3177,8 @@ module CreateInstances : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3205,7 +3229,8 @@ module CreateInstancesFromSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3257,7 +3282,8 @@ module CreateInstanceSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3309,7 +3335,8 @@ module CreateKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3365,7 +3392,8 @@ module CreateLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3423,7 +3451,8 @@ module CreateLoadBalancerTlsCertificate : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3477,7 +3506,8 @@ module CreateRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3528,7 +3558,8 @@ module CreateRelationalDatabaseFromSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3583,7 +3614,8 @@ module CreateRelationalDatabaseSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3632,7 +3664,8 @@ module DeleteAlarm : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3681,7 +3714,8 @@ module DeleteAutoSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3723,7 +3757,8 @@ module DeleteBucket : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3767,7 +3802,8 @@ module DeleteBucketAccessKey : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3813,7 +3849,8 @@ module DeleteCertificate : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3860,7 +3897,8 @@ module DeleteContactMethod : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3908,7 +3946,8 @@ module DeleteContainerImage : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3948,7 +3987,8 @@ module DeleteContainerService : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes your Amazon Lightsail container service.\n"]
@@ -3993,7 +4033,8 @@ module DeleteDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4047,7 +4088,8 @@ module DeleteDiskSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4098,7 +4140,8 @@ module DeleteDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes your Amazon Lightsail content delivery network (CDN) distribution.\n"]
@@ -4143,7 +4186,8 @@ module DeleteDomain : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4194,7 +4238,8 @@ module DeleteDomainEntry : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4245,7 +4290,8 @@ module DeleteInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4296,7 +4342,8 @@ module DeleteInstanceSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4347,7 +4394,8 @@ module DeleteKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4407,7 +4455,8 @@ module DeleteKnownHostKeys : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4462,7 +4511,8 @@ module DeleteLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4515,7 +4565,8 @@ module DeleteLoadBalancerTlsCertificate : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4567,7 +4618,8 @@ module DeleteRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4618,7 +4670,8 @@ module DeleteRelationalDatabaseSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4664,7 +4717,8 @@ module DetachCertificateFromDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4714,7 +4768,8 @@ module DetachDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4767,7 +4822,8 @@ module DetachInstancesFromLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4822,7 +4878,8 @@ module DetachStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Detaches a static IP from the Amazon Lightsail instance to which it is attached.\n"]
@@ -4864,7 +4921,8 @@ module DisableAddOn : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4912,7 +4970,8 @@ module DownloadDefaultKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4958,7 +5017,8 @@ module EnableAddOn : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5006,7 +5066,8 @@ module ExportSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5071,7 +5132,8 @@ module GetActiveNames : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the names of all active (not deleted) resources.\n"]
@@ -5113,7 +5175,8 @@ module GetAlarms : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5164,7 +5227,8 @@ module GetAutoSnapshots : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5213,7 +5277,8 @@ module GetBlueprints : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5262,7 +5327,8 @@ module GetBucketAccessKeys : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5305,7 +5371,8 @@ module GetBucketBundles : sig
       | `InvalidInputException of invalid_input_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5352,7 +5419,8 @@ module GetBucketMetricData : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5396,7 +5464,8 @@ module GetBuckets : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5448,7 +5517,8 @@ module GetBundles : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5494,7 +5564,8 @@ module GetCertificates : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5545,7 +5616,8 @@ module GetCloudFormationStackRecords : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5592,7 +5664,8 @@ module GetContactMethods : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5635,7 +5708,8 @@ module GetContainerAPIMetadata : sig
       | `AccessDeniedException of access_denied_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5676,7 +5750,8 @@ module GetContainerImages : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5721,7 +5796,8 @@ module GetContainerLog : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5770,7 +5846,8 @@ module GetContainerServiceDeployments : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5822,7 +5899,8 @@ module GetContainerServiceMetricData : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5865,7 +5943,8 @@ module GetContainerServicePowers : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5908,7 +5987,8 @@ module GetContainerServices : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about one or more of your Amazon Lightsail container services.\n"]
@@ -5947,7 +6027,8 @@ module GetCostEstimate : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5994,7 +6075,8 @@ module GetDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific block storage disk.\n"]
@@ -6039,7 +6121,8 @@ module GetDisks : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all block storage disks in your AWS account and region.\n"]
@@ -6084,7 +6167,8 @@ module GetDiskSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific block storage disk snapshot.\n"]
@@ -6129,7 +6213,8 @@ module GetDiskSnapshots : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6169,7 +6254,8 @@ module GetDistributionBundles : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6213,7 +6299,8 @@ module GetDistributionLatestCacheReset : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6254,7 +6341,8 @@ module GetDistributionMetricData : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6299,7 +6387,8 @@ module GetDistributions : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6346,7 +6435,8 @@ module GetDomain : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific domain recordset.\n"]
@@ -6391,7 +6481,8 @@ module GetDomains : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of all domains in the user's account.\n"]
@@ -6436,7 +6527,8 @@ module GetExportSnapshotRecords : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6488,7 +6580,8 @@ module GetInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6535,7 +6628,8 @@ module GetInstanceAccessDetails : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6587,7 +6681,8 @@ module GetInstanceMetricData : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6638,7 +6733,8 @@ module GetInstancePortStates : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6685,7 +6781,8 @@ module GetInstances : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6731,7 +6828,8 @@ module GetInstanceSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific instance snapshot.\n"]
@@ -6776,7 +6874,8 @@ module GetInstanceSnapshots : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns all instance snapshots for the user's account.\n"]
@@ -6821,7 +6920,8 @@ module GetInstanceState : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the state of a specific instance. Works on one instance at a time.\n"]
@@ -6866,7 +6966,8 @@ module GetKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific key pair.\n"]
@@ -6911,7 +7012,8 @@ module GetKeyPairs : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all key pairs in the user's account.\n"]
@@ -6956,7 +7058,8 @@ module GetLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the specified Lightsail load balancer.\n"]
@@ -7001,7 +7104,8 @@ module GetLoadBalancerMetricData : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7051,7 +7155,8 @@ module GetLoadBalancers : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all load balancers in an account.\n"]
@@ -7096,7 +7201,8 @@ module GetLoadBalancerTlsCertificates : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7142,7 +7248,8 @@ module GetLoadBalancerTlsPolicies : sig
       | `InvalidInputException of invalid_input_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7193,7 +7300,8 @@ module GetOperation : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7240,7 +7348,8 @@ module GetOperations : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7290,7 +7399,8 @@ module GetOperationsForResource : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets operations for a specific resource (an instance or a static IP).\n"]
@@ -7335,7 +7445,8 @@ module GetRegions : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7382,7 +7493,8 @@ module GetRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific database in Amazon Lightsail.\n"]
@@ -7427,7 +7539,8 @@ module GetRelationalDatabaseBlueprints : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7476,7 +7589,8 @@ module GetRelationalDatabaseBundles : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7525,7 +7639,8 @@ module GetRelationalDatabaseEvents : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of events for a specific database in Amazon Lightsail.\n"]
@@ -7570,7 +7685,8 @@ module GetRelationalDatabaseLogEvents : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of log events for a database in Amazon Lightsail.\n"]
@@ -7615,7 +7731,8 @@ module GetRelationalDatabaseLogStreams : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7661,7 +7778,8 @@ module GetRelationalDatabaseMasterUserPassword : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7711,7 +7829,8 @@ module GetRelationalDatabaseMetricData : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7761,7 +7880,8 @@ module GetRelationalDatabaseParameters : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7812,7 +7932,8 @@ module GetRelationalDatabases : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all of your databases in Amazon Lightsail.\n"]
@@ -7857,7 +7978,8 @@ module GetRelationalDatabaseSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific database snapshot in Amazon Lightsail.\n"]
@@ -7902,7 +8024,8 @@ module GetRelationalDatabaseSnapshots : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all of your database snapshots in Amazon Lightsail.\n"]
@@ -7941,7 +8064,8 @@ module GetSetupHistory : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7988,7 +8112,8 @@ module GetStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about an Amazon Lightsail static IP.\n"]
@@ -8033,7 +8158,8 @@ module GetStaticIps : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all static IPs in the user's account.\n"]
@@ -8078,7 +8204,8 @@ module ImportKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Imports a public SSH key from a specific key pair.\n"]
@@ -8123,7 +8250,8 @@ module IsVpcPeered : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a Boolean value indicating whether your Lightsail VPC is peered.\n"]
@@ -8168,7 +8296,8 @@ module OpenInstancePublicPorts : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8220,7 +8349,8 @@ module PeerVpc : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Peers the Lightsail VPC with the user's default VPC.\n"]
@@ -8262,7 +8392,8 @@ module PutAlarm : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8327,7 +8458,8 @@ module PutInstancePublicPorts : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8382,7 +8514,8 @@ module RebootInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8433,7 +8566,8 @@ module RebootRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8478,7 +8612,8 @@ module RegisterContainerImage : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8531,7 +8666,8 @@ module ReleaseStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a specific static IP from your account.\n"]
@@ -8570,7 +8706,8 @@ module ResetDistributionCache : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8617,7 +8754,8 @@ module SendContactMethodVerification : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8680,7 +8818,8 @@ module SetIpAddressType : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8724,7 +8863,8 @@ module SetResourceAccessForBucket : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8767,7 +8907,8 @@ module SetupInstanceHttps : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8811,7 +8952,8 @@ module StartGUISession : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8859,7 +9001,8 @@ module StartInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8917,7 +9060,8 @@ module StartRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8963,7 +9107,8 @@ module StopGUISession : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9011,7 +9156,8 @@ module StopInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9068,7 +9214,8 @@ module StopRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9124,7 +9271,8 @@ module TagResource : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9176,7 +9324,8 @@ module TestAlarm : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9230,7 +9379,8 @@ module UnpeerVpc : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Unpeers the Lightsail VPC from the user's default VPC.\n"]
@@ -9275,7 +9425,8 @@ module UntagResource : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9321,7 +9472,8 @@ module UpdateBucket : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9364,7 +9516,8 @@ module UpdateBucketBundle : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9418,7 +9571,8 @@ module UpdateContainerService : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9459,7 +9613,8 @@ module UpdateDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9501,7 +9656,8 @@ module UpdateDistributionBundle : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9558,7 +9714,8 @@ module UpdateDomainEntry : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9609,7 +9766,8 @@ module UpdateInstanceMetadataOptions : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9661,7 +9819,8 @@ module UpdateLoadBalancerAttribute : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9714,7 +9873,8 @@ module UpdateRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -9770,7 +9930,8 @@ module UpdateRelationalDatabaseParameters : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/lightsail/Smaws_Client_Lightsail.mli
+++ b/sdks/lightsail/Smaws_Client_Lightsail.mli
@@ -1941,6 +1941,21 @@ module AllocateStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    allocate_static_ip_request ->
+    ( allocate_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Allocates a static IP address.\n"]
 
@@ -1959,6 +1974,19 @@ module AttachCertificateToDistribution : sig
     'http_type Smaws_Lib.Context.t ->
     attach_certificate_to_distribution_request ->
     ( attach_certificate_to_distribution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_certificate_to_distribution_request ->
+    ( attach_certificate_to_distribution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2011,6 +2039,21 @@ module AttachDisk : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_disk_request ->
+    ( attach_disk_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attaches a block storage disk to a running or stopped Lightsail instance and exposes it to the \
@@ -2038,6 +2081,21 @@ module AttachInstancesToLoadBalancer : sig
     'http_type Smaws_Lib.Context.t ->
     attach_instances_to_load_balancer_request ->
     ( attach_instances_to_load_balancer_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_instances_to_load_balancer_request ->
+    ( attach_instances_to_load_balancer_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2078,6 +2136,21 @@ module AttachLoadBalancerTlsCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     attach_load_balancer_tls_certificate_request ->
     ( attach_load_balancer_tls_certificate_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_load_balancer_tls_certificate_request ->
+    ( attach_load_balancer_tls_certificate_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2131,6 +2204,21 @@ module AttachStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_static_ip_request ->
+    ( attach_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Attaches a static IP address to a specific Amazon Lightsail instance.\n"]
 
@@ -2151,6 +2239,21 @@ module CloseInstancePublicPorts : sig
     'http_type Smaws_Lib.Context.t ->
     close_instance_public_ports_request ->
     ( close_instance_public_ports_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    close_instance_public_ports_request ->
+    ( close_instance_public_ports_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2197,6 +2300,21 @@ module CopySnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    copy_snapshot_request ->
+    ( copy_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Copies a manual snapshot of an instance or disk as another manual snapshot, or copies an \
@@ -2233,6 +2351,18 @@ module CreateBucket : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_bucket_request ->
+    ( create_bucket_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an Amazon Lightsail bucket.\n\n\
@@ -2258,6 +2388,19 @@ module CreateBucketAccessKey : sig
     'http_type Smaws_Lib.Context.t ->
     create_bucket_access_key_request ->
     ( create_bucket_access_key_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_bucket_access_key_request ->
+    ( create_bucket_access_key_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2308,6 +2451,19 @@ module CreateCertificate : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_certificate_request ->
+    ( create_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an SSL/TLS certificate for an Amazon Lightsail content delivery network (CDN) \
@@ -2350,6 +2506,21 @@ module CreateCloudFormationStack : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_cloud_formation_stack_request ->
+    ( create_cloud_formation_stack_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an AWS CloudFormation stack, which creates a new Amazon EC2 instance from an exported \
@@ -2377,6 +2548,20 @@ module CreateContactMethod : sig
     'http_type Smaws_Lib.Context.t ->
     create_contact_method_request ->
     ( create_contact_method_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_contact_method_request ->
+    ( create_contact_method_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2426,6 +2611,19 @@ module CreateContainerService : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_container_service_request ->
+    ( create_container_service_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an Amazon Lightsail container service.\n\n\
@@ -2450,6 +2648,19 @@ module CreateContainerServiceDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     create_container_service_deployment_request ->
     ( create_container_service_deployment_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_container_service_deployment_request ->
+    ( create_container_service_deployment_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2489,6 +2700,19 @@ module CreateContainerServiceRegistryLogin : sig
     'http_type Smaws_Lib.Context.t ->
     create_container_service_registry_login_request ->
     ( create_container_service_registry_login_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_container_service_registry_login_request ->
+    ( create_container_service_registry_login_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2548,6 +2772,21 @@ module CreateDisk : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_disk_request ->
+    ( create_disk_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a block storage disk that can be attached to an Amazon Lightsail instance in the same \
@@ -2575,6 +2814,21 @@ module CreateDiskFromSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     create_disk_from_snapshot_request ->
     ( create_disk_from_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_disk_from_snapshot_request ->
+    ( create_disk_from_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2613,6 +2867,21 @@ module CreateDiskSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     create_disk_snapshot_request ->
     ( create_disk_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_disk_snapshot_request ->
+    ( create_disk_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2673,6 +2942,19 @@ module CreateDistribution : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_distribution_request ->
+    ( create_distribution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an Amazon Lightsail content delivery network (CDN) distribution.\n\n\
@@ -2700,6 +2982,21 @@ module CreateDomain : sig
     'http_type Smaws_Lib.Context.t ->
     create_domain_request ->
     ( create_domain_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_domain_request ->
+    ( create_domain_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2746,6 +3043,21 @@ module CreateDomainEntry : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_domain_entry_request ->
+    ( create_domain_entry_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates one of the following domain name system (DNS) records in a domain DNS zone: Address \
@@ -2772,6 +3084,19 @@ module CreateGUISessionAccessDetails : sig
     'http_type Smaws_Lib.Context.t ->
     create_gui_session_access_details_request ->
     ( create_gui_session_access_details_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_gui_session_access_details_request ->
+    ( create_gui_session_access_details_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2816,6 +3141,21 @@ module CreateInstances : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_instances_request ->
+    ( create_instances_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates one or more Amazon Lightsail instances.\n\n\
@@ -2842,6 +3182,21 @@ module CreateInstancesFromSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     create_instances_from_snapshot_request ->
     ( create_instances_from_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_instances_from_snapshot_request ->
+    ( create_instances_from_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2889,6 +3244,21 @@ module CreateInstanceSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_instance_snapshot_request ->
+    ( create_instance_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a snapshot of a specific virtual private server, or {i instance}. You can use a \
@@ -2916,6 +3286,21 @@ module CreateKeyPair : sig
     'http_type Smaws_Lib.Context.t ->
     create_key_pair_request ->
     ( create_key_pair_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_key_pair_request ->
+    ( create_key_pair_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2957,6 +3342,21 @@ module CreateLoadBalancer : sig
     'http_type Smaws_Lib.Context.t ->
     create_load_balancer_request ->
     ( create_load_balancer_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_load_balancer_request ->
+    ( create_load_balancer_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3010,6 +3410,21 @@ module CreateLoadBalancerTlsCertificate : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_load_balancer_tls_certificate_request ->
+    ( create_load_balancer_tls_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an SSL/TLS certificate for an Amazon Lightsail load balancer.\n\n\
@@ -3049,6 +3464,21 @@ module CreateRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_relational_database_request ->
+    ( create_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new database in Amazon Lightsail.\n\n\
@@ -3075,6 +3505,21 @@ module CreateRelationalDatabaseFromSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     create_relational_database_from_snapshot_request ->
     ( create_relational_database_from_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_relational_database_from_snapshot_request ->
+    ( create_relational_database_from_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3125,6 +3570,21 @@ module CreateRelationalDatabaseSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_relational_database_snapshot_request ->
+    ( create_relational_database_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a snapshot of your database in Amazon Lightsail. You can use snapshots for backups, to \
@@ -3151,6 +3611,20 @@ module DeleteAlarm : sig
     'http_type Smaws_Lib.Context.t ->
     delete_alarm_request ->
     ( delete_alarm_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_alarm_request ->
+    ( delete_alarm_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -3195,6 +3669,20 @@ module DeleteAutoSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_auto_snapshot_request ->
+    ( delete_auto_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an automatic snapshot of an instance or disk. For more information, see the \
@@ -3216,6 +3704,19 @@ module DeleteBucket : sig
     'http_type Smaws_Lib.Context.t ->
     delete_bucket_request ->
     ( delete_bucket_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_bucket_request ->
+    ( delete_bucket_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -3247,6 +3748,19 @@ module DeleteBucketAccessKey : sig
     'http_type Smaws_Lib.Context.t ->
     delete_bucket_access_key_request ->
     ( delete_bucket_access_key_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_bucket_access_key_request ->
+    ( delete_bucket_access_key_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -3288,6 +3802,19 @@ module DeleteCertificate : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_certificate_request ->
+    ( delete_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an SSL/TLS certificate for your Amazon Lightsail content delivery network (CDN) \
@@ -3312,6 +3839,20 @@ module DeleteContactMethod : sig
     'http_type Smaws_Lib.Context.t ->
     delete_contact_method_request ->
     ( delete_contact_method_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_contact_method_request ->
+    ( delete_contact_method_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -3356,6 +3897,19 @@ module DeleteContainerImage : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_container_image_request ->
+    ( delete_container_image_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a container image that is registered to your Amazon Lightsail container service.\n"]
@@ -3375,6 +3929,19 @@ module DeleteContainerService : sig
     'http_type Smaws_Lib.Context.t ->
     delete_container_service_request ->
     ( delete_container_service_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_container_service_request ->
+    ( delete_container_service_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -3403,6 +3970,21 @@ module DeleteDisk : sig
     'http_type Smaws_Lib.Context.t ->
     delete_disk_request ->
     ( delete_disk_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_disk_request ->
+    ( delete_disk_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3452,6 +4034,21 @@ module DeleteDiskSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_disk_snapshot_request ->
+    ( delete_disk_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified disk snapshot.\n\n\
@@ -3490,6 +4087,19 @@ module DeleteDistribution : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_distribution_request ->
+    ( delete_distribution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes your Amazon Lightsail content delivery network (CDN) distribution.\n"]
 
@@ -3510,6 +4120,21 @@ module DeleteDomain : sig
     'http_type Smaws_Lib.Context.t ->
     delete_domain_request ->
     ( delete_domain_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_domain_request ->
+    ( delete_domain_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3556,6 +4181,21 @@ module DeleteDomainEntry : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_domain_entry_request ->
+    ( delete_domain_entry_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a specific domain entry.\n\n\
@@ -3582,6 +4222,21 @@ module DeleteInstance : sig
     'http_type Smaws_Lib.Context.t ->
     delete_instance_request ->
     ( delete_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_instance_request ->
+    ( delete_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3628,6 +4283,21 @@ module DeleteInstanceSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_instance_snapshot_request ->
+    ( delete_instance_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a specific snapshot of a virtual private server (or {i instance}).\n\n\
@@ -3654,6 +4324,21 @@ module DeleteKeyPair : sig
     'http_type Smaws_Lib.Context.t ->
     delete_key_pair_request ->
     ( delete_key_pair_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_key_pair_request ->
+    ( delete_key_pair_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3709,6 +4394,21 @@ module DeleteKnownHostKeys : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_known_host_keys_request ->
+    ( delete_known_host_keys_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the known host key or certificate used by the Amazon Lightsail browser-based SSH or RDP \
@@ -3739,6 +4439,21 @@ module DeleteLoadBalancer : sig
     'http_type Smaws_Lib.Context.t ->
     delete_load_balancer_request ->
     ( delete_load_balancer_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_load_balancer_request ->
+    ( delete_load_balancer_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3787,6 +4502,21 @@ module DeleteLoadBalancerTlsCertificate : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_load_balancer_tls_certificate_request ->
+    ( delete_load_balancer_tls_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an SSL/TLS certificate associated with a Lightsail load balancer.\n\n\
@@ -3814,6 +4544,21 @@ module DeleteRelationalDatabase : sig
     'http_type Smaws_Lib.Context.t ->
     delete_relational_database_request ->
     ( delete_relational_database_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_relational_database_request ->
+    ( delete_relational_database_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3860,6 +4605,21 @@ module DeleteRelationalDatabaseSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_relational_database_snapshot_request ->
+    ( delete_relational_database_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a database snapshot in Amazon Lightsail.\n\n\
@@ -3885,6 +4645,19 @@ module DetachCertificateFromDistribution : sig
     'http_type Smaws_Lib.Context.t ->
     detach_certificate_from_distribution_request ->
     ( detach_certificate_from_distribution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    detach_certificate_from_distribution_request ->
+    ( detach_certificate_from_distribution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -3928,6 +4701,21 @@ module DetachDisk : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    detach_disk_request ->
+    ( detach_disk_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Detaches a stopped block storage disk from a Lightsail instance. Make sure to unmount any file \
@@ -3956,6 +4744,21 @@ module DetachInstancesFromLoadBalancer : sig
     'http_type Smaws_Lib.Context.t ->
     detach_instances_from_load_balancer_request ->
     ( detach_instances_from_load_balancer_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    detach_instances_from_load_balancer_request ->
+    ( detach_instances_from_load_balancer_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4006,6 +4809,21 @@ module DetachStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    detach_static_ip_request ->
+    ( detach_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Detaches a static IP from the Amazon Lightsail instance to which it is attached.\n"]
 
@@ -4025,6 +4843,20 @@ module DisableAddOn : sig
     'http_type Smaws_Lib.Context.t ->
     disable_add_on_request ->
     ( disable_add_on_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_add_on_request ->
+    ( disable_add_on_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4067,6 +4899,21 @@ module DownloadDefaultKeyPair : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    download_default_key_pair_request ->
+    ( download_default_key_pair_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Downloads the regional Amazon Lightsail default key pair.\n\n\
@@ -4099,6 +4946,20 @@ module EnableAddOn : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_add_on_request ->
+    ( enable_add_on_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables or modifies an add-on for an Amazon Lightsail resource. For more information, see the \
@@ -4122,6 +4983,21 @@ module ExportSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     export_snapshot_request ->
     ( export_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    export_snapshot_request ->
+    ( export_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4182,6 +5058,21 @@ module GetActiveNames : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_active_names_request ->
+    ( get_active_names_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the names of all active (not deleted) resources.\n"]
 
@@ -4201,6 +5092,20 @@ module GetAlarms : sig
     'http_type Smaws_Lib.Context.t ->
     get_alarms_request ->
     ( get_alarms_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_alarms_request ->
+    ( get_alarms_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4247,6 +5152,20 @@ module GetAutoSnapshots : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_auto_snapshots_request ->
+    ( get_auto_snapshots_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the available automatic snapshots for an instance or disk. For more information, see \
@@ -4271,6 +5190,21 @@ module GetBlueprints : sig
     'http_type Smaws_Lib.Context.t ->
     get_blueprints_request ->
     ( get_blueprints_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_blueprints_request ->
+    ( get_blueprints_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4317,6 +5251,19 @@ module GetBucketAccessKeys : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bucket_access_keys_request ->
+    ( get_bucket_access_keys_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the existing access key IDs for the specified Amazon Lightsail bucket.\n\n\
@@ -4341,6 +5288,18 @@ module GetBucketBundles : sig
     'http_type Smaws_Lib.Context.t ->
     get_bucket_bundles_request ->
     ( get_bucket_bundles_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bucket_bundles_request ->
+    ( get_bucket_bundles_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4382,6 +5341,19 @@ module GetBucketMetricData : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bucket_metric_data_request ->
+    ( get_bucket_metric_data_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the data points of a specific metric for an Amazon Lightsail bucket.\n\n\
@@ -4405,6 +5377,19 @@ module GetBuckets : sig
     'http_type Smaws_Lib.Context.t ->
     get_buckets_request ->
     ( get_buckets_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_buckets_request ->
+    ( get_buckets_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4450,6 +5435,21 @@ module GetBundles : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bundles_request ->
+    ( get_bundles_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the bundles that you can apply to an Amazon Lightsail instance when you create it.\n\n\
@@ -4475,6 +5475,19 @@ module GetCertificates : sig
     'http_type Smaws_Lib.Context.t ->
     get_certificates_request ->
     ( get_certificates_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_certificates_request ->
+    ( get_certificates_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4519,6 +5532,21 @@ module GetCloudFormationStackRecords : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_cloud_formation_stack_records_request ->
+    ( get_cloud_formation_stack_records_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the CloudFormation stack record created as a result of the [create cloud\n\
@@ -4543,6 +5571,20 @@ module GetContactMethods : sig
     'http_type Smaws_Lib.Context.t ->
     get_contact_methods_request ->
     ( get_contact_methods_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_contact_methods_request ->
+    ( get_contact_methods_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4584,6 +5626,17 @@ module GetContainerAPIMetadata : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_api_metadata_request ->
+    ( get_container_api_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about Amazon Lightsail containers, such as the current version of the \
@@ -4604,6 +5657,19 @@ module GetContainerImages : sig
     'http_type Smaws_Lib.Context.t ->
     get_container_images_request ->
     ( get_container_images_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_images_request ->
+    ( get_container_images_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4644,6 +5710,19 @@ module GetContainerLog : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_log_request ->
+    ( get_container_log_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the log events of a container of your Amazon Lightsail container service.\n\n\
@@ -4672,6 +5751,19 @@ module GetContainerServiceDeployments : sig
     'http_type Smaws_Lib.Context.t ->
     get_container_service_deployments_request ->
     ( get_container_service_deployments_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_service_deployments_request ->
+    ( get_container_service_deployments_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4719,6 +5811,19 @@ module GetContainerServiceMetricData : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_service_metric_data_request ->
+    ( get_container_service_metric_data_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the data points of a specific metric of your Amazon Lightsail container service.\n\n\
@@ -4741,6 +5846,19 @@ module GetContainerServicePowers : sig
     'http_type Smaws_Lib.Context.t ->
     get_container_service_powers_request ->
     ( get_container_service_powers_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_service_powers_request ->
+    ( get_container_service_powers_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4779,6 +5897,19 @@ module GetContainerServices : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_services_request ->
+    ( container_services_list_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about one or more of your Amazon Lightsail container services.\n"]
 
@@ -4797,6 +5928,19 @@ module GetCostEstimate : sig
     'http_type Smaws_Lib.Context.t ->
     get_cost_estimate_request ->
     ( get_cost_estimate_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_cost_estimate_request ->
+    ( get_cost_estimate_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4837,6 +5981,21 @@ module GetDisk : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_disk_request ->
+    ( get_disk_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a specific block storage disk.\n"]
 
@@ -4857,6 +6016,21 @@ module GetDisks : sig
     'http_type Smaws_Lib.Context.t ->
     get_disks_request ->
     ( get_disks_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_disks_request ->
+    ( get_disks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4897,6 +6071,21 @@ module GetDiskSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_disk_snapshot_request ->
+    ( get_disk_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a specific block storage disk snapshot.\n"]
 
@@ -4927,6 +6116,21 @@ module GetDiskSnapshots : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_disk_snapshots_request ->
+    ( get_disk_snapshots_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about all block storage disk snapshots in your AWS account and region.\n"]
@@ -4946,6 +6150,19 @@ module GetDistributionBundles : sig
     'http_type Smaws_Lib.Context.t ->
     get_distribution_bundles_request ->
     ( get_distribution_bundles_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_distribution_bundles_request ->
+    ( get_distribution_bundles_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4985,6 +6202,19 @@ module GetDistributionLatestCacheReset : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_distribution_latest_cache_reset_request ->
+    ( get_distribution_latest_cache_reset_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the timestamp and status of the last cache reset of a specific Amazon Lightsail content \
@@ -5005,6 +6235,19 @@ module GetDistributionMetricData : sig
     'http_type Smaws_Lib.Context.t ->
     get_distribution_metric_data_request ->
     ( get_distribution_metric_data_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_distribution_metric_data_request ->
+    ( get_distribution_metric_data_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -5045,6 +6288,19 @@ module GetDistributions : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_distributions_request ->
+    ( get_distributions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about one or more of your Amazon Lightsail content delivery network (CDN) \
@@ -5067,6 +6323,21 @@ module GetDomain : sig
     'http_type Smaws_Lib.Context.t ->
     get_domain_request ->
     ( get_domain_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_domain_request ->
+    ( get_domain_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5107,6 +6378,21 @@ module GetDomains : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_domains_request ->
+    ( get_domains_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of all domains in the user's account.\n"]
 
@@ -5127,6 +6413,21 @@ module GetExportSnapshotRecords : sig
     'http_type Smaws_Lib.Context.t ->
     get_export_snapshot_records_request ->
     ( get_export_snapshot_records_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_export_snapshot_records_request ->
+    ( get_export_snapshot_records_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5174,6 +6475,21 @@ module GetInstance : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_request ->
+    ( get_instance_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a specific Amazon Lightsail instance, which is a virtual private \
@@ -5196,6 +6512,21 @@ module GetInstanceAccessDetails : sig
     'http_type Smaws_Lib.Context.t ->
     get_instance_access_details_request ->
     ( get_instance_access_details_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_access_details_request ->
+    ( get_instance_access_details_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5243,6 +6574,21 @@ module GetInstanceMetricData : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_metric_data_request ->
+    ( get_instance_metric_data_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the data points for the specified Amazon Lightsail instance metric, given an instance \
@@ -5269,6 +6615,21 @@ module GetInstancePortStates : sig
     'http_type Smaws_Lib.Context.t ->
     get_instance_port_states_request ->
     ( get_instance_port_states_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_port_states_request ->
+    ( get_instance_port_states_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5311,6 +6672,21 @@ module GetInstances : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instances_request ->
+    ( get_instances_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about all Amazon Lightsail virtual private servers, or {i instances}.\n"]
@@ -5332,6 +6708,21 @@ module GetInstanceSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     get_instance_snapshot_request ->
     ( get_instance_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_snapshot_request ->
+    ( get_instance_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5372,6 +6763,21 @@ module GetInstanceSnapshots : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_snapshots_request ->
+    ( get_instance_snapshots_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns all instance snapshots for the user's account.\n"]
 
@@ -5392,6 +6798,21 @@ module GetInstanceState : sig
     'http_type Smaws_Lib.Context.t ->
     get_instance_state_request ->
     ( get_instance_state_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_state_request ->
+    ( get_instance_state_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5432,6 +6853,21 @@ module GetKeyPair : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_pair_request ->
+    ( get_key_pair_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a specific key pair.\n"]
 
@@ -5452,6 +6888,21 @@ module GetKeyPairs : sig
     'http_type Smaws_Lib.Context.t ->
     get_key_pairs_request ->
     ( get_key_pairs_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_pairs_request ->
+    ( get_key_pairs_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5492,6 +6943,21 @@ module GetLoadBalancer : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancer_request ->
+    ( get_load_balancer_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the specified Lightsail load balancer.\n"]
 
@@ -5512,6 +6978,21 @@ module GetLoadBalancerMetricData : sig
     'http_type Smaws_Lib.Context.t ->
     get_load_balancer_metric_data_request ->
     ( get_load_balancer_metric_data_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancer_metric_data_request ->
+    ( get_load_balancer_metric_data_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5557,6 +7038,21 @@ module GetLoadBalancers : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancers_request ->
+    ( get_load_balancers_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about all load balancers in an account.\n"]
 
@@ -5577,6 +7073,21 @@ module GetLoadBalancerTlsCertificates : sig
     'http_type Smaws_Lib.Context.t ->
     get_load_balancer_tls_certificates_request ->
     ( get_load_balancer_tls_certificates_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancer_tls_certificates_request ->
+    ( get_load_balancer_tls_certificates_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5612,6 +7123,19 @@ module GetLoadBalancerTlsPolicies : sig
     'http_type Smaws_Lib.Context.t ->
     get_load_balancer_tls_policies_request ->
     ( get_load_balancer_tls_policies_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancer_tls_policies_request ->
+    ( get_load_balancer_tls_policies_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5656,6 +7180,21 @@ module GetOperation : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_operation_request ->
+    ( get_operation_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a specific operation. Operations include events such as when you \
@@ -5678,6 +7217,21 @@ module GetOperations : sig
     'http_type Smaws_Lib.Context.t ->
     get_operations_request ->
     ( get_operations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_operations_request ->
+    ( get_operations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5723,6 +7277,21 @@ module GetOperationsForResource : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_operations_for_resource_request ->
+    ( get_operations_for_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Gets operations for a specific resource (an instance or a static IP).\n"]
 
@@ -5743,6 +7312,21 @@ module GetRegions : sig
     'http_type Smaws_Lib.Context.t ->
     get_regions_request ->
     ( get_regions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_regions_request ->
+    ( get_regions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5785,6 +7369,21 @@ module GetRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_request ->
+    ( get_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a specific database in Amazon Lightsail.\n"]
 
@@ -5805,6 +7404,21 @@ module GetRelationalDatabaseBlueprints : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_blueprints_request ->
     ( get_relational_database_blueprints_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_blueprints_request ->
+    ( get_relational_database_blueprints_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5849,6 +7463,21 @@ module GetRelationalDatabaseBundles : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_bundles_request ->
+    ( get_relational_database_bundles_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the list of bundles that are available in Amazon Lightsail. A bundle describes the \
@@ -5873,6 +7502,21 @@ module GetRelationalDatabaseEvents : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_events_request ->
     ( get_relational_database_events_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_events_request ->
+    ( get_relational_database_events_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5913,6 +7557,21 @@ module GetRelationalDatabaseLogEvents : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_log_events_request ->
+    ( get_relational_database_log_events_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of log events for a database in Amazon Lightsail.\n"]
 
@@ -5933,6 +7592,21 @@ module GetRelationalDatabaseLogStreams : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_log_streams_request ->
     ( get_relational_database_log_streams_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_log_streams_request ->
+    ( get_relational_database_log_streams_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5964,6 +7638,21 @@ module GetRelationalDatabaseMasterUserPassword : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_master_user_password_request ->
     ( get_relational_database_master_user_password_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_master_user_password_request ->
+    ( get_relational_database_master_user_password_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -6009,6 +7698,21 @@ module GetRelationalDatabaseMetricData : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_metric_data_request ->
+    ( get_relational_database_metric_data_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the data points of the specified metric for a database in Amazon Lightsail.\n\n\
@@ -6034,6 +7738,21 @@ module GetRelationalDatabaseParameters : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_parameters_request ->
     ( get_relational_database_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_parameters_request ->
+    ( get_relational_database_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -6080,6 +7799,21 @@ module GetRelationalDatabases : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_databases_request ->
+    ( get_relational_databases_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about all of your databases in Amazon Lightsail.\n"]
 
@@ -6100,6 +7834,21 @@ module GetRelationalDatabaseSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_snapshot_request ->
     ( get_relational_database_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_snapshot_request ->
+    ( get_relational_database_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -6140,6 +7889,21 @@ module GetRelationalDatabaseSnapshots : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_snapshots_request ->
+    ( get_relational_database_snapshots_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about all of your database snapshots in Amazon Lightsail.\n"]
 
@@ -6158,6 +7922,19 @@ module GetSetupHistory : sig
     'http_type Smaws_Lib.Context.t ->
     get_setup_history_request ->
     ( get_setup_history_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_setup_history_request ->
+    ( get_setup_history_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -6198,6 +7975,21 @@ module GetStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_static_ip_request ->
+    ( get_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about an Amazon Lightsail static IP.\n"]
 
@@ -6218,6 +8010,21 @@ module GetStaticIps : sig
     'http_type Smaws_Lib.Context.t ->
     get_static_ips_request ->
     ( get_static_ips_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_static_ips_request ->
+    ( get_static_ips_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -6258,6 +8065,21 @@ module ImportKeyPair : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_key_pair_request ->
+    ( import_key_pair_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Imports a public SSH key from a specific key pair.\n"]
 
@@ -6288,6 +8110,21 @@ module IsVpcPeered : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    is_vpc_peered_request ->
+    ( is_vpc_peered_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a Boolean value indicating whether your Lightsail VPC is peered.\n"]
 
@@ -6308,6 +8145,21 @@ module OpenInstancePublicPorts : sig
     'http_type Smaws_Lib.Context.t ->
     open_instance_public_ports_request ->
     ( open_instance_public_ports_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    open_instance_public_ports_request ->
+    ( open_instance_public_ports_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -6355,6 +8207,21 @@ module PeerVpc : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    peer_vpc_request ->
+    ( peer_vpc_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Peers the Lightsail VPC with the user's default VPC.\n"]
 
@@ -6374,6 +8241,20 @@ module PutAlarm : sig
     'http_type Smaws_Lib.Context.t ->
     put_alarm_request ->
     ( put_alarm_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_alarm_request ->
+    ( put_alarm_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -6433,6 +8314,21 @@ module PutInstancePublicPorts : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_instance_public_ports_request ->
+    ( put_instance_public_ports_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Opens ports for a specific Amazon Lightsail instance, and specifies the IP addresses allowed to \
@@ -6463,6 +8359,21 @@ module RebootInstance : sig
     'http_type Smaws_Lib.Context.t ->
     reboot_instance_request ->
     ( reboot_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reboot_instance_request ->
+    ( reboot_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -6509,6 +8420,21 @@ module RebootRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reboot_relational_database_request ->
+    ( reboot_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Restarts a specific database in Amazon Lightsail.\n\n\
@@ -6533,6 +8459,19 @@ module RegisterContainerImage : sig
     'http_type Smaws_Lib.Context.t ->
     register_container_image_request ->
     ( register_container_image_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_container_image_request ->
+    ( register_container_image_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -6579,6 +8518,21 @@ module ReleaseStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    release_static_ip_request ->
+    ( release_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a specific static IP from your account.\n"]
 
@@ -6597,6 +8551,19 @@ module ResetDistributionCache : sig
     'http_type Smaws_Lib.Context.t ->
     reset_distribution_cache_request ->
     ( reset_distribution_cache_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reset_distribution_cache_request ->
+    ( reset_distribution_cache_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -6629,6 +8596,20 @@ module SendContactMethodVerification : sig
     'http_type Smaws_Lib.Context.t ->
     send_contact_method_verification_request ->
     ( send_contact_method_verification_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_contact_method_verification_request ->
+    ( send_contact_method_verification_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -6686,6 +8667,21 @@ module SetIpAddressType : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_ip_address_type_request ->
+    ( set_ip_address_type_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the IP address type for an Amazon Lightsail resource.\n\n\
@@ -6717,6 +8713,19 @@ module SetResourceAccessForBucket : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_resource_access_for_bucket_request ->
+    ( set_resource_access_for_bucket_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the Amazon Lightsail resources that can access the specified Lightsail bucket.\n\n\
@@ -6739,6 +8748,19 @@ module SetupInstanceHttps : sig
     'http_type Smaws_Lib.Context.t ->
     setup_instance_https_request ->
     ( setup_instance_https_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    setup_instance_https_request ->
+    ( setup_instance_https_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -6778,6 +8800,19 @@ module StartGUISession : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_gui_session_request ->
+    ( start_gui_session_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Initiates a graphical user interface (GUI) session that\226\128\153s used to access a virtual \
@@ -6801,6 +8836,21 @@ module StartInstance : sig
     'http_type Smaws_Lib.Context.t ->
     start_instance_request ->
     ( start_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_instance_request ->
+    ( start_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -6854,6 +8904,21 @@ module StartRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_relational_database_request ->
+    ( start_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts a specific database from a stopped state in Amazon Lightsail. To restart a database, use \
@@ -6887,6 +8952,19 @@ module StopGUISession : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_gui_session_request ->
+    ( stop_gui_session_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Terminates a web-based Amazon DCV session that\226\128\153s used to access a virtual \
@@ -6910,6 +8988,21 @@ module StopInstance : sig
     'http_type Smaws_Lib.Context.t ->
     stop_instance_request ->
     ( stop_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_instance_request ->
+    ( stop_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -6962,6 +9055,21 @@ module StopRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_relational_database_request ->
+    ( stop_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops a specific database that is currently running in Amazon Lightsail.\n\n\
@@ -6993,6 +9101,21 @@ module TagResource : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resource_request ->
     ( tag_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -7041,6 +9164,20 @@ module TestAlarm : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_alarm_request ->
+    ( test_alarm_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Tests an alarm by displaying a banner on the Amazon Lightsail console. If a notification \
@@ -7080,6 +9217,21 @@ module UnpeerVpc : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unpeer_vpc_request ->
+    ( unpeer_vpc_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Unpeers the Lightsail VPC from the user's default VPC.\n"]
 
@@ -7100,6 +9252,21 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -7143,6 +9310,19 @@ module UpdateBucket : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_bucket_request ->
+    ( update_bucket_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing Amazon Lightsail bucket.\n\n\
@@ -7165,6 +9345,19 @@ module UpdateBucketBundle : sig
     'http_type Smaws_Lib.Context.t ->
     update_bucket_bundle_request ->
     ( update_bucket_bundle_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_bucket_bundle_request ->
+    ( update_bucket_bundle_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -7214,6 +9407,19 @@ module UpdateContainerService : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_container_service_request ->
+    ( update_container_service_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the configuration of your Amazon Lightsail container service, such as its power, scale, \
@@ -7234,6 +9440,19 @@ module UpdateDistribution : sig
     'http_type Smaws_Lib.Context.t ->
     update_distribution_request ->
     ( update_distribution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_distribution_request ->
+    ( update_distribution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -7263,6 +9482,19 @@ module UpdateDistributionBundle : sig
     'http_type Smaws_Lib.Context.t ->
     update_distribution_bundle_request ->
     ( update_distribution_bundle_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_distribution_bundle_request ->
+    ( update_distribution_bundle_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -7313,6 +9545,21 @@ module UpdateDomainEntry : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_domain_entry_request ->
+    ( update_domain_entry_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates a domain recordset after it is created.\n\n\
@@ -7339,6 +9586,21 @@ module UpdateInstanceMetadataOptions : sig
     'http_type Smaws_Lib.Context.t ->
     update_instance_metadata_options_request ->
     ( update_instance_metadata_options_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_instance_metadata_options_request ->
+    ( update_instance_metadata_options_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -7376,6 +9638,21 @@ module UpdateLoadBalancerAttribute : sig
     'http_type Smaws_Lib.Context.t ->
     update_load_balancer_attribute_request ->
     ( update_load_balancer_attribute_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_load_balancer_attribute_request ->
+    ( update_load_balancer_attribute_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -7424,6 +9701,21 @@ module UpdateRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_relational_database_request ->
+    ( update_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows the update of one or more attributes of a database in Amazon Lightsail.\n\n\
@@ -7455,6 +9747,21 @@ module UpdateRelationalDatabaseParameters : sig
     'http_type Smaws_Lib.Context.t ->
     update_relational_database_parameters_request ->
     ( update_relational_database_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_relational_database_parameters_request ->
+    ( update_relational_database_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception

--- a/sdks/lightsail/operations.ml
+++ b/sdks/lightsail/operations.ml
@@ -46,6 +46,13 @@ module AllocateStaticIp = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.AllocateStaticIp" ~service
       ~context ~input ~output_deserializer:Json_deserializers.allocate_static_ip_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : allocate_static_ip_request) =
+    let input = Json_serializers.allocate_static_ip_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.AllocateStaticIp" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.allocate_static_ip_result_of_yojson
+      ~error_deserializer
 end
 
 module AttachCertificateToDistribution = struct
@@ -82,6 +89,13 @@ module AttachCertificateToDistribution = struct
   let request context (request : attach_certificate_to_distribution_request) =
     let input = Json_serializers.attach_certificate_to_distribution_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.AttachCertificateToDistribution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.attach_certificate_to_distribution_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : attach_certificate_to_distribution_request) =
+    let input = Json_serializers.attach_certificate_to_distribution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.AttachCertificateToDistribution" ~service ~context ~input
       ~output_deserializer:Json_deserializers.attach_certificate_to_distribution_result_of_yojson
       ~error_deserializer
@@ -132,6 +146,12 @@ module AttachDisk = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.AttachDisk" ~service
       ~context ~input ~output_deserializer:Json_deserializers.attach_disk_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : attach_disk_request) =
+    let input = Json_serializers.attach_disk_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.AttachDisk"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.attach_disk_result_of_yojson
+      ~error_deserializer
 end
 
 module AttachInstancesToLoadBalancer = struct
@@ -177,6 +197,13 @@ module AttachInstancesToLoadBalancer = struct
   let request context (request : attach_instances_to_load_balancer_request) =
     let input = Json_serializers.attach_instances_to_load_balancer_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.AttachInstancesToLoadBalancer" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.attach_instances_to_load_balancer_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : attach_instances_to_load_balancer_request) =
+    let input = Json_serializers.attach_instances_to_load_balancer_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.AttachInstancesToLoadBalancer" ~service ~context ~input
       ~output_deserializer:Json_deserializers.attach_instances_to_load_balancer_result_of_yojson
       ~error_deserializer
@@ -228,6 +255,13 @@ module AttachLoadBalancerTlsCertificate = struct
       ~shape_name:"Lightsail_20161128.AttachLoadBalancerTlsCertificate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.attach_load_balancer_tls_certificate_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : attach_load_balancer_tls_certificate_request) =
+    let input = Json_serializers.attach_load_balancer_tls_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.AttachLoadBalancerTlsCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.attach_load_balancer_tls_certificate_result_of_yojson
+      ~error_deserializer
 end
 
 module AttachStaticIp = struct
@@ -275,6 +309,12 @@ module AttachStaticIp = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.AttachStaticIp" ~service
       ~context ~input ~output_deserializer:Json_deserializers.attach_static_ip_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : attach_static_ip_request) =
+    let input = Json_serializers.attach_static_ip_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.AttachStaticIp" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.attach_static_ip_result_of_yojson ~error_deserializer
 end
 
 module CloseInstancePublicPorts = struct
@@ -321,6 +361,13 @@ module CloseInstancePublicPorts = struct
     let input = Json_serializers.close_instance_public_ports_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CloseInstancePublicPorts"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.close_instance_public_ports_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : close_instance_public_ports_request) =
+    let input = Json_serializers.close_instance_public_ports_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CloseInstancePublicPorts" ~service ~context ~input
       ~output_deserializer:Json_deserializers.close_instance_public_ports_result_of_yojson
       ~error_deserializer
 end
@@ -370,6 +417,12 @@ module CopySnapshot = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CopySnapshot" ~service
       ~context ~input ~output_deserializer:Json_deserializers.copy_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : copy_snapshot_request) =
+    let input = Json_serializers.copy_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.CopySnapshot"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.copy_snapshot_result_of_yojson ~error_deserializer
 end
 
 module CreateBucket = struct
@@ -405,6 +458,12 @@ module CreateBucket = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateBucket" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_bucket_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_bucket_request) =
+    let input = Json_serializers.create_bucket_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.CreateBucket"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_bucket_result_of_yojson ~error_deserializer
 end
 
 module CreateBucketAccessKey = struct
@@ -444,6 +503,13 @@ module CreateBucketAccessKey = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_bucket_access_key_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_bucket_access_key_request) =
+    let input = Json_serializers.create_bucket_access_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateBucketAccessKey" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_bucket_access_key_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateCertificate = struct
@@ -481,6 +547,13 @@ module CreateCertificate = struct
     let input = Json_serializers.create_certificate_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateCertificate" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_certificate_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_certificate_request) =
+    let input = Json_serializers.create_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_certificate_result_of_yojson
       ~error_deserializer
 end
 
@@ -530,6 +603,13 @@ module CreateCloudFormationStack = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_cloud_formation_stack_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_cloud_formation_stack_request) =
+    let input = Json_serializers.create_cloud_formation_stack_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateCloudFormationStack" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_cloud_formation_stack_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateContactMethod = struct
@@ -573,6 +653,13 @@ module CreateContactMethod = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_contact_method_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_contact_method_request) =
+    let input = Json_serializers.create_contact_method_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateContactMethod" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_contact_method_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateContainerService = struct
@@ -610,6 +697,13 @@ module CreateContainerService = struct
     let input = Json_serializers.create_container_service_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateContainerService"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_container_service_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_container_service_request) =
+    let input = Json_serializers.create_container_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateContainerService" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_container_service_result_of_yojson
       ~error_deserializer
 end
@@ -651,6 +745,13 @@ module CreateContainerServiceDeployment = struct
       ~shape_name:"Lightsail_20161128.CreateContainerServiceDeployment" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_container_service_deployment_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_container_service_deployment_request) =
+    let input = Json_serializers.create_container_service_deployment_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateContainerServiceDeployment" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_container_service_deployment_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateContainerServiceRegistryLogin = struct
@@ -689,6 +790,16 @@ module CreateContainerServiceRegistryLogin = struct
       Json_serializers.create_container_service_registry_login_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.CreateContainerServiceRegistryLogin" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.create_container_service_registry_login_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_container_service_registry_login_request) =
+    let input =
+      Json_serializers.create_container_service_registry_login_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.CreateContainerServiceRegistryLogin" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.create_container_service_registry_login_result_of_yojson
@@ -740,6 +851,12 @@ module CreateDisk = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateDisk" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_disk_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_disk_request) =
+    let input = Json_serializers.create_disk_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.CreateDisk"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.create_disk_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateDiskFromSnapshot = struct
@@ -786,6 +903,13 @@ module CreateDiskFromSnapshot = struct
     let input = Json_serializers.create_disk_from_snapshot_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateDiskFromSnapshot"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_disk_from_snapshot_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_disk_from_snapshot_request) =
+    let input = Json_serializers.create_disk_from_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateDiskFromSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_disk_from_snapshot_result_of_yojson
       ~error_deserializer
 end
@@ -835,6 +959,13 @@ module CreateDiskSnapshot = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateDiskSnapshot" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_disk_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_disk_snapshot_request) =
+    let input = Json_serializers.create_disk_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateDiskSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_disk_snapshot_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateDistribution = struct
@@ -872,6 +1003,13 @@ module CreateDistribution = struct
     let input = Json_serializers.create_distribution_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateDistribution" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_distribution_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_distribution_request) =
+    let input = Json_serializers.create_distribution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateDistribution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_distribution_result_of_yojson
       ~error_deserializer
 end
 
@@ -920,6 +1058,12 @@ module CreateDomain = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateDomain" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_domain_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_domain_request) =
+    let input = Json_serializers.create_domain_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.CreateDomain"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_domain_result_of_yojson ~error_deserializer
 end
 
 module CreateDomainEntry = struct
@@ -967,6 +1111,13 @@ module CreateDomainEntry = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateDomainEntry" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_domain_entry_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_domain_entry_request) =
+    let input = Json_serializers.create_domain_entry_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateDomainEntry" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_domain_entry_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateGUISessionAccessDetails = struct
@@ -1003,6 +1154,13 @@ module CreateGUISessionAccessDetails = struct
   let request context (request : create_gui_session_access_details_request) =
     let input = Json_serializers.create_gui_session_access_details_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.CreateGUISessionAccessDetails" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_gui_session_access_details_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_gui_session_access_details_request) =
+    let input = Json_serializers.create_gui_session_access_details_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.CreateGUISessionAccessDetails" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_gui_session_access_details_result_of_yojson
       ~error_deserializer
@@ -1053,6 +1211,12 @@ module CreateInstances = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateInstances" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_instances_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_instances_request) =
+    let input = Json_serializers.create_instances_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateInstances" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_instances_result_of_yojson ~error_deserializer
 end
 
 module CreateInstancesFromSnapshot = struct
@@ -1099,6 +1263,13 @@ module CreateInstancesFromSnapshot = struct
     let input = Json_serializers.create_instances_from_snapshot_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateInstancesFromSnapshot"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_instances_from_snapshot_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_instances_from_snapshot_request) =
+    let input = Json_serializers.create_instances_from_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateInstancesFromSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_instances_from_snapshot_result_of_yojson
       ~error_deserializer
 end
@@ -1149,6 +1320,13 @@ module CreateInstanceSnapshot = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_instance_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_instance_snapshot_request) =
+    let input = Json_serializers.create_instance_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateInstanceSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_instance_snapshot_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateKeyPair = struct
@@ -1196,6 +1374,12 @@ module CreateKeyPair = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateKeyPair" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_key_pair_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_key_pair_request) =
+    let input = Json_serializers.create_key_pair_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.CreateKeyPair"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_key_pair_result_of_yojson ~error_deserializer
 end
 
 module CreateLoadBalancer = struct
@@ -1242,6 +1426,13 @@ module CreateLoadBalancer = struct
     let input = Json_serializers.create_load_balancer_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateLoadBalancer" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_load_balancer_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_load_balancer_request) =
+    let input = Json_serializers.create_load_balancer_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateLoadBalancer" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_load_balancer_result_of_yojson
       ~error_deserializer
 end
 
@@ -1291,6 +1482,13 @@ module CreateLoadBalancerTlsCertificate = struct
       ~shape_name:"Lightsail_20161128.CreateLoadBalancerTlsCertificate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_load_balancer_tls_certificate_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_load_balancer_tls_certificate_request) =
+    let input = Json_serializers.create_load_balancer_tls_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateLoadBalancerTlsCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_load_balancer_tls_certificate_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateRelationalDatabase = struct
@@ -1337,6 +1535,13 @@ module CreateRelationalDatabase = struct
     let input = Json_serializers.create_relational_database_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.CreateRelationalDatabase"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_relational_database_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_relational_database_request) =
+    let input = Json_serializers.create_relational_database_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateRelationalDatabase" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_relational_database_result_of_yojson
       ~error_deserializer
 end
@@ -1390,6 +1595,16 @@ module CreateRelationalDatabaseFromSnapshot = struct
       ~output_deserializer:
         Json_deserializers.create_relational_database_from_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_relational_database_from_snapshot_request) =
+    let input =
+      Json_serializers.create_relational_database_from_snapshot_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateRelationalDatabaseFromSnapshot" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.create_relational_database_from_snapshot_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateRelationalDatabaseSnapshot = struct
@@ -1438,6 +1653,13 @@ module CreateRelationalDatabaseSnapshot = struct
       ~shape_name:"Lightsail_20161128.CreateRelationalDatabaseSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_relational_database_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_relational_database_snapshot_request) =
+    let input = Json_serializers.create_relational_database_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.CreateRelationalDatabaseSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_relational_database_snapshot_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteAlarm = struct
@@ -1479,6 +1701,12 @@ module DeleteAlarm = struct
     let input = Json_serializers.delete_alarm_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteAlarm" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_alarm_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_alarm_request) =
+    let input = Json_serializers.delete_alarm_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.DeleteAlarm"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.delete_alarm_result_of_yojson
       ~error_deserializer
 end
 
@@ -1522,6 +1750,13 @@ module DeleteAutoSnapshot = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteAutoSnapshot" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_auto_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_auto_snapshot_request) =
+    let input = Json_serializers.delete_auto_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteAutoSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_auto_snapshot_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteBucket = struct
@@ -1560,6 +1795,12 @@ module DeleteBucket = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteBucket" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_bucket_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_bucket_request) =
+    let input = Json_serializers.delete_bucket_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.DeleteBucket"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_bucket_result_of_yojson ~error_deserializer
 end
 
 module DeleteBucketAccessKey = struct
@@ -1599,6 +1840,13 @@ module DeleteBucketAccessKey = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_bucket_access_key_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_bucket_access_key_request) =
+    let input = Json_serializers.delete_bucket_access_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteBucketAccessKey" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_bucket_access_key_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteCertificate = struct
@@ -1636,6 +1884,13 @@ module DeleteCertificate = struct
     let input = Json_serializers.delete_certificate_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteCertificate" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_certificate_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_certificate_request) =
+    let input = Json_serializers.delete_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_certificate_result_of_yojson
       ~error_deserializer
 end
 
@@ -1680,6 +1935,13 @@ module DeleteContactMethod = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_contact_method_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_contact_method_request) =
+    let input = Json_serializers.delete_contact_method_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteContactMethod" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_contact_method_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteContainerImage = struct
@@ -1719,6 +1981,13 @@ module DeleteContainerImage = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_container_image_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_container_image_request) =
+    let input = Json_serializers.delete_container_image_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteContainerImage" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_container_image_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteContainerService = struct
@@ -1756,6 +2025,13 @@ module DeleteContainerService = struct
     let input = Json_serializers.delete_container_service_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteContainerService"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_container_service_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_container_service_request) =
+    let input = Json_serializers.delete_container_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteContainerService" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_container_service_result_of_yojson
       ~error_deserializer
 end
@@ -1805,6 +2081,12 @@ module DeleteDisk = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteDisk" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_disk_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_disk_request) =
+    let input = Json_serializers.delete_disk_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.DeleteDisk"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.delete_disk_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteDiskSnapshot = struct
@@ -1852,6 +2134,13 @@ module DeleteDiskSnapshot = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteDiskSnapshot" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_disk_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_disk_snapshot_request) =
+    let input = Json_serializers.delete_disk_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteDiskSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_disk_snapshot_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteDistribution = struct
@@ -1889,6 +2178,13 @@ module DeleteDistribution = struct
     let input = Json_serializers.delete_distribution_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteDistribution" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_distribution_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_distribution_request) =
+    let input = Json_serializers.delete_distribution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteDistribution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_distribution_result_of_yojson
       ~error_deserializer
 end
 
@@ -1937,6 +2233,12 @@ module DeleteDomain = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteDomain" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_domain_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_domain_request) =
+    let input = Json_serializers.delete_domain_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.DeleteDomain"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_domain_result_of_yojson ~error_deserializer
 end
 
 module DeleteDomainEntry = struct
@@ -1983,6 +2285,13 @@ module DeleteDomainEntry = struct
     let input = Json_serializers.delete_domain_entry_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteDomainEntry" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_domain_entry_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_domain_entry_request) =
+    let input = Json_serializers.delete_domain_entry_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteDomainEntry" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_domain_entry_result_of_yojson
       ~error_deserializer
 end
 
@@ -2031,6 +2340,12 @@ module DeleteInstance = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteInstance" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_instance_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_instance_request) =
+    let input = Json_serializers.delete_instance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteInstance" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_instance_result_of_yojson ~error_deserializer
 end
 
 module DeleteInstanceSnapshot = struct
@@ -2077,6 +2392,13 @@ module DeleteInstanceSnapshot = struct
     let input = Json_serializers.delete_instance_snapshot_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteInstanceSnapshot"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_instance_snapshot_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_instance_snapshot_request) =
+    let input = Json_serializers.delete_instance_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteInstanceSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_instance_snapshot_result_of_yojson
       ~error_deserializer
 end
@@ -2126,6 +2448,12 @@ module DeleteKeyPair = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteKeyPair" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_key_pair_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_key_pair_request) =
+    let input = Json_serializers.delete_key_pair_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.DeleteKeyPair"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_key_pair_result_of_yojson ~error_deserializer
 end
 
 module DeleteKnownHostKeys = struct
@@ -2172,6 +2500,13 @@ module DeleteKnownHostKeys = struct
     let input = Json_serializers.delete_known_host_keys_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteKnownHostKeys"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_known_host_keys_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_known_host_keys_request) =
+    let input = Json_serializers.delete_known_host_keys_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteKnownHostKeys" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_known_host_keys_result_of_yojson
       ~error_deserializer
 end
@@ -2221,6 +2556,13 @@ module DeleteLoadBalancer = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DeleteLoadBalancer" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_load_balancer_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_load_balancer_request) =
+    let input = Json_serializers.delete_load_balancer_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteLoadBalancer" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_load_balancer_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteLoadBalancerTlsCertificate = struct
@@ -2266,6 +2608,13 @@ module DeleteLoadBalancerTlsCertificate = struct
   let request context (request : delete_load_balancer_tls_certificate_request) =
     let input = Json_serializers.delete_load_balancer_tls_certificate_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.DeleteLoadBalancerTlsCertificate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_load_balancer_tls_certificate_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_load_balancer_tls_certificate_request) =
+    let input = Json_serializers.delete_load_balancer_tls_certificate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.DeleteLoadBalancerTlsCertificate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_load_balancer_tls_certificate_result_of_yojson
       ~error_deserializer
@@ -2317,6 +2666,13 @@ module DeleteRelationalDatabase = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_relational_database_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_relational_database_request) =
+    let input = Json_serializers.delete_relational_database_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteRelationalDatabase" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_relational_database_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteRelationalDatabaseSnapshot = struct
@@ -2365,6 +2721,13 @@ module DeleteRelationalDatabaseSnapshot = struct
       ~shape_name:"Lightsail_20161128.DeleteRelationalDatabaseSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_relational_database_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_relational_database_snapshot_request) =
+    let input = Json_serializers.delete_relational_database_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DeleteRelationalDatabaseSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_relational_database_snapshot_result_of_yojson
+      ~error_deserializer
 end
 
 module DetachCertificateFromDistribution = struct
@@ -2401,6 +2764,13 @@ module DetachCertificateFromDistribution = struct
   let request context (request : detach_certificate_from_distribution_request) =
     let input = Json_serializers.detach_certificate_from_distribution_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.DetachCertificateFromDistribution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.detach_certificate_from_distribution_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : detach_certificate_from_distribution_request) =
+    let input = Json_serializers.detach_certificate_from_distribution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.DetachCertificateFromDistribution" ~service ~context ~input
       ~output_deserializer:Json_deserializers.detach_certificate_from_distribution_result_of_yojson
       ~error_deserializer
@@ -2451,6 +2821,12 @@ module DetachDisk = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DetachDisk" ~service
       ~context ~input ~output_deserializer:Json_deserializers.detach_disk_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : detach_disk_request) =
+    let input = Json_serializers.detach_disk_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.DetachDisk"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.detach_disk_result_of_yojson
+      ~error_deserializer
 end
 
 module DetachInstancesFromLoadBalancer = struct
@@ -2496,6 +2872,13 @@ module DetachInstancesFromLoadBalancer = struct
   let request context (request : detach_instances_from_load_balancer_request) =
     let input = Json_serializers.detach_instances_from_load_balancer_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.DetachInstancesFromLoadBalancer" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.detach_instances_from_load_balancer_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : detach_instances_from_load_balancer_request) =
+    let input = Json_serializers.detach_instances_from_load_balancer_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.DetachInstancesFromLoadBalancer" ~service ~context ~input
       ~output_deserializer:Json_deserializers.detach_instances_from_load_balancer_result_of_yojson
       ~error_deserializer
@@ -2546,6 +2929,12 @@ module DetachStaticIp = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DetachStaticIp" ~service
       ~context ~input ~output_deserializer:Json_deserializers.detach_static_ip_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : detach_static_ip_request) =
+    let input = Json_serializers.detach_static_ip_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DetachStaticIp" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.detach_static_ip_result_of_yojson ~error_deserializer
 end
 
 module DisableAddOn = struct
@@ -2588,6 +2977,12 @@ module DisableAddOn = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.DisableAddOn" ~service
       ~context ~input ~output_deserializer:Json_deserializers.disable_add_on_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disable_add_on_request) =
+    let input = Json_serializers.disable_add_on_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.DisableAddOn"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disable_add_on_result_of_yojson ~error_deserializer
 end
 
 module DownloadDefaultKeyPair = struct
@@ -2636,6 +3031,13 @@ module DownloadDefaultKeyPair = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.download_default_key_pair_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : download_default_key_pair_request) =
+    let input = Json_serializers.download_default_key_pair_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.DownloadDefaultKeyPair" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.download_default_key_pair_result_of_yojson
+      ~error_deserializer
 end
 
 module EnableAddOn = struct
@@ -2678,6 +3080,12 @@ module EnableAddOn = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.EnableAddOn" ~service
       ~context ~input ~output_deserializer:Json_deserializers.enable_add_on_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : enable_add_on_request) =
+    let input = Json_serializers.enable_add_on_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.EnableAddOn"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enable_add_on_result_of_yojson ~error_deserializer
 end
 
 module ExportSnapshot = struct
@@ -2725,6 +3133,12 @@ module ExportSnapshot = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.ExportSnapshot" ~service
       ~context ~input ~output_deserializer:Json_deserializers.export_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : export_snapshot_request) =
+    let input = Json_serializers.export_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.ExportSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.export_snapshot_result_of_yojson ~error_deserializer
 end
 
 module GetActiveNames = struct
@@ -2772,6 +3186,12 @@ module GetActiveNames = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetActiveNames" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_active_names_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_active_names_request) =
+    let input = Json_serializers.get_active_names_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetActiveNames" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_active_names_result_of_yojson ~error_deserializer
 end
 
 module GetAlarms = struct
@@ -2813,6 +3233,12 @@ module GetAlarms = struct
     let input = Json_serializers.get_alarms_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetAlarms" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_alarms_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_alarms_request) =
+    let input = Json_serializers.get_alarms_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetAlarms"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_alarms_result_of_yojson
+      ~error_deserializer
 end
 
 module GetAutoSnapshots = struct
@@ -2854,6 +3280,13 @@ module GetAutoSnapshots = struct
     let input = Json_serializers.get_auto_snapshots_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetAutoSnapshots" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_auto_snapshots_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_auto_snapshots_request) =
+    let input = Json_serializers.get_auto_snapshots_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetAutoSnapshots" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_auto_snapshots_result_of_yojson
       ~error_deserializer
 end
 
@@ -2902,6 +3335,12 @@ module GetBlueprints = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetBlueprints" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_blueprints_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_blueprints_request) =
+    let input = Json_serializers.get_blueprints_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetBlueprints"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_blueprints_result_of_yojson ~error_deserializer
 end
 
 module GetBucketAccessKeys = struct
@@ -2941,6 +3380,13 @@ module GetBucketAccessKeys = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_bucket_access_keys_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_bucket_access_keys_request) =
+    let input = Json_serializers.get_bucket_access_keys_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetBucketAccessKeys" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_bucket_access_keys_result_of_yojson
+      ~error_deserializer
 end
 
 module GetBucketBundles = struct
@@ -2975,6 +3421,13 @@ module GetBucketBundles = struct
     let input = Json_serializers.get_bucket_bundles_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetBucketBundles" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_bucket_bundles_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_bucket_bundles_request) =
+    let input = Json_serializers.get_bucket_bundles_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetBucketBundles" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_bucket_bundles_result_of_yojson
       ~error_deserializer
 end
 
@@ -3015,6 +3468,13 @@ module GetBucketMetricData = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_bucket_metric_data_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_bucket_metric_data_request) =
+    let input = Json_serializers.get_bucket_metric_data_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetBucketMetricData" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_bucket_metric_data_result_of_yojson
+      ~error_deserializer
 end
 
 module GetBuckets = struct
@@ -3052,6 +3512,12 @@ module GetBuckets = struct
     let input = Json_serializers.get_buckets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetBuckets" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_buckets_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_buckets_request) =
+    let input = Json_serializers.get_buckets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetBuckets"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_buckets_result_of_yojson
       ~error_deserializer
 end
 
@@ -3100,6 +3566,12 @@ module GetBundles = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetBundles" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_bundles_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_bundles_request) =
+    let input = Json_serializers.get_bundles_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetBundles"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_bundles_result_of_yojson
+      ~error_deserializer
 end
 
 module GetCertificates = struct
@@ -3138,6 +3610,12 @@ module GetCertificates = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetCertificates" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_certificates_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_certificates_request) =
+    let input = Json_serializers.get_certificates_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetCertificates" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_certificates_result_of_yojson ~error_deserializer
 end
 
 module GetCloudFormationStackRecords = struct
@@ -3186,6 +3664,13 @@ module GetCloudFormationStackRecords = struct
       ~shape_name:"Lightsail_20161128.GetCloudFormationStackRecords" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_cloud_formation_stack_records_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_cloud_formation_stack_records_request) =
+    let input = Json_serializers.get_cloud_formation_stack_records_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetCloudFormationStackRecords" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_cloud_formation_stack_records_result_of_yojson
+      ~error_deserializer
 end
 
 module GetContactMethods = struct
@@ -3228,6 +3713,13 @@ module GetContactMethods = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetContactMethods" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_contact_methods_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_contact_methods_request) =
+    let input = Json_serializers.get_contact_methods_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetContactMethods" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_contact_methods_result_of_yojson
+      ~error_deserializer
 end
 
 module GetContainerAPIMetadata = struct
@@ -3259,6 +3751,13 @@ module GetContainerAPIMetadata = struct
     let input = Json_serializers.get_container_api_metadata_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetContainerAPIMetadata"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_container_api_metadata_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_container_api_metadata_request) =
+    let input = Json_serializers.get_container_api_metadata_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetContainerAPIMetadata" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_container_api_metadata_result_of_yojson
       ~error_deserializer
 end
@@ -3299,6 +3798,13 @@ module GetContainerImages = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetContainerImages" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_container_images_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_container_images_request) =
+    let input = Json_serializers.get_container_images_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetContainerImages" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_container_images_result_of_yojson
+      ~error_deserializer
 end
 
 module GetContainerLog = struct
@@ -3337,6 +3843,12 @@ module GetContainerLog = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetContainerLog" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_container_log_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_container_log_request) =
+    let input = Json_serializers.get_container_log_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetContainerLog" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_container_log_result_of_yojson ~error_deserializer
 end
 
 module GetContainerServiceDeployments = struct
@@ -3373,6 +3885,13 @@ module GetContainerServiceDeployments = struct
   let request context (request : get_container_service_deployments_request) =
     let input = Json_serializers.get_container_service_deployments_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.GetContainerServiceDeployments" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_container_service_deployments_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_container_service_deployments_request) =
+    let input = Json_serializers.get_container_service_deployments_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.GetContainerServiceDeployments" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_container_service_deployments_result_of_yojson
       ~error_deserializer
@@ -3415,6 +3934,13 @@ module GetContainerServiceMetricData = struct
       ~shape_name:"Lightsail_20161128.GetContainerServiceMetricData" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_container_service_metric_data_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_container_service_metric_data_request) =
+    let input = Json_serializers.get_container_service_metric_data_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetContainerServiceMetricData" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_container_service_metric_data_result_of_yojson
+      ~error_deserializer
 end
 
 module GetContainerServicePowers = struct
@@ -3452,6 +3978,13 @@ module GetContainerServicePowers = struct
     let input = Json_serializers.get_container_service_powers_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetContainerServicePowers"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_container_service_powers_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_container_service_powers_request) =
+    let input = Json_serializers.get_container_service_powers_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetContainerServicePowers" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_container_service_powers_result_of_yojson
       ~error_deserializer
 end
@@ -3493,6 +4026,13 @@ module GetContainerServices = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.container_services_list_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_container_services_request) =
+    let input = Json_serializers.get_container_services_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetContainerServices" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.container_services_list_result_of_yojson
+      ~error_deserializer
 end
 
 module GetCostEstimate = struct
@@ -3531,6 +4071,12 @@ module GetCostEstimate = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetCostEstimate" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_cost_estimate_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_cost_estimate_request) =
+    let input = Json_serializers.get_cost_estimate_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetCostEstimate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_cost_estimate_result_of_yojson ~error_deserializer
 end
 
 module GetDisk = struct
@@ -3577,6 +4123,12 @@ module GetDisk = struct
     let input = Json_serializers.get_disk_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetDisk" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_disk_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_disk_request) =
+    let input = Json_serializers.get_disk_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetDisk"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_disk_result_of_yojson
+      ~error_deserializer
 end
 
 module GetDisks = struct
@@ -3623,6 +4175,12 @@ module GetDisks = struct
     let input = Json_serializers.get_disks_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetDisks" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_disks_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_disks_request) =
+    let input = Json_serializers.get_disks_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetDisks"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_disks_result_of_yojson
+      ~error_deserializer
 end
 
 module GetDiskSnapshot = struct
@@ -3670,6 +4228,12 @@ module GetDiskSnapshot = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetDiskSnapshot" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_disk_snapshot_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_disk_snapshot_request) =
+    let input = Json_serializers.get_disk_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetDiskSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_disk_snapshot_result_of_yojson ~error_deserializer
 end
 
 module GetDiskSnapshots = struct
@@ -3717,6 +4281,13 @@ module GetDiskSnapshots = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetDiskSnapshots" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_disk_snapshots_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_disk_snapshots_request) =
+    let input = Json_serializers.get_disk_snapshots_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetDiskSnapshots" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_disk_snapshots_result_of_yojson
+      ~error_deserializer
 end
 
 module GetDistributionBundles = struct
@@ -3756,6 +4327,13 @@ module GetDistributionBundles = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_distribution_bundles_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_distribution_bundles_request) =
+    let input = Json_serializers.get_distribution_bundles_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetDistributionBundles" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_distribution_bundles_result_of_yojson
+      ~error_deserializer
 end
 
 module GetDistributionLatestCacheReset = struct
@@ -3792,6 +4370,13 @@ module GetDistributionLatestCacheReset = struct
   let request context (request : get_distribution_latest_cache_reset_request) =
     let input = Json_serializers.get_distribution_latest_cache_reset_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.GetDistributionLatestCacheReset" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_distribution_latest_cache_reset_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_distribution_latest_cache_reset_request) =
+    let input = Json_serializers.get_distribution_latest_cache_reset_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.GetDistributionLatestCacheReset" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_distribution_latest_cache_reset_result_of_yojson
       ~error_deserializer
@@ -3834,6 +4419,13 @@ module GetDistributionMetricData = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_distribution_metric_data_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_distribution_metric_data_request) =
+    let input = Json_serializers.get_distribution_metric_data_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetDistributionMetricData" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_distribution_metric_data_result_of_yojson
+      ~error_deserializer
 end
 
 module GetDistributions = struct
@@ -3872,6 +4464,12 @@ module GetDistributions = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetDistributions" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_distributions_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_distributions_request) =
+    let input = Json_serializers.get_distributions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetDistributions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_distributions_result_of_yojson ~error_deserializer
 end
 
 module GetDomain = struct
@@ -3918,6 +4516,12 @@ module GetDomain = struct
     let input = Json_serializers.get_domain_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetDomain" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_domain_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_domain_request) =
+    let input = Json_serializers.get_domain_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetDomain"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_domain_result_of_yojson
+      ~error_deserializer
 end
 
 module GetDomains = struct
@@ -3964,6 +4568,12 @@ module GetDomains = struct
     let input = Json_serializers.get_domains_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetDomains" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_domains_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_domains_request) =
+    let input = Json_serializers.get_domains_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetDomains"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_domains_result_of_yojson
       ~error_deserializer
 end
 
@@ -4013,6 +4623,13 @@ module GetExportSnapshotRecords = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_export_snapshot_records_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_export_snapshot_records_request) =
+    let input = Json_serializers.get_export_snapshot_records_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetExportSnapshotRecords" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_export_snapshot_records_result_of_yojson
+      ~error_deserializer
 end
 
 module GetInstance = struct
@@ -4060,6 +4677,12 @@ module GetInstance = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetInstance" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_instance_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_instance_request) =
+    let input = Json_serializers.get_instance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetInstance"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_instance_result_of_yojson
+      ~error_deserializer
 end
 
 module GetInstanceAccessDetails = struct
@@ -4106,6 +4729,13 @@ module GetInstanceAccessDetails = struct
     let input = Json_serializers.get_instance_access_details_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetInstanceAccessDetails"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_instance_access_details_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_instance_access_details_request) =
+    let input = Json_serializers.get_instance_access_details_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetInstanceAccessDetails" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_instance_access_details_result_of_yojson
       ~error_deserializer
 end
@@ -4156,6 +4786,13 @@ module GetInstanceMetricData = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_instance_metric_data_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_instance_metric_data_request) =
+    let input = Json_serializers.get_instance_metric_data_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetInstanceMetricData" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_instance_metric_data_result_of_yojson
+      ~error_deserializer
 end
 
 module GetInstancePortStates = struct
@@ -4202,6 +4839,13 @@ module GetInstancePortStates = struct
     let input = Json_serializers.get_instance_port_states_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetInstancePortStates"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_instance_port_states_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_instance_port_states_request) =
+    let input = Json_serializers.get_instance_port_states_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetInstancePortStates" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_instance_port_states_result_of_yojson
       ~error_deserializer
 end
@@ -4251,6 +4895,12 @@ module GetInstances = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetInstances" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_instances_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_instances_request) =
+    let input = Json_serializers.get_instances_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetInstances"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_instances_result_of_yojson ~error_deserializer
 end
 
 module GetInstanceSnapshot = struct
@@ -4297,6 +4947,13 @@ module GetInstanceSnapshot = struct
     let input = Json_serializers.get_instance_snapshot_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetInstanceSnapshot"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_instance_snapshot_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_instance_snapshot_request) =
+    let input = Json_serializers.get_instance_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetInstanceSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_instance_snapshot_result_of_yojson
       ~error_deserializer
 end
@@ -4347,6 +5004,13 @@ module GetInstanceSnapshots = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_instance_snapshots_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_instance_snapshots_request) =
+    let input = Json_serializers.get_instance_snapshots_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetInstanceSnapshots" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_instance_snapshots_result_of_yojson
+      ~error_deserializer
 end
 
 module GetInstanceState = struct
@@ -4393,6 +5057,13 @@ module GetInstanceState = struct
     let input = Json_serializers.get_instance_state_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetInstanceState" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_instance_state_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_instance_state_request) =
+    let input = Json_serializers.get_instance_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetInstanceState" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_instance_state_result_of_yojson
       ~error_deserializer
 end
 
@@ -4441,6 +5112,12 @@ module GetKeyPair = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetKeyPair" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_key_pair_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_key_pair_request) =
+    let input = Json_serializers.get_key_pair_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetKeyPair"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_key_pair_result_of_yojson
+      ~error_deserializer
 end
 
 module GetKeyPairs = struct
@@ -4488,6 +5165,12 @@ module GetKeyPairs = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetKeyPairs" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_key_pairs_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_key_pairs_request) =
+    let input = Json_serializers.get_key_pairs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetKeyPairs"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_key_pairs_result_of_yojson ~error_deserializer
 end
 
 module GetLoadBalancer = struct
@@ -4535,6 +5218,12 @@ module GetLoadBalancer = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetLoadBalancer" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_load_balancer_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_load_balancer_request) =
+    let input = Json_serializers.get_load_balancer_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetLoadBalancer" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_load_balancer_result_of_yojson ~error_deserializer
 end
 
 module GetLoadBalancerMetricData = struct
@@ -4581,6 +5270,13 @@ module GetLoadBalancerMetricData = struct
     let input = Json_serializers.get_load_balancer_metric_data_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetLoadBalancerMetricData"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_load_balancer_metric_data_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_load_balancer_metric_data_request) =
+    let input = Json_serializers.get_load_balancer_metric_data_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetLoadBalancerMetricData" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_load_balancer_metric_data_result_of_yojson
       ~error_deserializer
 end
@@ -4630,6 +5326,13 @@ module GetLoadBalancers = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetLoadBalancers" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_load_balancers_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_load_balancers_request) =
+    let input = Json_serializers.get_load_balancers_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetLoadBalancers" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_load_balancers_result_of_yojson
+      ~error_deserializer
 end
 
 module GetLoadBalancerTlsCertificates = struct
@@ -4678,6 +5381,13 @@ module GetLoadBalancerTlsCertificates = struct
       ~shape_name:"Lightsail_20161128.GetLoadBalancerTlsCertificates" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_load_balancer_tls_certificates_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_load_balancer_tls_certificates_request) =
+    let input = Json_serializers.get_load_balancer_tls_certificates_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetLoadBalancerTlsCertificates" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_load_balancer_tls_certificates_result_of_yojson
+      ~error_deserializer
 end
 
 module GetLoadBalancerTlsPolicies = struct
@@ -4717,6 +5427,13 @@ module GetLoadBalancerTlsPolicies = struct
     let input = Json_serializers.get_load_balancer_tls_policies_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetLoadBalancerTlsPolicies"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_load_balancer_tls_policies_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_load_balancer_tls_policies_request) =
+    let input = Json_serializers.get_load_balancer_tls_policies_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetLoadBalancerTlsPolicies" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_load_balancer_tls_policies_result_of_yojson
       ~error_deserializer
 end
@@ -4766,6 +5483,12 @@ module GetOperation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetOperation" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_operation_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_operation_request) =
+    let input = Json_serializers.get_operation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetOperation"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_operation_result_of_yojson ~error_deserializer
 end
 
 module GetOperations = struct
@@ -4813,6 +5536,12 @@ module GetOperations = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetOperations" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_operations_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_operations_request) =
+    let input = Json_serializers.get_operations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetOperations"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_operations_result_of_yojson ~error_deserializer
 end
 
 module GetOperationsForResource = struct
@@ -4859,6 +5588,13 @@ module GetOperationsForResource = struct
     let input = Json_serializers.get_operations_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetOperationsForResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_operations_for_resource_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_operations_for_resource_request) =
+    let input = Json_serializers.get_operations_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetOperationsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_operations_for_resource_result_of_yojson
       ~error_deserializer
 end
@@ -4908,6 +5644,12 @@ module GetRegions = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetRegions" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_regions_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_regions_request) =
+    let input = Json_serializers.get_regions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetRegions"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_regions_result_of_yojson
+      ~error_deserializer
 end
 
 module GetRelationalDatabase = struct
@@ -4956,6 +5698,13 @@ module GetRelationalDatabase = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_request) =
+    let input = Json_serializers.get_relational_database_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabase" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_result_of_yojson
+      ~error_deserializer
 end
 
 module GetRelationalDatabaseBlueprints = struct
@@ -5001,6 +5750,13 @@ module GetRelationalDatabaseBlueprints = struct
   let request context (request : get_relational_database_blueprints_request) =
     let input = Json_serializers.get_relational_database_blueprints_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseBlueprints" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_blueprints_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_blueprints_request) =
+    let input = Json_serializers.get_relational_database_blueprints_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.GetRelationalDatabaseBlueprints" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_blueprints_result_of_yojson
       ~error_deserializer
@@ -5052,6 +5808,13 @@ module GetRelationalDatabaseBundles = struct
       ~shape_name:"Lightsail_20161128.GetRelationalDatabaseBundles" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_bundles_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_bundles_request) =
+    let input = Json_serializers.get_relational_database_bundles_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseBundles" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_bundles_result_of_yojson
+      ~error_deserializer
 end
 
 module GetRelationalDatabaseEvents = struct
@@ -5098,6 +5861,13 @@ module GetRelationalDatabaseEvents = struct
     let input = Json_serializers.get_relational_database_events_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetRelationalDatabaseEvents"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_events_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_events_request) =
+    let input = Json_serializers.get_relational_database_events_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseEvents" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_events_result_of_yojson
       ~error_deserializer
 end
@@ -5148,6 +5918,13 @@ module GetRelationalDatabaseLogEvents = struct
       ~shape_name:"Lightsail_20161128.GetRelationalDatabaseLogEvents" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_log_events_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_log_events_request) =
+    let input = Json_serializers.get_relational_database_log_events_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseLogEvents" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_log_events_result_of_yojson
+      ~error_deserializer
 end
 
 module GetRelationalDatabaseLogStreams = struct
@@ -5193,6 +5970,13 @@ module GetRelationalDatabaseLogStreams = struct
   let request context (request : get_relational_database_log_streams_request) =
     let input = Json_serializers.get_relational_database_log_streams_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseLogStreams" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_log_streams_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_log_streams_request) =
+    let input = Json_serializers.get_relational_database_log_streams_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.GetRelationalDatabaseLogStreams" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_log_streams_result_of_yojson
       ~error_deserializer
@@ -5248,6 +6032,18 @@ module GetRelationalDatabaseMasterUserPassword = struct
       ~output_deserializer:
         Json_deserializers.get_relational_database_master_user_password_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_master_user_password_request)
+      =
+    let input =
+      Json_serializers.get_relational_database_master_user_password_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseMasterUserPassword" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.get_relational_database_master_user_password_result_of_yojson
+      ~error_deserializer
 end
 
 module GetRelationalDatabaseMetricData = struct
@@ -5293,6 +6089,13 @@ module GetRelationalDatabaseMetricData = struct
   let request context (request : get_relational_database_metric_data_request) =
     let input = Json_serializers.get_relational_database_metric_data_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseMetricData" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_metric_data_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_metric_data_request) =
+    let input = Json_serializers.get_relational_database_metric_data_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.GetRelationalDatabaseMetricData" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_metric_data_result_of_yojson
       ~error_deserializer
@@ -5344,6 +6147,13 @@ module GetRelationalDatabaseParameters = struct
       ~shape_name:"Lightsail_20161128.GetRelationalDatabaseParameters" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_parameters_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_parameters_request) =
+    let input = Json_serializers.get_relational_database_parameters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseParameters" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_parameters_result_of_yojson
+      ~error_deserializer
 end
 
 module GetRelationalDatabases = struct
@@ -5392,6 +6202,13 @@ module GetRelationalDatabases = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_databases_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_databases_request) =
+    let input = Json_serializers.get_relational_databases_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabases" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_databases_result_of_yojson
+      ~error_deserializer
 end
 
 module GetRelationalDatabaseSnapshot = struct
@@ -5437,6 +6254,13 @@ module GetRelationalDatabaseSnapshot = struct
   let request context (request : get_relational_database_snapshot_request) =
     let input = Json_serializers.get_relational_database_snapshot_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseSnapshot" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_snapshot_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_snapshot_request) =
+    let input = Json_serializers.get_relational_database_snapshot_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.GetRelationalDatabaseSnapshot" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_snapshot_result_of_yojson
       ~error_deserializer
@@ -5488,6 +6312,13 @@ module GetRelationalDatabaseSnapshots = struct
       ~shape_name:"Lightsail_20161128.GetRelationalDatabaseSnapshots" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_relational_database_snapshots_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_relational_database_snapshots_request) =
+    let input = Json_serializers.get_relational_database_snapshots_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetRelationalDatabaseSnapshots" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_relational_database_snapshots_result_of_yojson
+      ~error_deserializer
 end
 
 module GetSetupHistory = struct
@@ -5526,6 +6357,12 @@ module GetSetupHistory = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetSetupHistory" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_setup_history_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_setup_history_request) =
+    let input = Json_serializers.get_setup_history_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.GetSetupHistory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_setup_history_result_of_yojson ~error_deserializer
 end
 
 module GetStaticIp = struct
@@ -5573,6 +6410,12 @@ module GetStaticIp = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetStaticIp" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_static_ip_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_static_ip_request) =
+    let input = Json_serializers.get_static_ip_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetStaticIp"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_static_ip_result_of_yojson ~error_deserializer
 end
 
 module GetStaticIps = struct
@@ -5620,6 +6463,12 @@ module GetStaticIps = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.GetStaticIps" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_static_ips_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_static_ips_request) =
+    let input = Json_serializers.get_static_ips_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.GetStaticIps"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_static_ips_result_of_yojson ~error_deserializer
 end
 
 module ImportKeyPair = struct
@@ -5667,6 +6516,12 @@ module ImportKeyPair = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.ImportKeyPair" ~service
       ~context ~input ~output_deserializer:Json_deserializers.import_key_pair_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : import_key_pair_request) =
+    let input = Json_serializers.import_key_pair_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.ImportKeyPair"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.import_key_pair_result_of_yojson ~error_deserializer
 end
 
 module IsVpcPeered = struct
@@ -5714,6 +6569,12 @@ module IsVpcPeered = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.IsVpcPeered" ~service
       ~context ~input ~output_deserializer:Json_deserializers.is_vpc_peered_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : is_vpc_peered_request) =
+    let input = Json_serializers.is_vpc_peered_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.IsVpcPeered"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.is_vpc_peered_result_of_yojson ~error_deserializer
 end
 
 module OpenInstancePublicPorts = struct
@@ -5762,6 +6623,13 @@ module OpenInstancePublicPorts = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.open_instance_public_ports_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : open_instance_public_ports_request) =
+    let input = Json_serializers.open_instance_public_ports_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.OpenInstancePublicPorts" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.open_instance_public_ports_result_of_yojson
+      ~error_deserializer
 end
 
 module PeerVpc = struct
@@ -5808,6 +6676,12 @@ module PeerVpc = struct
     let input = Json_serializers.peer_vpc_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.PeerVpc" ~service ~context
       ~input ~output_deserializer:Json_deserializers.peer_vpc_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : peer_vpc_request) =
+    let input = Json_serializers.peer_vpc_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.PeerVpc"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.peer_vpc_result_of_yojson
+      ~error_deserializer
 end
 
 module PutAlarm = struct
@@ -5849,6 +6723,12 @@ module PutAlarm = struct
     let input = Json_serializers.put_alarm_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.PutAlarm" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_alarm_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : put_alarm_request) =
+    let input = Json_serializers.put_alarm_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.PutAlarm"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.put_alarm_result_of_yojson
+      ~error_deserializer
 end
 
 module PutInstancePublicPorts = struct
@@ -5895,6 +6775,13 @@ module PutInstancePublicPorts = struct
     let input = Json_serializers.put_instance_public_ports_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.PutInstancePublicPorts"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_instance_public_ports_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_instance_public_ports_request) =
+    let input = Json_serializers.put_instance_public_ports_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.PutInstancePublicPorts" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_instance_public_ports_result_of_yojson
       ~error_deserializer
 end
@@ -5944,6 +6831,12 @@ module RebootInstance = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.RebootInstance" ~service
       ~context ~input ~output_deserializer:Json_deserializers.reboot_instance_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : reboot_instance_request) =
+    let input = Json_serializers.reboot_instance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.RebootInstance" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.reboot_instance_result_of_yojson ~error_deserializer
 end
 
 module RebootRelationalDatabase = struct
@@ -5992,6 +6885,13 @@ module RebootRelationalDatabase = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.reboot_relational_database_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : reboot_relational_database_request) =
+    let input = Json_serializers.reboot_relational_database_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.RebootRelationalDatabase" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.reboot_relational_database_result_of_yojson
+      ~error_deserializer
 end
 
 module RegisterContainerImage = struct
@@ -6029,6 +6929,13 @@ module RegisterContainerImage = struct
     let input = Json_serializers.register_container_image_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.RegisterContainerImage"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.register_container_image_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : register_container_image_request) =
+    let input = Json_serializers.register_container_image_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.RegisterContainerImage" ~service ~context ~input
       ~output_deserializer:Json_deserializers.register_container_image_result_of_yojson
       ~error_deserializer
 end
@@ -6078,6 +6985,12 @@ module ReleaseStaticIp = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.ReleaseStaticIp" ~service
       ~context ~input ~output_deserializer:Json_deserializers.release_static_ip_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : release_static_ip_request) =
+    let input = Json_serializers.release_static_ip_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.ReleaseStaticIp" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.release_static_ip_result_of_yojson ~error_deserializer
 end
 
 module ResetDistributionCache = struct
@@ -6115,6 +7028,13 @@ module ResetDistributionCache = struct
     let input = Json_serializers.reset_distribution_cache_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.ResetDistributionCache"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.reset_distribution_cache_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : reset_distribution_cache_request) =
+    let input = Json_serializers.reset_distribution_cache_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.ResetDistributionCache" ~service ~context ~input
       ~output_deserializer:Json_deserializers.reset_distribution_cache_result_of_yojson
       ~error_deserializer
 end
@@ -6157,6 +7077,13 @@ module SendContactMethodVerification = struct
   let request context (request : send_contact_method_verification_request) =
     let input = Json_serializers.send_contact_method_verification_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.SendContactMethodVerification" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.send_contact_method_verification_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : send_contact_method_verification_request) =
+    let input = Json_serializers.send_contact_method_verification_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.SendContactMethodVerification" ~service ~context ~input
       ~output_deserializer:Json_deserializers.send_contact_method_verification_result_of_yojson
       ~error_deserializer
@@ -6207,6 +7134,13 @@ module SetIpAddressType = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.SetIpAddressType" ~service
       ~context ~input ~output_deserializer:Json_deserializers.set_ip_address_type_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : set_ip_address_type_request) =
+    let input = Json_serializers.set_ip_address_type_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.SetIpAddressType" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.set_ip_address_type_result_of_yojson
+      ~error_deserializer
 end
 
 module SetResourceAccessForBucket = struct
@@ -6244,6 +7178,13 @@ module SetResourceAccessForBucket = struct
     let input = Json_serializers.set_resource_access_for_bucket_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.SetResourceAccessForBucket"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.set_resource_access_for_bucket_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : set_resource_access_for_bucket_request) =
+    let input = Json_serializers.set_resource_access_for_bucket_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.SetResourceAccessForBucket" ~service ~context ~input
       ~output_deserializer:Json_deserializers.set_resource_access_for_bucket_result_of_yojson
       ~error_deserializer
 end
@@ -6284,6 +7225,13 @@ module SetupInstanceHttps = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.SetupInstanceHttps" ~service
       ~context ~input ~output_deserializer:Json_deserializers.setup_instance_https_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : setup_instance_https_request) =
+    let input = Json_serializers.setup_instance_https_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.SetupInstanceHttps" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.setup_instance_https_result_of_yojson
+      ~error_deserializer
 end
 
 module StartGUISession = struct
@@ -6322,6 +7270,12 @@ module StartGUISession = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.StartGUISession" ~service
       ~context ~input ~output_deserializer:Json_deserializers.start_gui_session_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_gui_session_request) =
+    let input = Json_serializers.start_gui_session_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.StartGUISession" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_gui_session_result_of_yojson ~error_deserializer
 end
 
 module StartInstance = struct
@@ -6369,6 +7323,12 @@ module StartInstance = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.StartInstance" ~service
       ~context ~input ~output_deserializer:Json_deserializers.start_instance_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_instance_request) =
+    let input = Json_serializers.start_instance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.StartInstance"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_instance_result_of_yojson ~error_deserializer
 end
 
 module StartRelationalDatabase = struct
@@ -6417,6 +7377,13 @@ module StartRelationalDatabase = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_relational_database_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_relational_database_request) =
+    let input = Json_serializers.start_relational_database_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.StartRelationalDatabase" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_relational_database_result_of_yojson
+      ~error_deserializer
 end
 
 module StopGUISession = struct
@@ -6455,6 +7422,12 @@ module StopGUISession = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.StopGUISession" ~service
       ~context ~input ~output_deserializer:Json_deserializers.stop_gui_session_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : stop_gui_session_request) =
+    let input = Json_serializers.stop_gui_session_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.StopGUISession" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_gui_session_result_of_yojson ~error_deserializer
 end
 
 module StopInstance = struct
@@ -6502,6 +7475,12 @@ module StopInstance = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.StopInstance" ~service
       ~context ~input ~output_deserializer:Json_deserializers.stop_instance_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : stop_instance_request) =
+    let input = Json_serializers.stop_instance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.StopInstance"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_instance_result_of_yojson ~error_deserializer
 end
 
 module StopRelationalDatabase = struct
@@ -6548,6 +7527,13 @@ module StopRelationalDatabase = struct
     let input = Json_serializers.stop_relational_database_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.StopRelationalDatabase"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_relational_database_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : stop_relational_database_request) =
+    let input = Json_serializers.stop_relational_database_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.StopRelationalDatabase" ~service ~context ~input
       ~output_deserializer:Json_deserializers.stop_relational_database_result_of_yojson
       ~error_deserializer
 end
@@ -6597,6 +7583,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.TagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.tag_resource_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.TagResource"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.tag_resource_result_of_yojson
+      ~error_deserializer
 end
 
 module TestAlarm = struct
@@ -6638,6 +7630,12 @@ module TestAlarm = struct
     let input = Json_serializers.test_alarm_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.TestAlarm" ~service ~context
       ~input ~output_deserializer:Json_deserializers.test_alarm_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : test_alarm_request) =
+    let input = Json_serializers.test_alarm_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.TestAlarm"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.test_alarm_result_of_yojson
+      ~error_deserializer
 end
 
 module UnpeerVpc = struct
@@ -6684,6 +7682,12 @@ module UnpeerVpc = struct
     let input = Json_serializers.unpeer_vpc_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.UnpeerVpc" ~service ~context
       ~input ~output_deserializer:Json_deserializers.unpeer_vpc_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : unpeer_vpc_request) =
+    let input = Json_serializers.unpeer_vpc_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.UnpeerVpc"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.unpeer_vpc_result_of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -6731,6 +7735,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_result_of_yojson ~error_deserializer
 end
 
 module UpdateBucket = struct
@@ -6769,6 +7779,12 @@ module UpdateBucket = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.UpdateBucket" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_bucket_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_bucket_request) =
+    let input = Json_serializers.update_bucket_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Lightsail_20161128.UpdateBucket"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_bucket_result_of_yojson ~error_deserializer
 end
 
 module UpdateBucketBundle = struct
@@ -6806,6 +7822,13 @@ module UpdateBucketBundle = struct
     let input = Json_serializers.update_bucket_bundle_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.UpdateBucketBundle" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_bucket_bundle_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_bucket_bundle_request) =
+    let input = Json_serializers.update_bucket_bundle_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.UpdateBucketBundle" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_bucket_bundle_result_of_yojson
       ~error_deserializer
 end
 
@@ -6846,6 +7869,13 @@ module UpdateContainerService = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_container_service_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_container_service_request) =
+    let input = Json_serializers.update_container_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.UpdateContainerService" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_container_service_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateDistribution = struct
@@ -6884,6 +7914,13 @@ module UpdateDistribution = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.UpdateDistribution" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_distribution_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_distribution_request) =
+    let input = Json_serializers.update_distribution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.UpdateDistribution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_distribution_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateDistributionBundle = struct
@@ -6921,6 +7958,13 @@ module UpdateDistributionBundle = struct
     let input = Json_serializers.update_distribution_bundle_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.UpdateDistributionBundle"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_distribution_bundle_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_distribution_bundle_request) =
+    let input = Json_serializers.update_distribution_bundle_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.UpdateDistributionBundle" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_distribution_bundle_result_of_yojson
       ~error_deserializer
 end
@@ -6970,6 +8014,13 @@ module UpdateDomainEntry = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Lightsail_20161128.UpdateDomainEntry" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_domain_entry_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_domain_entry_request) =
+    let input = Json_serializers.update_domain_entry_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.UpdateDomainEntry" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_domain_entry_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateInstanceMetadataOptions = struct
@@ -7015,6 +8066,13 @@ module UpdateInstanceMetadataOptions = struct
   let request context (request : update_instance_metadata_options_request) =
     let input = Json_serializers.update_instance_metadata_options_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.UpdateInstanceMetadataOptions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_instance_metadata_options_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_instance_metadata_options_request) =
+    let input = Json_serializers.update_instance_metadata_options_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.UpdateInstanceMetadataOptions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_instance_metadata_options_result_of_yojson
       ~error_deserializer
@@ -7066,6 +8124,13 @@ module UpdateLoadBalancerAttribute = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_load_balancer_attribute_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_load_balancer_attribute_request) =
+    let input = Json_serializers.update_load_balancer_attribute_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.UpdateLoadBalancerAttribute" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_load_balancer_attribute_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateRelationalDatabase = struct
@@ -7114,6 +8179,13 @@ module UpdateRelationalDatabase = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_relational_database_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_relational_database_request) =
+    let input = Json_serializers.update_relational_database_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Lightsail_20161128.UpdateRelationalDatabase" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_relational_database_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateRelationalDatabaseParameters = struct
@@ -7159,6 +8231,13 @@ module UpdateRelationalDatabaseParameters = struct
   let request context (request : update_relational_database_parameters_request) =
     let input = Json_serializers.update_relational_database_parameters_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Lightsail_20161128.UpdateRelationalDatabaseParameters" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_relational_database_parameters_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_relational_database_parameters_request) =
+    let input = Json_serializers.update_relational_database_parameters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Lightsail_20161128.UpdateRelationalDatabaseParameters" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_relational_database_parameters_result_of_yojson
       ~error_deserializer

--- a/sdks/lightsail/operations.mli
+++ b/sdks/lightsail/operations.mli
@@ -27,6 +27,21 @@ module AllocateStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    allocate_static_ip_request ->
+    ( allocate_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Allocates a static IP address.\n"]
 
@@ -45,6 +60,19 @@ module AttachCertificateToDistribution : sig
     'http_type Smaws_Lib.Context.t ->
     attach_certificate_to_distribution_request ->
     ( attach_certificate_to_distribution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_certificate_to_distribution_request ->
+    ( attach_certificate_to_distribution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -97,6 +125,21 @@ module AttachDisk : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_disk_request ->
+    ( attach_disk_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attaches a block storage disk to a running or stopped Lightsail instance and exposes it to the \
@@ -124,6 +167,21 @@ module AttachInstancesToLoadBalancer : sig
     'http_type Smaws_Lib.Context.t ->
     attach_instances_to_load_balancer_request ->
     ( attach_instances_to_load_balancer_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_instances_to_load_balancer_request ->
+    ( attach_instances_to_load_balancer_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -164,6 +222,21 @@ module AttachLoadBalancerTlsCertificate : sig
     'http_type Smaws_Lib.Context.t ->
     attach_load_balancer_tls_certificate_request ->
     ( attach_load_balancer_tls_certificate_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_load_balancer_tls_certificate_request ->
+    ( attach_load_balancer_tls_certificate_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -217,6 +290,21 @@ module AttachStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    attach_static_ip_request ->
+    ( attach_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Attaches a static IP address to a specific Amazon Lightsail instance.\n"]
 
@@ -237,6 +325,21 @@ module CloseInstancePublicPorts : sig
     'http_type Smaws_Lib.Context.t ->
     close_instance_public_ports_request ->
     ( close_instance_public_ports_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    close_instance_public_ports_request ->
+    ( close_instance_public_ports_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -283,6 +386,21 @@ module CopySnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    copy_snapshot_request ->
+    ( copy_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Copies a manual snapshot of an instance or disk as another manual snapshot, or copies an \
@@ -319,6 +437,18 @@ module CreateBucket : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_bucket_request ->
+    ( create_bucket_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an Amazon Lightsail bucket.\n\n\
@@ -344,6 +474,19 @@ module CreateBucketAccessKey : sig
     'http_type Smaws_Lib.Context.t ->
     create_bucket_access_key_request ->
     ( create_bucket_access_key_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_bucket_access_key_request ->
+    ( create_bucket_access_key_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -394,6 +537,19 @@ module CreateCertificate : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_certificate_request ->
+    ( create_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an SSL/TLS certificate for an Amazon Lightsail content delivery network (CDN) \
@@ -436,6 +592,21 @@ module CreateCloudFormationStack : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_cloud_formation_stack_request ->
+    ( create_cloud_formation_stack_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an AWS CloudFormation stack, which creates a new Amazon EC2 instance from an exported \
@@ -463,6 +634,20 @@ module CreateContactMethod : sig
     'http_type Smaws_Lib.Context.t ->
     create_contact_method_request ->
     ( create_contact_method_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_contact_method_request ->
+    ( create_contact_method_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -512,6 +697,19 @@ module CreateContainerService : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_container_service_request ->
+    ( create_container_service_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an Amazon Lightsail container service.\n\n\
@@ -536,6 +734,19 @@ module CreateContainerServiceDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     create_container_service_deployment_request ->
     ( create_container_service_deployment_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_container_service_deployment_request ->
+    ( create_container_service_deployment_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -575,6 +786,19 @@ module CreateContainerServiceRegistryLogin : sig
     'http_type Smaws_Lib.Context.t ->
     create_container_service_registry_login_request ->
     ( create_container_service_registry_login_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_container_service_registry_login_request ->
+    ( create_container_service_registry_login_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -634,6 +858,21 @@ module CreateDisk : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_disk_request ->
+    ( create_disk_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a block storage disk that can be attached to an Amazon Lightsail instance in the same \
@@ -661,6 +900,21 @@ module CreateDiskFromSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     create_disk_from_snapshot_request ->
     ( create_disk_from_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_disk_from_snapshot_request ->
+    ( create_disk_from_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -699,6 +953,21 @@ module CreateDiskSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     create_disk_snapshot_request ->
     ( create_disk_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_disk_snapshot_request ->
+    ( create_disk_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -759,6 +1028,19 @@ module CreateDistribution : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_distribution_request ->
+    ( create_distribution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an Amazon Lightsail content delivery network (CDN) distribution.\n\n\
@@ -786,6 +1068,21 @@ module CreateDomain : sig
     'http_type Smaws_Lib.Context.t ->
     create_domain_request ->
     ( create_domain_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_domain_request ->
+    ( create_domain_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -832,6 +1129,21 @@ module CreateDomainEntry : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_domain_entry_request ->
+    ( create_domain_entry_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates one of the following domain name system (DNS) records in a domain DNS zone: Address \
@@ -858,6 +1170,19 @@ module CreateGUISessionAccessDetails : sig
     'http_type Smaws_Lib.Context.t ->
     create_gui_session_access_details_request ->
     ( create_gui_session_access_details_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_gui_session_access_details_request ->
+    ( create_gui_session_access_details_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -902,6 +1227,21 @@ module CreateInstances : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_instances_request ->
+    ( create_instances_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates one or more Amazon Lightsail instances.\n\n\
@@ -928,6 +1268,21 @@ module CreateInstancesFromSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     create_instances_from_snapshot_request ->
     ( create_instances_from_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_instances_from_snapshot_request ->
+    ( create_instances_from_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -975,6 +1330,21 @@ module CreateInstanceSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_instance_snapshot_request ->
+    ( create_instance_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a snapshot of a specific virtual private server, or {i instance}. You can use a \
@@ -1002,6 +1372,21 @@ module CreateKeyPair : sig
     'http_type Smaws_Lib.Context.t ->
     create_key_pair_request ->
     ( create_key_pair_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_key_pair_request ->
+    ( create_key_pair_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -1043,6 +1428,21 @@ module CreateLoadBalancer : sig
     'http_type Smaws_Lib.Context.t ->
     create_load_balancer_request ->
     ( create_load_balancer_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_load_balancer_request ->
+    ( create_load_balancer_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -1096,6 +1496,21 @@ module CreateLoadBalancerTlsCertificate : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_load_balancer_tls_certificate_request ->
+    ( create_load_balancer_tls_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an SSL/TLS certificate for an Amazon Lightsail load balancer.\n\n\
@@ -1135,6 +1550,21 @@ module CreateRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_relational_database_request ->
+    ( create_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new database in Amazon Lightsail.\n\n\
@@ -1161,6 +1591,21 @@ module CreateRelationalDatabaseFromSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     create_relational_database_from_snapshot_request ->
     ( create_relational_database_from_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_relational_database_from_snapshot_request ->
+    ( create_relational_database_from_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -1211,6 +1656,21 @@ module CreateRelationalDatabaseSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_relational_database_snapshot_request ->
+    ( create_relational_database_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a snapshot of your database in Amazon Lightsail. You can use snapshots for backups, to \
@@ -1237,6 +1697,20 @@ module DeleteAlarm : sig
     'http_type Smaws_Lib.Context.t ->
     delete_alarm_request ->
     ( delete_alarm_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_alarm_request ->
+    ( delete_alarm_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -1281,6 +1755,20 @@ module DeleteAutoSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_auto_snapshot_request ->
+    ( delete_auto_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an automatic snapshot of an instance or disk. For more information, see the \
@@ -1302,6 +1790,19 @@ module DeleteBucket : sig
     'http_type Smaws_Lib.Context.t ->
     delete_bucket_request ->
     ( delete_bucket_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_bucket_request ->
+    ( delete_bucket_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -1333,6 +1834,19 @@ module DeleteBucketAccessKey : sig
     'http_type Smaws_Lib.Context.t ->
     delete_bucket_access_key_request ->
     ( delete_bucket_access_key_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_bucket_access_key_request ->
+    ( delete_bucket_access_key_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -1374,6 +1888,19 @@ module DeleteCertificate : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_certificate_request ->
+    ( delete_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an SSL/TLS certificate for your Amazon Lightsail content delivery network (CDN) \
@@ -1398,6 +1925,20 @@ module DeleteContactMethod : sig
     'http_type Smaws_Lib.Context.t ->
     delete_contact_method_request ->
     ( delete_contact_method_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_contact_method_request ->
+    ( delete_contact_method_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -1442,6 +1983,19 @@ module DeleteContainerImage : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_container_image_request ->
+    ( delete_container_image_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a container image that is registered to your Amazon Lightsail container service.\n"]
@@ -1461,6 +2015,19 @@ module DeleteContainerService : sig
     'http_type Smaws_Lib.Context.t ->
     delete_container_service_request ->
     ( delete_container_service_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_container_service_request ->
+    ( delete_container_service_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -1489,6 +2056,21 @@ module DeleteDisk : sig
     'http_type Smaws_Lib.Context.t ->
     delete_disk_request ->
     ( delete_disk_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_disk_request ->
+    ( delete_disk_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -1538,6 +2120,21 @@ module DeleteDiskSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_disk_snapshot_request ->
+    ( delete_disk_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified disk snapshot.\n\n\
@@ -1576,6 +2173,19 @@ module DeleteDistribution : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_distribution_request ->
+    ( delete_distribution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes your Amazon Lightsail content delivery network (CDN) distribution.\n"]
 
@@ -1596,6 +2206,21 @@ module DeleteDomain : sig
     'http_type Smaws_Lib.Context.t ->
     delete_domain_request ->
     ( delete_domain_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_domain_request ->
+    ( delete_domain_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -1642,6 +2267,21 @@ module DeleteDomainEntry : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_domain_entry_request ->
+    ( delete_domain_entry_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a specific domain entry.\n\n\
@@ -1668,6 +2308,21 @@ module DeleteInstance : sig
     'http_type Smaws_Lib.Context.t ->
     delete_instance_request ->
     ( delete_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_instance_request ->
+    ( delete_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -1714,6 +2369,21 @@ module DeleteInstanceSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_instance_snapshot_request ->
+    ( delete_instance_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a specific snapshot of a virtual private server (or {i instance}).\n\n\
@@ -1740,6 +2410,21 @@ module DeleteKeyPair : sig
     'http_type Smaws_Lib.Context.t ->
     delete_key_pair_request ->
     ( delete_key_pair_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_key_pair_request ->
+    ( delete_key_pair_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -1795,6 +2480,21 @@ module DeleteKnownHostKeys : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_known_host_keys_request ->
+    ( delete_known_host_keys_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the known host key or certificate used by the Amazon Lightsail browser-based SSH or RDP \
@@ -1825,6 +2525,21 @@ module DeleteLoadBalancer : sig
     'http_type Smaws_Lib.Context.t ->
     delete_load_balancer_request ->
     ( delete_load_balancer_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_load_balancer_request ->
+    ( delete_load_balancer_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -1873,6 +2588,21 @@ module DeleteLoadBalancerTlsCertificate : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_load_balancer_tls_certificate_request ->
+    ( delete_load_balancer_tls_certificate_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an SSL/TLS certificate associated with a Lightsail load balancer.\n\n\
@@ -1900,6 +2630,21 @@ module DeleteRelationalDatabase : sig
     'http_type Smaws_Lib.Context.t ->
     delete_relational_database_request ->
     ( delete_relational_database_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_relational_database_request ->
+    ( delete_relational_database_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -1946,6 +2691,21 @@ module DeleteRelationalDatabaseSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_relational_database_snapshot_request ->
+    ( delete_relational_database_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a database snapshot in Amazon Lightsail.\n\n\
@@ -1971,6 +2731,19 @@ module DetachCertificateFromDistribution : sig
     'http_type Smaws_Lib.Context.t ->
     detach_certificate_from_distribution_request ->
     ( detach_certificate_from_distribution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    detach_certificate_from_distribution_request ->
+    ( detach_certificate_from_distribution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2014,6 +2787,21 @@ module DetachDisk : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    detach_disk_request ->
+    ( detach_disk_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Detaches a stopped block storage disk from a Lightsail instance. Make sure to unmount any file \
@@ -2042,6 +2830,21 @@ module DetachInstancesFromLoadBalancer : sig
     'http_type Smaws_Lib.Context.t ->
     detach_instances_from_load_balancer_request ->
     ( detach_instances_from_load_balancer_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    detach_instances_from_load_balancer_request ->
+    ( detach_instances_from_load_balancer_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2092,6 +2895,21 @@ module DetachStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    detach_static_ip_request ->
+    ( detach_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Detaches a static IP from the Amazon Lightsail instance to which it is attached.\n"]
 
@@ -2111,6 +2929,20 @@ module DisableAddOn : sig
     'http_type Smaws_Lib.Context.t ->
     disable_add_on_request ->
     ( disable_add_on_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_add_on_request ->
+    ( disable_add_on_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2153,6 +2985,21 @@ module DownloadDefaultKeyPair : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    download_default_key_pair_request ->
+    ( download_default_key_pair_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Downloads the regional Amazon Lightsail default key pair.\n\n\
@@ -2185,6 +3032,20 @@ module EnableAddOn : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_add_on_request ->
+    ( enable_add_on_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables or modifies an add-on for an Amazon Lightsail resource. For more information, see the \
@@ -2208,6 +3069,21 @@ module ExportSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     export_snapshot_request ->
     ( export_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    export_snapshot_request ->
+    ( export_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2268,6 +3144,21 @@ module GetActiveNames : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_active_names_request ->
+    ( get_active_names_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the names of all active (not deleted) resources.\n"]
 
@@ -2287,6 +3178,20 @@ module GetAlarms : sig
     'http_type Smaws_Lib.Context.t ->
     get_alarms_request ->
     ( get_alarms_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_alarms_request ->
+    ( get_alarms_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2333,6 +3238,20 @@ module GetAutoSnapshots : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_auto_snapshots_request ->
+    ( get_auto_snapshots_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the available automatic snapshots for an instance or disk. For more information, see \
@@ -2357,6 +3276,21 @@ module GetBlueprints : sig
     'http_type Smaws_Lib.Context.t ->
     get_blueprints_request ->
     ( get_blueprints_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_blueprints_request ->
+    ( get_blueprints_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2403,6 +3337,19 @@ module GetBucketAccessKeys : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bucket_access_keys_request ->
+    ( get_bucket_access_keys_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the existing access key IDs for the specified Amazon Lightsail bucket.\n\n\
@@ -2427,6 +3374,18 @@ module GetBucketBundles : sig
     'http_type Smaws_Lib.Context.t ->
     get_bucket_bundles_request ->
     ( get_bucket_bundles_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bucket_bundles_request ->
+    ( get_bucket_bundles_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2468,6 +3427,19 @@ module GetBucketMetricData : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bucket_metric_data_request ->
+    ( get_bucket_metric_data_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the data points of a specific metric for an Amazon Lightsail bucket.\n\n\
@@ -2491,6 +3463,19 @@ module GetBuckets : sig
     'http_type Smaws_Lib.Context.t ->
     get_buckets_request ->
     ( get_buckets_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_buckets_request ->
+    ( get_buckets_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2536,6 +3521,21 @@ module GetBundles : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_bundles_request ->
+    ( get_bundles_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the bundles that you can apply to an Amazon Lightsail instance when you create it.\n\n\
@@ -2561,6 +3561,19 @@ module GetCertificates : sig
     'http_type Smaws_Lib.Context.t ->
     get_certificates_request ->
     ( get_certificates_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_certificates_request ->
+    ( get_certificates_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2605,6 +3618,21 @@ module GetCloudFormationStackRecords : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_cloud_formation_stack_records_request ->
+    ( get_cloud_formation_stack_records_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the CloudFormation stack record created as a result of the [create cloud\n\
@@ -2629,6 +3657,20 @@ module GetContactMethods : sig
     'http_type Smaws_Lib.Context.t ->
     get_contact_methods_request ->
     ( get_contact_methods_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_contact_methods_request ->
+    ( get_contact_methods_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2670,6 +3712,17 @@ module GetContainerAPIMetadata : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_api_metadata_request ->
+    ( get_container_api_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about Amazon Lightsail containers, such as the current version of the \
@@ -2690,6 +3743,19 @@ module GetContainerImages : sig
     'http_type Smaws_Lib.Context.t ->
     get_container_images_request ->
     ( get_container_images_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_images_request ->
+    ( get_container_images_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2730,6 +3796,19 @@ module GetContainerLog : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_log_request ->
+    ( get_container_log_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the log events of a container of your Amazon Lightsail container service.\n\n\
@@ -2758,6 +3837,19 @@ module GetContainerServiceDeployments : sig
     'http_type Smaws_Lib.Context.t ->
     get_container_service_deployments_request ->
     ( get_container_service_deployments_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_service_deployments_request ->
+    ( get_container_service_deployments_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2805,6 +3897,19 @@ module GetContainerServiceMetricData : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_service_metric_data_request ->
+    ( get_container_service_metric_data_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the data points of a specific metric of your Amazon Lightsail container service.\n\n\
@@ -2827,6 +3932,19 @@ module GetContainerServicePowers : sig
     'http_type Smaws_Lib.Context.t ->
     get_container_service_powers_request ->
     ( get_container_service_powers_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_service_powers_request ->
+    ( get_container_service_powers_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2865,6 +3983,19 @@ module GetContainerServices : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_container_services_request ->
+    ( container_services_list_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about one or more of your Amazon Lightsail container services.\n"]
 
@@ -2883,6 +4014,19 @@ module GetCostEstimate : sig
     'http_type Smaws_Lib.Context.t ->
     get_cost_estimate_request ->
     ( get_cost_estimate_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_cost_estimate_request ->
+    ( get_cost_estimate_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -2923,6 +4067,21 @@ module GetDisk : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_disk_request ->
+    ( get_disk_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a specific block storage disk.\n"]
 
@@ -2943,6 +4102,21 @@ module GetDisks : sig
     'http_type Smaws_Lib.Context.t ->
     get_disks_request ->
     ( get_disks_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_disks_request ->
+    ( get_disks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -2983,6 +4157,21 @@ module GetDiskSnapshot : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_disk_snapshot_request ->
+    ( get_disk_snapshot_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a specific block storage disk snapshot.\n"]
 
@@ -3013,6 +4202,21 @@ module GetDiskSnapshots : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_disk_snapshots_request ->
+    ( get_disk_snapshots_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about all block storage disk snapshots in your AWS account and region.\n"]
@@ -3032,6 +4236,19 @@ module GetDistributionBundles : sig
     'http_type Smaws_Lib.Context.t ->
     get_distribution_bundles_request ->
     ( get_distribution_bundles_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_distribution_bundles_request ->
+    ( get_distribution_bundles_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -3071,6 +4288,19 @@ module GetDistributionLatestCacheReset : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_distribution_latest_cache_reset_request ->
+    ( get_distribution_latest_cache_reset_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the timestamp and status of the last cache reset of a specific Amazon Lightsail content \
@@ -3091,6 +4321,19 @@ module GetDistributionMetricData : sig
     'http_type Smaws_Lib.Context.t ->
     get_distribution_metric_data_request ->
     ( get_distribution_metric_data_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_distribution_metric_data_request ->
+    ( get_distribution_metric_data_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -3131,6 +4374,19 @@ module GetDistributions : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_distributions_request ->
+    ( get_distributions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about one or more of your Amazon Lightsail content delivery network (CDN) \
@@ -3153,6 +4409,21 @@ module GetDomain : sig
     'http_type Smaws_Lib.Context.t ->
     get_domain_request ->
     ( get_domain_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_domain_request ->
+    ( get_domain_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3193,6 +4464,21 @@ module GetDomains : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_domains_request ->
+    ( get_domains_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of all domains in the user's account.\n"]
 
@@ -3213,6 +4499,21 @@ module GetExportSnapshotRecords : sig
     'http_type Smaws_Lib.Context.t ->
     get_export_snapshot_records_request ->
     ( get_export_snapshot_records_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_export_snapshot_records_request ->
+    ( get_export_snapshot_records_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3260,6 +4561,21 @@ module GetInstance : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_request ->
+    ( get_instance_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a specific Amazon Lightsail instance, which is a virtual private \
@@ -3282,6 +4598,21 @@ module GetInstanceAccessDetails : sig
     'http_type Smaws_Lib.Context.t ->
     get_instance_access_details_request ->
     ( get_instance_access_details_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_access_details_request ->
+    ( get_instance_access_details_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3329,6 +4660,21 @@ module GetInstanceMetricData : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_metric_data_request ->
+    ( get_instance_metric_data_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the data points for the specified Amazon Lightsail instance metric, given an instance \
@@ -3355,6 +4701,21 @@ module GetInstancePortStates : sig
     'http_type Smaws_Lib.Context.t ->
     get_instance_port_states_request ->
     ( get_instance_port_states_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_port_states_request ->
+    ( get_instance_port_states_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3397,6 +4758,21 @@ module GetInstances : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instances_request ->
+    ( get_instances_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about all Amazon Lightsail virtual private servers, or {i instances}.\n"]
@@ -3418,6 +4794,21 @@ module GetInstanceSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     get_instance_snapshot_request ->
     ( get_instance_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_snapshot_request ->
+    ( get_instance_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3458,6 +4849,21 @@ module GetInstanceSnapshots : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_snapshots_request ->
+    ( get_instance_snapshots_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns all instance snapshots for the user's account.\n"]
 
@@ -3478,6 +4884,21 @@ module GetInstanceState : sig
     'http_type Smaws_Lib.Context.t ->
     get_instance_state_request ->
     ( get_instance_state_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_state_request ->
+    ( get_instance_state_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3518,6 +4939,21 @@ module GetKeyPair : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_pair_request ->
+    ( get_key_pair_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a specific key pair.\n"]
 
@@ -3538,6 +4974,21 @@ module GetKeyPairs : sig
     'http_type Smaws_Lib.Context.t ->
     get_key_pairs_request ->
     ( get_key_pairs_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_key_pairs_request ->
+    ( get_key_pairs_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3578,6 +5029,21 @@ module GetLoadBalancer : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancer_request ->
+    ( get_load_balancer_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about the specified Lightsail load balancer.\n"]
 
@@ -3598,6 +5064,21 @@ module GetLoadBalancerMetricData : sig
     'http_type Smaws_Lib.Context.t ->
     get_load_balancer_metric_data_request ->
     ( get_load_balancer_metric_data_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancer_metric_data_request ->
+    ( get_load_balancer_metric_data_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3643,6 +5124,21 @@ module GetLoadBalancers : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancers_request ->
+    ( get_load_balancers_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about all load balancers in an account.\n"]
 
@@ -3663,6 +5159,21 @@ module GetLoadBalancerTlsCertificates : sig
     'http_type Smaws_Lib.Context.t ->
     get_load_balancer_tls_certificates_request ->
     ( get_load_balancer_tls_certificates_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancer_tls_certificates_request ->
+    ( get_load_balancer_tls_certificates_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3698,6 +5209,19 @@ module GetLoadBalancerTlsPolicies : sig
     'http_type Smaws_Lib.Context.t ->
     get_load_balancer_tls_policies_request ->
     ( get_load_balancer_tls_policies_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_load_balancer_tls_policies_request ->
+    ( get_load_balancer_tls_policies_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3742,6 +5266,21 @@ module GetOperation : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_operation_request ->
+    ( get_operation_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a specific operation. Operations include events such as when you \
@@ -3764,6 +5303,21 @@ module GetOperations : sig
     'http_type Smaws_Lib.Context.t ->
     get_operations_request ->
     ( get_operations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_operations_request ->
+    ( get_operations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3809,6 +5363,21 @@ module GetOperationsForResource : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_operations_for_resource_request ->
+    ( get_operations_for_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Gets operations for a specific resource (an instance or a static IP).\n"]
 
@@ -3829,6 +5398,21 @@ module GetRegions : sig
     'http_type Smaws_Lib.Context.t ->
     get_regions_request ->
     ( get_regions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_regions_request ->
+    ( get_regions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3871,6 +5455,21 @@ module GetRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_request ->
+    ( get_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a specific database in Amazon Lightsail.\n"]
 
@@ -3891,6 +5490,21 @@ module GetRelationalDatabaseBlueprints : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_blueprints_request ->
     ( get_relational_database_blueprints_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_blueprints_request ->
+    ( get_relational_database_blueprints_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3935,6 +5549,21 @@ module GetRelationalDatabaseBundles : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_bundles_request ->
+    ( get_relational_database_bundles_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the list of bundles that are available in Amazon Lightsail. A bundle describes the \
@@ -3959,6 +5588,21 @@ module GetRelationalDatabaseEvents : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_events_request ->
     ( get_relational_database_events_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_events_request ->
+    ( get_relational_database_events_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -3999,6 +5643,21 @@ module GetRelationalDatabaseLogEvents : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_log_events_request ->
+    ( get_relational_database_log_events_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of log events for a database in Amazon Lightsail.\n"]
 
@@ -4019,6 +5678,21 @@ module GetRelationalDatabaseLogStreams : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_log_streams_request ->
     ( get_relational_database_log_streams_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_log_streams_request ->
+    ( get_relational_database_log_streams_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4050,6 +5724,21 @@ module GetRelationalDatabaseMasterUserPassword : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_master_user_password_request ->
     ( get_relational_database_master_user_password_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_master_user_password_request ->
+    ( get_relational_database_master_user_password_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4095,6 +5784,21 @@ module GetRelationalDatabaseMetricData : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_metric_data_request ->
+    ( get_relational_database_metric_data_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the data points of the specified metric for a database in Amazon Lightsail.\n\n\
@@ -4120,6 +5824,21 @@ module GetRelationalDatabaseParameters : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_parameters_request ->
     ( get_relational_database_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_parameters_request ->
+    ( get_relational_database_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4166,6 +5885,21 @@ module GetRelationalDatabases : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_databases_request ->
+    ( get_relational_databases_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about all of your databases in Amazon Lightsail.\n"]
 
@@ -4186,6 +5920,21 @@ module GetRelationalDatabaseSnapshot : sig
     'http_type Smaws_Lib.Context.t ->
     get_relational_database_snapshot_request ->
     ( get_relational_database_snapshot_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_snapshot_request ->
+    ( get_relational_database_snapshot_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4226,6 +5975,21 @@ module GetRelationalDatabaseSnapshots : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_relational_database_snapshots_request ->
+    ( get_relational_database_snapshots_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about all of your database snapshots in Amazon Lightsail.\n"]
 
@@ -4244,6 +6008,19 @@ module GetSetupHistory : sig
     'http_type Smaws_Lib.Context.t ->
     get_setup_history_request ->
     ( get_setup_history_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_setup_history_request ->
+    ( get_setup_history_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4284,6 +6061,21 @@ module GetStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_static_ip_request ->
+    ( get_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about an Amazon Lightsail static IP.\n"]
 
@@ -4304,6 +6096,21 @@ module GetStaticIps : sig
     'http_type Smaws_Lib.Context.t ->
     get_static_ips_request ->
     ( get_static_ips_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_static_ips_request ->
+    ( get_static_ips_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4344,6 +6151,21 @@ module ImportKeyPair : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_key_pair_request ->
+    ( import_key_pair_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Imports a public SSH key from a specific key pair.\n"]
 
@@ -4374,6 +6196,21 @@ module IsVpcPeered : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    is_vpc_peered_request ->
+    ( is_vpc_peered_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a Boolean value indicating whether your Lightsail VPC is peered.\n"]
 
@@ -4394,6 +6231,21 @@ module OpenInstancePublicPorts : sig
     'http_type Smaws_Lib.Context.t ->
     open_instance_public_ports_request ->
     ( open_instance_public_ports_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    open_instance_public_ports_request ->
+    ( open_instance_public_ports_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4441,6 +6293,21 @@ module PeerVpc : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    peer_vpc_request ->
+    ( peer_vpc_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Peers the Lightsail VPC with the user's default VPC.\n"]
 
@@ -4460,6 +6327,20 @@ module PutAlarm : sig
     'http_type Smaws_Lib.Context.t ->
     put_alarm_request ->
     ( put_alarm_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_alarm_request ->
+    ( put_alarm_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4519,6 +6400,21 @@ module PutInstancePublicPorts : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_instance_public_ports_request ->
+    ( put_instance_public_ports_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Opens ports for a specific Amazon Lightsail instance, and specifies the IP addresses allowed to \
@@ -4549,6 +6445,21 @@ module RebootInstance : sig
     'http_type Smaws_Lib.Context.t ->
     reboot_instance_request ->
     ( reboot_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reboot_instance_request ->
+    ( reboot_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4595,6 +6506,21 @@ module RebootRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reboot_relational_database_request ->
+    ( reboot_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Restarts a specific database in Amazon Lightsail.\n\n\
@@ -4619,6 +6545,19 @@ module RegisterContainerImage : sig
     'http_type Smaws_Lib.Context.t ->
     register_container_image_request ->
     ( register_container_image_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_container_image_request ->
+    ( register_container_image_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4665,6 +6604,21 @@ module ReleaseStaticIp : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    release_static_ip_request ->
+    ( release_static_ip_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a specific static IP from your account.\n"]
 
@@ -4683,6 +6637,19 @@ module ResetDistributionCache : sig
     'http_type Smaws_Lib.Context.t ->
     reset_distribution_cache_request ->
     ( reset_distribution_cache_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reset_distribution_cache_request ->
+    ( reset_distribution_cache_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4715,6 +6682,20 @@ module SendContactMethodVerification : sig
     'http_type Smaws_Lib.Context.t ->
     send_contact_method_verification_request ->
     ( send_contact_method_verification_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_contact_method_verification_request ->
+    ( send_contact_method_verification_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4772,6 +6753,21 @@ module SetIpAddressType : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_ip_address_type_request ->
+    ( set_ip_address_type_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the IP address type for an Amazon Lightsail resource.\n\n\
@@ -4803,6 +6799,19 @@ module SetResourceAccessForBucket : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_resource_access_for_bucket_request ->
+    ( set_resource_access_for_bucket_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Sets the Amazon Lightsail resources that can access the specified Lightsail bucket.\n\n\
@@ -4825,6 +6834,19 @@ module SetupInstanceHttps : sig
     'http_type Smaws_Lib.Context.t ->
     setup_instance_https_request ->
     ( setup_instance_https_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    setup_instance_https_request ->
+    ( setup_instance_https_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -4864,6 +6886,19 @@ module StartGUISession : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_gui_session_request ->
+    ( start_gui_session_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Initiates a graphical user interface (GUI) session that\226\128\153s used to access a virtual \
@@ -4887,6 +6922,21 @@ module StartInstance : sig
     'http_type Smaws_Lib.Context.t ->
     start_instance_request ->
     ( start_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_instance_request ->
+    ( start_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -4940,6 +6990,21 @@ module StartRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_relational_database_request ->
+    ( start_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Starts a specific database from a stopped state in Amazon Lightsail. To restart a database, use \
@@ -4973,6 +7038,19 @@ module StopGUISession : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_gui_session_request ->
+    ( stop_gui_session_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Terminates a web-based Amazon DCV session that\226\128\153s used to access a virtual \
@@ -4996,6 +7074,21 @@ module StopInstance : sig
     'http_type Smaws_Lib.Context.t ->
     stop_instance_request ->
     ( stop_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_instance_request ->
+    ( stop_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5048,6 +7141,21 @@ module StopRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_relational_database_request ->
+    ( stop_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Stops a specific database that is currently running in Amazon Lightsail.\n\n\
@@ -5079,6 +7187,21 @@ module TagResource : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resource_request ->
     ( tag_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5127,6 +7250,20 @@ module TestAlarm : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_alarm_request ->
+    ( test_alarm_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Tests an alarm by displaying a banner on the Amazon Lightsail console. If a notification \
@@ -5166,6 +7303,21 @@ module UnpeerVpc : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unpeer_vpc_request ->
+    ( unpeer_vpc_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc "Unpeers the Lightsail VPC from the user's default VPC.\n"]
 
@@ -5186,6 +7338,21 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5229,6 +7396,19 @@ module UpdateBucket : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_bucket_request ->
+    ( update_bucket_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing Amazon Lightsail bucket.\n\n\
@@ -5251,6 +7431,19 @@ module UpdateBucketBundle : sig
     'http_type Smaws_Lib.Context.t ->
     update_bucket_bundle_request ->
     ( update_bucket_bundle_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_bucket_bundle_request ->
+    ( update_bucket_bundle_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -5300,6 +7493,19 @@ module UpdateContainerService : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_container_service_request ->
+    ( update_container_service_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the configuration of your Amazon Lightsail container service, such as its power, scale, \
@@ -5320,6 +7526,19 @@ module UpdateDistribution : sig
     'http_type Smaws_Lib.Context.t ->
     update_distribution_request ->
     ( update_distribution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_distribution_request ->
+    ( update_distribution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -5349,6 +7568,19 @@ module UpdateDistributionBundle : sig
     'http_type Smaws_Lib.Context.t ->
     update_distribution_bundle_request ->
     ( update_distribution_bundle_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_distribution_bundle_request ->
+    ( update_distribution_bundle_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InvalidInputException of invalid_input_exception
@@ -5399,6 +7631,21 @@ module UpdateDomainEntry : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_domain_entry_request ->
+    ( update_domain_entry_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates a domain recordset after it is created.\n\n\
@@ -5425,6 +7672,21 @@ module UpdateInstanceMetadataOptions : sig
     'http_type Smaws_Lib.Context.t ->
     update_instance_metadata_options_request ->
     ( update_instance_metadata_options_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_instance_metadata_options_request ->
+    ( update_instance_metadata_options_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5462,6 +7724,21 @@ module UpdateLoadBalancerAttribute : sig
     'http_type Smaws_Lib.Context.t ->
     update_load_balancer_attribute_request ->
     ( update_load_balancer_attribute_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_load_balancer_attribute_request ->
+    ( update_load_balancer_attribute_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception
@@ -5510,6 +7787,21 @@ module UpdateRelationalDatabase : sig
       | `ServiceException of service_exception
       | `UnauthenticatedException of unauthenticated_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_relational_database_request ->
+    ( update_relational_database_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows the update of one or more attributes of a database in Amazon Lightsail.\n\n\
@@ -5540,6 +7832,21 @@ module UpdateRelationalDatabaseParameters : sig
     'http_type Smaws_Lib.Context.t ->
     update_relational_database_parameters_request ->
     ( update_relational_database_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `AccountSetupInProgressException of account_setup_in_progress_exception
+      | `InvalidInputException of invalid_input_exception
+      | `NotFoundException of not_found_exception
+      | `OperationFailureException of operation_failure_exception
+      | `RegionSetupInProgressException of region_setup_in_progress_exception
+      | `ServiceException of service_exception
+      | `UnauthenticatedException of unauthenticated_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_relational_database_parameters_request ->
+    ( update_relational_database_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `AccountSetupInProgressException of account_setup_in_progress_exception

--- a/sdks/lightsail/operations.mli
+++ b/sdks/lightsail/operations.mli
@@ -40,7 +40,8 @@ module AllocateStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Allocates a static IP address.\n"]
@@ -79,7 +80,8 @@ module AttachCertificateToDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -138,7 +140,8 @@ module AttachDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -190,7 +193,8 @@ module AttachInstancesToLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -245,7 +249,8 @@ module AttachLoadBalancerTlsCertificate : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -303,7 +308,8 @@ module AttachStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Attaches a static IP address to a specific Amazon Lightsail instance.\n"]
@@ -348,7 +354,8 @@ module CloseInstancePublicPorts : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -399,7 +406,8 @@ module CopySnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -447,7 +455,8 @@ module CreateBucket : sig
       | `InvalidInputException of invalid_input_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -493,7 +502,8 @@ module CreateBucketAccessKey : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -548,7 +558,8 @@ module CreateCertificate : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -605,7 +616,8 @@ module CreateCloudFormationStack : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -655,7 +667,8 @@ module CreateContactMethod : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -708,7 +721,8 @@ module CreateContainerService : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -753,7 +767,8 @@ module CreateContainerServiceDeployment : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -805,7 +820,8 @@ module CreateContainerServiceRegistryLogin : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -871,7 +887,8 @@ module CreateDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -923,7 +940,8 @@ module CreateDiskFromSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -976,7 +994,8 @@ module CreateDiskSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1039,7 +1058,8 @@ module CreateDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1091,7 +1111,8 @@ module CreateDomain : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1142,7 +1163,8 @@ module CreateDomainEntry : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1189,7 +1211,8 @@ module CreateGUISessionAccessDetails : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1240,7 +1263,8 @@ module CreateInstances : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1291,7 +1315,8 @@ module CreateInstancesFromSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1343,7 +1368,8 @@ module CreateInstanceSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1395,7 +1421,8 @@ module CreateKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1451,7 +1478,8 @@ module CreateLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1509,7 +1537,8 @@ module CreateLoadBalancerTlsCertificate : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1563,7 +1592,8 @@ module CreateRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1614,7 +1644,8 @@ module CreateRelationalDatabaseFromSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1669,7 +1700,8 @@ module CreateRelationalDatabaseSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1718,7 +1750,8 @@ module DeleteAlarm : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1767,7 +1800,8 @@ module DeleteAutoSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1809,7 +1843,8 @@ module DeleteBucket : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1853,7 +1888,8 @@ module DeleteBucketAccessKey : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1899,7 +1935,8 @@ module DeleteCertificate : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1946,7 +1983,8 @@ module DeleteContactMethod : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1994,7 +2032,8 @@ module DeleteContainerImage : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2034,7 +2073,8 @@ module DeleteContainerService : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes your Amazon Lightsail container service.\n"]
@@ -2079,7 +2119,8 @@ module DeleteDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2133,7 +2174,8 @@ module DeleteDiskSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2184,7 +2226,8 @@ module DeleteDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes your Amazon Lightsail content delivery network (CDN) distribution.\n"]
@@ -2229,7 +2272,8 @@ module DeleteDomain : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2280,7 +2324,8 @@ module DeleteDomainEntry : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2331,7 +2376,8 @@ module DeleteInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2382,7 +2428,8 @@ module DeleteInstanceSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2433,7 +2480,8 @@ module DeleteKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2493,7 +2541,8 @@ module DeleteKnownHostKeys : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2548,7 +2597,8 @@ module DeleteLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2601,7 +2651,8 @@ module DeleteLoadBalancerTlsCertificate : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2653,7 +2704,8 @@ module DeleteRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2704,7 +2756,8 @@ module DeleteRelationalDatabaseSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2750,7 +2803,8 @@ module DetachCertificateFromDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2800,7 +2854,8 @@ module DetachDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2853,7 +2908,8 @@ module DetachInstancesFromLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2908,7 +2964,8 @@ module DetachStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Detaches a static IP from the Amazon Lightsail instance to which it is attached.\n"]
@@ -2950,7 +3007,8 @@ module DisableAddOn : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2998,7 +3056,8 @@ module DownloadDefaultKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3044,7 +3103,8 @@ module EnableAddOn : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3092,7 +3152,8 @@ module ExportSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3157,7 +3218,8 @@ module GetActiveNames : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the names of all active (not deleted) resources.\n"]
@@ -3199,7 +3261,8 @@ module GetAlarms : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3250,7 +3313,8 @@ module GetAutoSnapshots : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3299,7 +3363,8 @@ module GetBlueprints : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3348,7 +3413,8 @@ module GetBucketAccessKeys : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3391,7 +3457,8 @@ module GetBucketBundles : sig
       | `InvalidInputException of invalid_input_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3438,7 +3505,8 @@ module GetBucketMetricData : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3482,7 +3550,8 @@ module GetBuckets : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3534,7 +3603,8 @@ module GetBundles : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3580,7 +3650,8 @@ module GetCertificates : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3631,7 +3702,8 @@ module GetCloudFormationStackRecords : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3678,7 +3750,8 @@ module GetContactMethods : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3721,7 +3794,8 @@ module GetContainerAPIMetadata : sig
       | `AccessDeniedException of access_denied_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3762,7 +3836,8 @@ module GetContainerImages : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3807,7 +3882,8 @@ module GetContainerLog : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3856,7 +3932,8 @@ module GetContainerServiceDeployments : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3908,7 +3985,8 @@ module GetContainerServiceMetricData : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3951,7 +4029,8 @@ module GetContainerServicePowers : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3994,7 +4073,8 @@ module GetContainerServices : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about one or more of your Amazon Lightsail container services.\n"]
@@ -4033,7 +4113,8 @@ module GetCostEstimate : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4080,7 +4161,8 @@ module GetDisk : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific block storage disk.\n"]
@@ -4125,7 +4207,8 @@ module GetDisks : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all block storage disks in your AWS account and region.\n"]
@@ -4170,7 +4253,8 @@ module GetDiskSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific block storage disk snapshot.\n"]
@@ -4215,7 +4299,8 @@ module GetDiskSnapshots : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4255,7 +4340,8 @@ module GetDistributionBundles : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4299,7 +4385,8 @@ module GetDistributionLatestCacheReset : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4340,7 +4427,8 @@ module GetDistributionMetricData : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4385,7 +4473,8 @@ module GetDistributions : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4432,7 +4521,8 @@ module GetDomain : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific domain recordset.\n"]
@@ -4477,7 +4567,8 @@ module GetDomains : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of all domains in the user's account.\n"]
@@ -4522,7 +4613,8 @@ module GetExportSnapshotRecords : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4574,7 +4666,8 @@ module GetInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4621,7 +4714,8 @@ module GetInstanceAccessDetails : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4673,7 +4767,8 @@ module GetInstanceMetricData : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4724,7 +4819,8 @@ module GetInstancePortStates : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4771,7 +4867,8 @@ module GetInstances : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4817,7 +4914,8 @@ module GetInstanceSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific instance snapshot.\n"]
@@ -4862,7 +4960,8 @@ module GetInstanceSnapshots : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns all instance snapshots for the user's account.\n"]
@@ -4907,7 +5006,8 @@ module GetInstanceState : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the state of a specific instance. Works on one instance at a time.\n"]
@@ -4952,7 +5052,8 @@ module GetKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific key pair.\n"]
@@ -4997,7 +5098,8 @@ module GetKeyPairs : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all key pairs in the user's account.\n"]
@@ -5042,7 +5144,8 @@ module GetLoadBalancer : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about the specified Lightsail load balancer.\n"]
@@ -5087,7 +5190,8 @@ module GetLoadBalancerMetricData : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5137,7 +5241,8 @@ module GetLoadBalancers : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all load balancers in an account.\n"]
@@ -5182,7 +5287,8 @@ module GetLoadBalancerTlsCertificates : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5228,7 +5334,8 @@ module GetLoadBalancerTlsPolicies : sig
       | `InvalidInputException of invalid_input_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5279,7 +5386,8 @@ module GetOperation : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5326,7 +5434,8 @@ module GetOperations : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5376,7 +5485,8 @@ module GetOperationsForResource : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets operations for a specific resource (an instance or a static IP).\n"]
@@ -5421,7 +5531,8 @@ module GetRegions : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5468,7 +5579,8 @@ module GetRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific database in Amazon Lightsail.\n"]
@@ -5513,7 +5625,8 @@ module GetRelationalDatabaseBlueprints : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5562,7 +5675,8 @@ module GetRelationalDatabaseBundles : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5611,7 +5725,8 @@ module GetRelationalDatabaseEvents : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of events for a specific database in Amazon Lightsail.\n"]
@@ -5656,7 +5771,8 @@ module GetRelationalDatabaseLogEvents : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of log events for a database in Amazon Lightsail.\n"]
@@ -5701,7 +5817,8 @@ module GetRelationalDatabaseLogStreams : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5747,7 +5864,8 @@ module GetRelationalDatabaseMasterUserPassword : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5797,7 +5915,8 @@ module GetRelationalDatabaseMetricData : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5847,7 +5966,8 @@ module GetRelationalDatabaseParameters : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5898,7 +6018,8 @@ module GetRelationalDatabases : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all of your databases in Amazon Lightsail.\n"]
@@ -5943,7 +6064,8 @@ module GetRelationalDatabaseSnapshot : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a specific database snapshot in Amazon Lightsail.\n"]
@@ -5988,7 +6110,8 @@ module GetRelationalDatabaseSnapshots : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all of your database snapshots in Amazon Lightsail.\n"]
@@ -6027,7 +6150,8 @@ module GetSetupHistory : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6074,7 +6198,8 @@ module GetStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about an Amazon Lightsail static IP.\n"]
@@ -6119,7 +6244,8 @@ module GetStaticIps : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about all static IPs in the user's account.\n"]
@@ -6164,7 +6290,8 @@ module ImportKeyPair : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Imports a public SSH key from a specific key pair.\n"]
@@ -6209,7 +6336,8 @@ module IsVpcPeered : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a Boolean value indicating whether your Lightsail VPC is peered.\n"]
@@ -6254,7 +6382,8 @@ module OpenInstancePublicPorts : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6306,7 +6435,8 @@ module PeerVpc : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Peers the Lightsail VPC with the user's default VPC.\n"]
@@ -6348,7 +6478,8 @@ module PutAlarm : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6413,7 +6544,8 @@ module PutInstancePublicPorts : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6468,7 +6600,8 @@ module RebootInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6519,7 +6652,8 @@ module RebootRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6564,7 +6698,8 @@ module RegisterContainerImage : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6617,7 +6752,8 @@ module ReleaseStaticIp : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a specific static IP from your account.\n"]
@@ -6656,7 +6792,8 @@ module ResetDistributionCache : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6703,7 +6840,8 @@ module SendContactMethodVerification : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6766,7 +6904,8 @@ module SetIpAddressType : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6810,7 +6949,8 @@ module SetResourceAccessForBucket : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6853,7 +6993,8 @@ module SetupInstanceHttps : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6897,7 +7038,8 @@ module StartGUISession : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6945,7 +7087,8 @@ module StartInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7003,7 +7146,8 @@ module StartRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7049,7 +7193,8 @@ module StopGUISession : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7097,7 +7242,8 @@ module StopInstance : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7154,7 +7300,8 @@ module StopRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7210,7 +7357,8 @@ module TagResource : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7262,7 +7410,8 @@ module TestAlarm : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7316,7 +7465,8 @@ module UnpeerVpc : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Unpeers the Lightsail VPC from the user's default VPC.\n"]
@@ -7361,7 +7511,8 @@ module UntagResource : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7407,7 +7558,8 @@ module UpdateBucket : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7450,7 +7602,8 @@ module UpdateBucketBundle : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7504,7 +7657,8 @@ module UpdateContainerService : sig
       | `NotFoundException of not_found_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7545,7 +7699,8 @@ module UpdateDistribution : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7587,7 +7742,8 @@ module UpdateDistributionBundle : sig
       | `NotFoundException of not_found_exception
       | `OperationFailureException of operation_failure_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7644,7 +7800,8 @@ module UpdateDomainEntry : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7695,7 +7852,8 @@ module UpdateInstanceMetadataOptions : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7747,7 +7905,8 @@ module UpdateLoadBalancerAttribute : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7800,7 +7959,8 @@ module UpdateRelationalDatabase : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7855,7 +8015,8 @@ module UpdateRelationalDatabaseParameters : sig
       | `OperationFailureException of operation_failure_exception
       | `RegionSetupInProgressException of region_setup_in_progress_exception
       | `ServiceException of service_exception
-      | `UnauthenticatedException of unauthenticated_exception ] )
+      | `UnauthenticatedException of unauthenticated_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/marketplace-agreement/Smaws_Client_MarketplaceAgreement.mli
+++ b/sdks/marketplace-agreement/Smaws_Client_MarketplaceAgreement.mli
@@ -771,6 +771,19 @@ module AcceptAgreementCancellationRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_agreement_cancellation_request_input ->
+    ( accept_agreement_cancellation_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows buyers (acceptors) to accept a cancellation request that is in [PENDING_APPROVAL] \
@@ -796,6 +809,19 @@ module AcceptAgreementPaymentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     accept_agreement_payment_request_input ->
     ( accept_agreement_payment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_agreement_payment_request_input ->
+    ( accept_agreement_payment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -838,6 +864,19 @@ module AcceptAgreementRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_agreement_request_input ->
+    ( accept_agreement_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Accepts an agreement request to finalize the agreement. The acceptor can optionally provide \
@@ -857,6 +896,18 @@ module BatchCreateBillingAdjustmentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     batch_create_billing_adjustment_request_input ->
     ( batch_create_billing_adjustment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_create_billing_adjustment_request_input ->
+    ( batch_create_billing_adjustment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -897,6 +948,19 @@ module CancelAgreement : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_agreement_input ->
+    ( cancel_agreement_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows an acceptor to cancel an active agreement. Not all agreements are eligible for \
@@ -917,6 +981,19 @@ module CancelAgreementCancellationRequest : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_agreement_cancellation_request_input ->
     ( cancel_agreement_cancellation_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_agreement_cancellation_request_input ->
+    ( cancel_agreement_cancellation_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -950,6 +1027,19 @@ module CancelAgreementPaymentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_agreement_payment_request_input ->
     ( cancel_agreement_payment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_agreement_payment_request_input ->
+    ( cancel_agreement_payment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -993,6 +1083,20 @@ module CreateAgreementRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_agreement_request_input ->
+    ( create_agreement_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an agreement request that acts as a quote for the terms you want to accept. The \
@@ -1020,6 +1124,18 @@ module DescribeAgreement : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_agreement_input ->
+    ( describe_agreement_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides details about an agreement, such as the proposer, acceptor, start date, and end date.\n"]
@@ -1038,6 +1154,18 @@ module GetAgreementCancellationRequest : sig
     'http_type Smaws_Lib.Context.t ->
     get_agreement_cancellation_request_input ->
     ( get_agreement_cancellation_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_agreement_cancellation_request_input ->
+    ( get_agreement_cancellation_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1072,6 +1200,18 @@ module GetAgreementEntitlements : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_agreement_entitlements_input ->
+    ( get_agreement_entitlements_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Obtains details about the entitlements of an agreement.\n"]
 
@@ -1089,6 +1229,18 @@ module GetAgreementPaymentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     get_agreement_payment_request_input ->
     ( get_agreement_payment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_agreement_payment_request_input ->
+    ( get_agreement_payment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1121,6 +1273,18 @@ module GetAgreementTerms : sig
     'http_type Smaws_Lib.Context.t ->
     get_agreement_terms_input ->
     ( get_agreement_terms_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_agreement_terms_input ->
+    ( get_agreement_terms_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1179,6 +1343,18 @@ module GetBillingAdjustmentRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_billing_adjustment_request_input ->
+    ( get_billing_adjustment_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves detailed information about a specific billing adjustment request. Sellers (proposers) \
@@ -1198,6 +1374,17 @@ module ListAgreementCancellationRequests : sig
     'http_type Smaws_Lib.Context.t ->
     list_agreement_cancellation_requests_input ->
     ( list_agreement_cancellation_requests_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_agreement_cancellation_requests_input ->
+    ( list_agreement_cancellation_requests_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1233,6 +1420,17 @@ module ListAgreementCharges : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_agreement_charges_input ->
+    ( list_agreement_charges_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows acceptors to view charges and purchase orders that are associated with an agreement. The \
@@ -1253,6 +1451,18 @@ module ListAgreementInvoiceLineItems : sig
     'http_type Smaws_Lib.Context.t ->
     list_agreement_invoice_line_items_input ->
     ( list_agreement_invoice_line_items_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_agreement_invoice_line_items_input ->
+    ( list_agreement_invoice_line_items_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1289,6 +1499,17 @@ module ListAgreementPaymentRequests : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_agreement_payment_requests_input ->
+    ( list_agreement_payment_requests_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists payment requests available to you as a seller or buyer. Both sellers (proposers) and \
@@ -1319,6 +1540,17 @@ module ListBillingAdjustmentRequests : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_billing_adjustment_requests_input ->
+    ( list_billing_adjustment_requests_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists billing adjustment requests for a specific agreement. Sellers (proposers) can use this \
@@ -1339,6 +1571,19 @@ module RejectAgreementCancellationRequest : sig
     'http_type Smaws_Lib.Context.t ->
     reject_agreement_cancellation_request_input ->
     ( reject_agreement_cancellation_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reject_agreement_cancellation_request_input ->
+    ( reject_agreement_cancellation_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1380,6 +1625,19 @@ module RejectAgreementPaymentRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reject_agreement_payment_request_input ->
+    ( reject_agreement_payment_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows buyers (acceptors) to reject a payment request that is in [PENDING_APPROVAL] status. \
@@ -1403,6 +1661,17 @@ module SearchAgreements : sig
     'http_type Smaws_Lib.Context.t ->
     search_agreements_input ->
     ( search_agreements_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    search_agreements_input ->
+    ( search_agreements_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1611,6 +1880,19 @@ module SendAgreementCancellationRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_agreement_cancellation_request_input ->
+    ( send_agreement_cancellation_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows sellers (proposers) to submit a cancellation request for an active agreement. The \
@@ -1632,6 +1914,19 @@ module SendAgreementPaymentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     send_agreement_payment_request_input ->
     ( send_agreement_payment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_agreement_payment_request_input ->
+    ( send_agreement_payment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1667,6 +1962,19 @@ module UpdatePurchaseOrders : sig
     'http_type Smaws_Lib.Context.t ->
     update_purchase_orders_input ->
     ( update_purchase_orders_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_purchase_orders_input ->
+    ( update_purchase_orders_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/marketplace-agreement/Smaws_Client_MarketplaceAgreement.mli
+++ b/sdks/marketplace-agreement/Smaws_Client_MarketplaceAgreement.mli
@@ -782,7 +782,8 @@ module AcceptAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -828,7 +829,8 @@ module AcceptAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -875,7 +877,8 @@ module AcceptAgreementRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -913,7 +916,8 @@ module BatchCreateBillingAdjustmentRequest : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -959,7 +963,8 @@ module CancelAgreement : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1000,7 +1005,8 @@ module CancelAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1046,7 +1052,8 @@ module CancelAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1095,7 +1102,8 @@ module CreateAgreementRequest : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1134,7 +1142,8 @@ module DescribeAgreement : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1171,7 +1180,8 @@ module GetAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1210,7 +1220,8 @@ module GetAgreementEntitlements : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Obtains details about the entitlements of an agreement.\n"]
@@ -1246,7 +1257,8 @@ module GetAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1290,7 +1302,8 @@ module GetAgreementTerms : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1353,7 +1366,8 @@ module GetBillingAdjustmentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1389,7 +1403,8 @@ module ListAgreementCancellationRequests : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1429,7 +1444,8 @@ module ListAgreementCharges : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1468,7 +1484,8 @@ module ListAgreementInvoiceLineItems : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1508,7 +1525,8 @@ module ListAgreementPaymentRequests : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1549,7 +1567,8 @@ module ListBillingAdjustmentRequests : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1590,7 +1609,8 @@ module RejectAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1636,7 +1656,8 @@ module RejectAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1676,7 +1697,8 @@ module SearchAgreements : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1891,7 +1913,8 @@ module SendAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1933,7 +1956,8 @@ module SendAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1981,7 +2005,8 @@ module UpdatePurchaseOrders : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/marketplace-agreement/operations.ml
+++ b/sdks/marketplace-agreement/operations.ml
@@ -39,6 +39,14 @@ module AcceptAgreementCancellationRequest = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.accept_agreement_cancellation_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : accept_agreement_cancellation_request_input) =
+    let input = Json_serializers.accept_agreement_cancellation_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.AcceptAgreementCancellationRequest" ~service
+      ~context ~input
+      ~output_deserializer:Json_deserializers.accept_agreement_cancellation_request_output_of_yojson
+      ~error_deserializer
 end
 
 module AcceptAgreementPaymentRequest = struct
@@ -75,6 +83,14 @@ module AcceptAgreementPaymentRequest = struct
   let request context (request : accept_agreement_payment_request_input) =
     let input = Json_serializers.accept_agreement_payment_request_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.AcceptAgreementPaymentRequest" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.accept_agreement_payment_request_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : accept_agreement_payment_request_input) =
+    let input = Json_serializers.accept_agreement_payment_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.AcceptAgreementPaymentRequest" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.accept_agreement_payment_request_output_of_yojson
@@ -118,6 +134,13 @@ module AcceptAgreementRequest = struct
       ~shape_name:"AWSMPCommerceService_v20200301.AcceptAgreementRequest" ~service ~context ~input
       ~output_deserializer:Json_deserializers.accept_agreement_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : accept_agreement_request_input) =
+    let input = Json_serializers.accept_agreement_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.AcceptAgreementRequest" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.accept_agreement_request_output_of_yojson
+      ~error_deserializer
 end
 
 module BatchCreateBillingAdjustmentRequest = struct
@@ -150,6 +173,15 @@ module BatchCreateBillingAdjustmentRequest = struct
   let request context (request : batch_create_billing_adjustment_request_input) =
     let input = Json_serializers.batch_create_billing_adjustment_request_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.BatchCreateBillingAdjustmentRequest" ~service
+      ~context ~input
+      ~output_deserializer:
+        Json_deserializers.batch_create_billing_adjustment_request_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : batch_create_billing_adjustment_request_input) =
+    let input = Json_serializers.batch_create_billing_adjustment_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.BatchCreateBillingAdjustmentRequest" ~service
       ~context ~input
       ~output_deserializer:
@@ -193,6 +225,12 @@ module CancelAgreement = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMPCommerceService_v20200301.CancelAgreement"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_agreement_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : cancel_agreement_input) =
+    let input = Json_serializers.cancel_agreement_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.CancelAgreement" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_agreement_output_of_yojson ~error_deserializer
 end
 
 module CancelAgreementCancellationRequest = struct
@@ -233,6 +271,14 @@ module CancelAgreementCancellationRequest = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.cancel_agreement_cancellation_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : cancel_agreement_cancellation_request_input) =
+    let input = Json_serializers.cancel_agreement_cancellation_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.CancelAgreementCancellationRequest" ~service
+      ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_agreement_cancellation_request_output_of_yojson
+      ~error_deserializer
 end
 
 module CancelAgreementPaymentRequest = struct
@@ -269,6 +315,14 @@ module CancelAgreementPaymentRequest = struct
   let request context (request : cancel_agreement_payment_request_input) =
     let input = Json_serializers.cancel_agreement_payment_request_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.CancelAgreementPaymentRequest" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.cancel_agreement_payment_request_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : cancel_agreement_payment_request_input) =
+    let input = Json_serializers.cancel_agreement_payment_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.CancelAgreementPaymentRequest" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.cancel_agreement_payment_request_output_of_yojson
@@ -317,6 +371,13 @@ module CreateAgreementRequest = struct
       ~shape_name:"AWSMPCommerceService_v20200301.CreateAgreementRequest" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_agreement_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_agreement_request_input) =
+    let input = Json_serializers.create_agreement_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.CreateAgreementRequest" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_agreement_request_output_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAgreement = struct
@@ -350,6 +411,13 @@ module DescribeAgreement = struct
   let request context (request : describe_agreement_input) =
     let input = Json_serializers.describe_agreement_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.DescribeAgreement" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_agreement_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_agreement_input) =
+    let input = Json_serializers.describe_agreement_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.DescribeAgreement" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_agreement_output_of_yojson
       ~error_deserializer
@@ -390,6 +458,14 @@ module GetAgreementCancellationRequest = struct
       ~input
       ~output_deserializer:Json_deserializers.get_agreement_cancellation_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_agreement_cancellation_request_input) =
+    let input = Json_serializers.get_agreement_cancellation_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.GetAgreementCancellationRequest" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.get_agreement_cancellation_request_output_of_yojson
+      ~error_deserializer
 end
 
 module GetAgreementEntitlements = struct
@@ -423,6 +499,13 @@ module GetAgreementEntitlements = struct
   let request context (request : get_agreement_entitlements_input) =
     let input = Json_serializers.get_agreement_entitlements_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.GetAgreementEntitlements" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_agreement_entitlements_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_agreement_entitlements_input) =
+    let input = Json_serializers.get_agreement_entitlements_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.GetAgreementEntitlements" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_agreement_entitlements_output_of_yojson
       ~error_deserializer
@@ -462,6 +545,13 @@ module GetAgreementPaymentRequest = struct
       ~shape_name:"AWSMPCommerceService_v20200301.GetAgreementPaymentRequest" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_agreement_payment_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_agreement_payment_request_input) =
+    let input = Json_serializers.get_agreement_payment_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.GetAgreementPaymentRequest" ~service ~context
+      ~input ~output_deserializer:Json_deserializers.get_agreement_payment_request_output_of_yojson
+      ~error_deserializer
 end
 
 module GetAgreementTerms = struct
@@ -495,6 +585,13 @@ module GetAgreementTerms = struct
   let request context (request : get_agreement_terms_input) =
     let input = Json_serializers.get_agreement_terms_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.GetAgreementTerms" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_agreement_terms_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_agreement_terms_input) =
+    let input = Json_serializers.get_agreement_terms_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.GetAgreementTerms" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_agreement_terms_output_of_yojson
       ~error_deserializer
@@ -534,6 +631,13 @@ module GetBillingAdjustmentRequest = struct
       ~shape_name:"AWSMPCommerceService_v20200301.GetBillingAdjustmentRequest" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_billing_adjustment_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_billing_adjustment_request_input) =
+    let input = Json_serializers.get_billing_adjustment_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.GetBillingAdjustmentRequest" ~service ~context
+      ~input ~output_deserializer:Json_deserializers.get_billing_adjustment_request_output_of_yojson
+      ~error_deserializer
 end
 
 module ListAgreementCancellationRequests = struct
@@ -567,6 +671,14 @@ module ListAgreementCancellationRequests = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_agreement_cancellation_requests_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_agreement_cancellation_requests_input) =
+    let input = Json_serializers.list_agreement_cancellation_requests_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.ListAgreementCancellationRequests" ~service
+      ~context ~input
+      ~output_deserializer:Json_deserializers.list_agreement_cancellation_requests_output_of_yojson
+      ~error_deserializer
 end
 
 module ListAgreementCharges = struct
@@ -596,6 +708,13 @@ module ListAgreementCharges = struct
   let request context (request : list_agreement_charges_input) =
     let input = Json_serializers.list_agreement_charges_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.ListAgreementCharges" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_agreement_charges_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_agreement_charges_input) =
+    let input = Json_serializers.list_agreement_charges_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.ListAgreementCharges" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_agreement_charges_output_of_yojson
       ~error_deserializer
@@ -636,6 +755,14 @@ module ListAgreementInvoiceLineItems = struct
       ~input
       ~output_deserializer:Json_deserializers.list_agreement_invoice_line_items_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_agreement_invoice_line_items_input) =
+    let input = Json_serializers.list_agreement_invoice_line_items_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.ListAgreementInvoiceLineItems" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.list_agreement_invoice_line_items_output_of_yojson
+      ~error_deserializer
 end
 
 module ListAgreementPaymentRequests = struct
@@ -669,6 +796,14 @@ module ListAgreementPaymentRequests = struct
       ~input
       ~output_deserializer:Json_deserializers.list_agreement_payment_requests_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_agreement_payment_requests_input) =
+    let input = Json_serializers.list_agreement_payment_requests_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.ListAgreementPaymentRequests" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.list_agreement_payment_requests_output_of_yojson
+      ~error_deserializer
 end
 
 module ListBillingAdjustmentRequests = struct
@@ -698,6 +833,14 @@ module ListBillingAdjustmentRequests = struct
   let request context (request : list_billing_adjustment_requests_input) =
     let input = Json_serializers.list_billing_adjustment_requests_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.ListBillingAdjustmentRequests" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.list_billing_adjustment_requests_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_billing_adjustment_requests_input) =
+    let input = Json_serializers.list_billing_adjustment_requests_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.ListBillingAdjustmentRequests" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.list_billing_adjustment_requests_output_of_yojson
@@ -742,6 +885,14 @@ module RejectAgreementCancellationRequest = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.reject_agreement_cancellation_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : reject_agreement_cancellation_request_input) =
+    let input = Json_serializers.reject_agreement_cancellation_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.RejectAgreementCancellationRequest" ~service
+      ~context ~input
+      ~output_deserializer:Json_deserializers.reject_agreement_cancellation_request_output_of_yojson
+      ~error_deserializer
 end
 
 module RejectAgreementPaymentRequest = struct
@@ -782,6 +933,14 @@ module RejectAgreementPaymentRequest = struct
       ~input
       ~output_deserializer:Json_deserializers.reject_agreement_payment_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : reject_agreement_payment_request_input) =
+    let input = Json_serializers.reject_agreement_payment_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.RejectAgreementPaymentRequest" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.reject_agreement_payment_request_output_of_yojson
+      ~error_deserializer
 end
 
 module SearchAgreements = struct
@@ -811,6 +970,12 @@ module SearchAgreements = struct
   let request context (request : search_agreements_input) =
     let input = Json_serializers.search_agreements_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.SearchAgreements" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.search_agreements_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : search_agreements_input) =
+    let input = Json_serializers.search_agreements_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.SearchAgreements" ~service ~context ~input
       ~output_deserializer:Json_deserializers.search_agreements_output_of_yojson ~error_deserializer
 end
@@ -849,6 +1014,14 @@ module SendAgreementCancellationRequest = struct
   let request context (request : send_agreement_cancellation_request_input) =
     let input = Json_serializers.send_agreement_cancellation_request_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.SendAgreementCancellationRequest" ~service
+      ~context ~input
+      ~output_deserializer:Json_deserializers.send_agreement_cancellation_request_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : send_agreement_cancellation_request_input) =
+    let input = Json_serializers.send_agreement_cancellation_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.SendAgreementCancellationRequest" ~service
       ~context ~input
       ~output_deserializer:Json_deserializers.send_agreement_cancellation_request_output_of_yojson
@@ -892,6 +1065,13 @@ module SendAgreementPaymentRequest = struct
       ~shape_name:"AWSMPCommerceService_v20200301.SendAgreementPaymentRequest" ~service ~context
       ~input ~output_deserializer:Json_deserializers.send_agreement_payment_request_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : send_agreement_payment_request_input) =
+    let input = Json_serializers.send_agreement_payment_request_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMPCommerceService_v20200301.SendAgreementPaymentRequest" ~service ~context
+      ~input ~output_deserializer:Json_deserializers.send_agreement_payment_request_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdatePurchaseOrders = struct
@@ -928,6 +1108,13 @@ module UpdatePurchaseOrders = struct
   let request context (request : update_purchase_orders_input) =
     let input = Json_serializers.update_purchase_orders_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSMPCommerceService_v20200301.UpdatePurchaseOrders" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_purchase_orders_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_purchase_orders_input) =
+    let input = Json_serializers.update_purchase_orders_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSMPCommerceService_v20200301.UpdatePurchaseOrders" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_purchase_orders_output_of_yojson
       ~error_deserializer

--- a/sdks/marketplace-agreement/operations.mli
+++ b/sdks/marketplace-agreement/operations.mli
@@ -34,7 +34,8 @@ module AcceptAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -80,7 +81,8 @@ module AcceptAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -127,7 +129,8 @@ module AcceptAgreementRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -165,7 +168,8 @@ module BatchCreateBillingAdjustmentRequest : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -211,7 +215,8 @@ module CancelAgreement : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -252,7 +257,8 @@ module CancelAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -298,7 +304,8 @@ module CancelAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -347,7 +354,8 @@ module CreateAgreementRequest : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -386,7 +394,8 @@ module DescribeAgreement : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -423,7 +432,8 @@ module GetAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -462,7 +472,8 @@ module GetAgreementEntitlements : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Obtains details about the entitlements of an agreement.\n"]
@@ -498,7 +509,8 @@ module GetAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -542,7 +554,8 @@ module GetAgreementTerms : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -605,7 +618,8 @@ module GetBillingAdjustmentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -641,7 +655,8 @@ module ListAgreementCancellationRequests : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -681,7 +696,8 @@ module ListAgreementCharges : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -720,7 +736,8 @@ module ListAgreementInvoiceLineItems : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -760,7 +777,8 @@ module ListAgreementPaymentRequests : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -801,7 +819,8 @@ module ListBillingAdjustmentRequests : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -842,7 +861,8 @@ module RejectAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -888,7 +908,8 @@ module RejectAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -928,7 +949,8 @@ module SearchAgreements : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1143,7 +1165,8 @@ module SendAgreementCancellationRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1185,7 +1208,8 @@ module SendAgreementPaymentRequest : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1232,7 +1256,8 @@ module UpdatePurchaseOrders : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/marketplace-agreement/operations.mli
+++ b/sdks/marketplace-agreement/operations.mli
@@ -23,6 +23,19 @@ module AcceptAgreementCancellationRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_agreement_cancellation_request_input ->
+    ( accept_agreement_cancellation_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows buyers (acceptors) to accept a cancellation request that is in [PENDING_APPROVAL] \
@@ -48,6 +61,19 @@ module AcceptAgreementPaymentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     accept_agreement_payment_request_input ->
     ( accept_agreement_payment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_agreement_payment_request_input ->
+    ( accept_agreement_payment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -90,6 +116,19 @@ module AcceptAgreementRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_agreement_request_input ->
+    ( accept_agreement_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Accepts an agreement request to finalize the agreement. The acceptor can optionally provide \
@@ -109,6 +148,18 @@ module BatchCreateBillingAdjustmentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     batch_create_billing_adjustment_request_input ->
     ( batch_create_billing_adjustment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_create_billing_adjustment_request_input ->
+    ( batch_create_billing_adjustment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -149,6 +200,19 @@ module CancelAgreement : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_agreement_input ->
+    ( cancel_agreement_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows an acceptor to cancel an active agreement. Not all agreements are eligible for \
@@ -169,6 +233,19 @@ module CancelAgreementCancellationRequest : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_agreement_cancellation_request_input ->
     ( cancel_agreement_cancellation_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_agreement_cancellation_request_input ->
+    ( cancel_agreement_cancellation_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -202,6 +279,19 @@ module CancelAgreementPaymentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_agreement_payment_request_input ->
     ( cancel_agreement_payment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_agreement_payment_request_input ->
+    ( cancel_agreement_payment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -245,6 +335,20 @@ module CreateAgreementRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_agreement_request_input ->
+    ( create_agreement_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an agreement request that acts as a quote for the terms you want to accept. The \
@@ -272,6 +376,18 @@ module DescribeAgreement : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_agreement_input ->
+    ( describe_agreement_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides details about an agreement, such as the proposer, acceptor, start date, and end date.\n"]
@@ -290,6 +406,18 @@ module GetAgreementCancellationRequest : sig
     'http_type Smaws_Lib.Context.t ->
     get_agreement_cancellation_request_input ->
     ( get_agreement_cancellation_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_agreement_cancellation_request_input ->
+    ( get_agreement_cancellation_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -324,6 +452,18 @@ module GetAgreementEntitlements : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_agreement_entitlements_input ->
+    ( get_agreement_entitlements_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Obtains details about the entitlements of an agreement.\n"]
 
@@ -341,6 +481,18 @@ module GetAgreementPaymentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     get_agreement_payment_request_input ->
     ( get_agreement_payment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_agreement_payment_request_input ->
+    ( get_agreement_payment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -373,6 +525,18 @@ module GetAgreementTerms : sig
     'http_type Smaws_Lib.Context.t ->
     get_agreement_terms_input ->
     ( get_agreement_terms_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_agreement_terms_input ->
+    ( get_agreement_terms_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -431,6 +595,18 @@ module GetBillingAdjustmentRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_billing_adjustment_request_input ->
+    ( get_billing_adjustment_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves detailed information about a specific billing adjustment request. Sellers (proposers) \
@@ -450,6 +626,17 @@ module ListAgreementCancellationRequests : sig
     'http_type Smaws_Lib.Context.t ->
     list_agreement_cancellation_requests_input ->
     ( list_agreement_cancellation_requests_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_agreement_cancellation_requests_input ->
+    ( list_agreement_cancellation_requests_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -485,6 +672,17 @@ module ListAgreementCharges : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_agreement_charges_input ->
+    ( list_agreement_charges_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows acceptors to view charges and purchase orders that are associated with an agreement. The \
@@ -505,6 +703,18 @@ module ListAgreementInvoiceLineItems : sig
     'http_type Smaws_Lib.Context.t ->
     list_agreement_invoice_line_items_input ->
     ( list_agreement_invoice_line_items_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_agreement_invoice_line_items_input ->
+    ( list_agreement_invoice_line_items_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -541,6 +751,17 @@ module ListAgreementPaymentRequests : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_agreement_payment_requests_input ->
+    ( list_agreement_payment_requests_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists payment requests available to you as a seller or buyer. Both sellers (proposers) and \
@@ -571,6 +792,17 @@ module ListBillingAdjustmentRequests : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_billing_adjustment_requests_input ->
+    ( list_billing_adjustment_requests_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists billing adjustment requests for a specific agreement. Sellers (proposers) can use this \
@@ -591,6 +823,19 @@ module RejectAgreementCancellationRequest : sig
     'http_type Smaws_Lib.Context.t ->
     reject_agreement_cancellation_request_input ->
     ( reject_agreement_cancellation_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reject_agreement_cancellation_request_input ->
+    ( reject_agreement_cancellation_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -632,6 +877,19 @@ module RejectAgreementPaymentRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reject_agreement_payment_request_input ->
+    ( reject_agreement_payment_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows buyers (acceptors) to reject a payment request that is in [PENDING_APPROVAL] status. \
@@ -655,6 +913,17 @@ module SearchAgreements : sig
     'http_type Smaws_Lib.Context.t ->
     search_agreements_input ->
     ( search_agreements_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    search_agreements_input ->
+    ( search_agreements_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -863,6 +1132,19 @@ module SendAgreementCancellationRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_agreement_cancellation_request_input ->
+    ( send_agreement_cancellation_request_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Allows sellers (proposers) to submit a cancellation request for an active agreement. The \
@@ -884,6 +1166,19 @@ module SendAgreementPaymentRequest : sig
     'http_type Smaws_Lib.Context.t ->
     send_agreement_payment_request_input ->
     ( send_agreement_payment_request_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_agreement_payment_request_input ->
+    ( send_agreement_payment_request_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -918,6 +1213,19 @@ module UpdatePurchaseOrders : sig
     'http_type Smaws_Lib.Context.t ->
     update_purchase_orders_input ->
     ( update_purchase_orders_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_purchase_orders_input ->
+    ( update_purchase_orders_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/migration-hub/Smaws_Client_MigrationHub.mli
+++ b/sdks/migration-hub/Smaws_Client_MigrationHub.mli
@@ -254,6 +254,22 @@ module AssociateCreatedArtifact : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_created_artifact_request ->
+    ( associate_created_artifact_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Associates a created artifact of an AWS cloud resource, the target receiving the migration, \
@@ -306,6 +322,23 @@ module AssociateDiscoveredResource : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_discovered_resource_request ->
+    ( associate_discovered_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `PolicyErrorException of policy_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Associates a discovered resource ID from Application Discovery Service with a migration task.\n"]
@@ -327,6 +360,21 @@ module AssociateSourceResource : sig
     'http_type Smaws_Lib.Context.t ->
     associate_source_resource_request ->
     ( associate_source_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_source_resource_request ->
+    ( associate_source_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -369,6 +417,21 @@ module CreateProgressUpdateStream : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_progress_update_stream_request ->
+    ( create_progress_update_stream_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Creates a progress update stream which is an AWS resource used for access control as well as a \
@@ -394,6 +457,22 @@ module DeleteProgressUpdateStream : sig
     'http_type Smaws_Lib.Context.t ->
     delete_progress_update_stream_request ->
     ( delete_progress_update_stream_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_progress_update_stream_request ->
+    ( delete_progress_update_stream_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -462,6 +541,21 @@ module DescribeApplicationState : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_state_request ->
+    ( describe_application_state_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `PolicyErrorException of policy_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Gets the migration status of an application.\n"]
 
@@ -481,6 +575,20 @@ module DescribeMigrationTask : sig
     'http_type Smaws_Lib.Context.t ->
     describe_migration_task_request ->
     ( describe_migration_task_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_migration_task_request ->
+    ( describe_migration_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `HomeRegionNotSetException of home_region_not_set_exception
@@ -511,6 +619,22 @@ module DisassociateCreatedArtifact : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_created_artifact_request ->
     ( disassociate_created_artifact_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_created_artifact_request ->
+    ( disassociate_created_artifact_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -572,6 +696,22 @@ module DisassociateDiscoveredResource : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_discovered_resource_request ->
+    ( disassociate_discovered_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Disassociate an Application Discovery Service discovered resource from a migration task.\n"]
@@ -593,6 +733,21 @@ module DisassociateSourceResource : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_source_resource_request ->
     ( disassociate_source_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_source_resource_request ->
+    ( disassociate_source_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -635,6 +790,22 @@ module ImportMigrationTask : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_migration_task_request ->
+    ( import_migration_task_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Registers a new migration task which represents a server, database, etc., being migrated to AWS \
@@ -666,6 +837,19 @@ module ListApplicationStates : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_application_states_request ->
+    ( list_application_states_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all the migration statuses for your applications. If you use the optional \
@@ -687,6 +871,20 @@ module ListCreatedArtifacts : sig
     'http_type Smaws_Lib.Context.t ->
     list_created_artifacts_request ->
     ( list_created_artifacts_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_created_artifacts_request ->
+    ( list_created_artifacts_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `HomeRegionNotSetException of home_region_not_set_exception
@@ -739,6 +937,20 @@ module ListDiscoveredResources : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_discovered_resources_request ->
+    ( list_discovered_resources_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Lists discovered resources associated with the given [MigrationTask].\n"]
 
@@ -757,6 +969,19 @@ module ListMigrationTaskUpdates : sig
     'http_type Smaws_Lib.Context.t ->
     list_migration_task_updates_request ->
     ( list_migration_task_updates_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_migration_task_updates_request ->
+    ( list_migration_task_updates_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerError of internal_server_error
@@ -787,6 +1012,21 @@ module ListMigrationTasks : sig
     'http_type Smaws_Lib.Context.t ->
     list_migration_tasks_request ->
     ( list_migration_tasks_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `PolicyErrorException of policy_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_migration_tasks_request ->
+    ( list_migration_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `HomeRegionNotSetException of home_region_not_set_exception
@@ -838,6 +1078,19 @@ module ListProgressUpdateStreams : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_progress_update_streams_request ->
+    ( list_progress_update_streams_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Lists progress update streams associated with the user account making this call.\n"]
 
@@ -856,6 +1109,19 @@ module ListSourceResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_source_resources_request ->
     ( list_source_resources_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_source_resources_request ->
+    ( list_source_resources_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerError of internal_server_error
@@ -900,6 +1166,23 @@ module NotifyApplicationState : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    notify_application_state_request ->
+    ( notify_application_state_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `PolicyErrorException of policy_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Sets the migration state of an application. For a given application identified by the value \
@@ -925,6 +1208,22 @@ module NotifyMigrationTaskState : sig
     'http_type Smaws_Lib.Context.t ->
     notify_migration_task_state_request ->
     ( notify_migration_task_state_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    notify_migration_task_state_request ->
+    ( notify_migration_task_state_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -974,6 +1273,22 @@ module PutResourceAttributes : sig
     'http_type Smaws_Lib.Context.t ->
     put_resource_attributes_request ->
     ( put_resource_attributes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_attributes_request ->
+    ( put_resource_attributes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation

--- a/sdks/migration-hub/Smaws_Client_MigrationHub.mli
+++ b/sdks/migration-hub/Smaws_Client_MigrationHub.mli
@@ -268,7 +268,8 @@ module AssociateCreatedArtifact : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -337,7 +338,8 @@ module AssociateDiscoveredResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -383,7 +385,8 @@ module AssociateSourceResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -430,7 +433,8 @@ module CreateProgressUpdateStream : sig
       | `InvalidInputException of invalid_input_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -482,7 +486,8 @@ module DeleteProgressUpdateStream : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -554,7 +559,8 @@ module DescribeApplicationState : sig
       | `PolicyErrorException of policy_error_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the migration status of an application.\n"]
@@ -596,7 +602,8 @@ module DescribeMigrationTask : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of all attributes associated with a specific migration task.\n"]
@@ -644,7 +651,8 @@ module DisassociateCreatedArtifact : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -710,7 +718,8 @@ module DisassociateDiscoveredResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -756,7 +765,8 @@ module DisassociateSourceResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the association between a source resource and a migration task.\n"]
@@ -804,7 +814,8 @@ module ImportMigrationTask : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -848,7 +859,8 @@ module ListApplicationStates : sig
       | `InternalServerError of internal_server_error
       | `InvalidInputException of invalid_input_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -892,7 +904,8 @@ module ListCreatedArtifacts : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -949,7 +962,8 @@ module ListDiscoveredResources : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists discovered resources associated with the given [MigrationTask].\n"]
@@ -988,7 +1002,8 @@ module ListMigrationTaskUpdates : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1035,7 +1050,8 @@ module ListMigrationTasks : sig
       | `PolicyErrorException of policy_error_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1089,7 +1105,8 @@ module ListProgressUpdateStreams : sig
       | `InternalServerError of internal_server_error
       | `InvalidInputException of invalid_input_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists progress update streams associated with the user account making this call.\n"]
@@ -1128,7 +1145,8 @@ module ListSourceResources : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1181,7 +1199,8 @@ module NotifyApplicationState : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1233,7 +1252,8 @@ module NotifyMigrationTaskState : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1298,7 +1318,8 @@ module PutResourceAttributes : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/migration-hub/operations.ml
+++ b/sdks/migration-hub/operations.ml
@@ -48,6 +48,13 @@ module AssociateCreatedArtifact = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_created_artifact_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_created_artifact_request) =
+    let input = Json_serializers.associate_created_artifact_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.AssociateCreatedArtifact" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_created_artifact_result_of_yojson
+      ~error_deserializer
 end
 
 module AssociateDiscoveredResource = struct
@@ -100,6 +107,13 @@ module AssociateDiscoveredResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_discovered_resource_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_discovered_resource_request) =
+    let input = Json_serializers.associate_discovered_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.AssociateDiscoveredResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_discovered_resource_result_of_yojson
+      ~error_deserializer
 end
 
 module AssociateSourceResource = struct
@@ -145,6 +159,13 @@ module AssociateSourceResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_source_resource_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_source_resource_request) =
+    let input = Json_serializers.associate_source_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.AssociateSourceResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_source_resource_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateProgressUpdateStream = struct
@@ -188,6 +209,13 @@ module CreateProgressUpdateStream = struct
     let input = Json_serializers.create_progress_update_stream_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMigrationHub.CreateProgressUpdateStream"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_progress_update_stream_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_progress_update_stream_request) =
+    let input = Json_serializers.create_progress_update_stream_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.CreateProgressUpdateStream" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_progress_update_stream_result_of_yojson
       ~error_deserializer
 end
@@ -239,6 +267,13 @@ module DeleteProgressUpdateStream = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_progress_update_stream_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_progress_update_stream_request) =
+    let input = Json_serializers.delete_progress_update_stream_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.DeleteProgressUpdateStream" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_progress_update_stream_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeApplicationState = struct
@@ -285,6 +320,13 @@ module DescribeApplicationState = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_application_state_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_application_state_request) =
+    let input = Json_serializers.describe_application_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.DescribeApplicationState" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_application_state_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeMigrationTask = struct
@@ -326,6 +368,13 @@ module DescribeMigrationTask = struct
     let input = Json_serializers.describe_migration_task_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMigrationHub.DescribeMigrationTask" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_migration_task_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_migration_task_request) =
+    let input = Json_serializers.describe_migration_task_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.DescribeMigrationTask" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_migration_task_result_of_yojson
       ~error_deserializer
 end
@@ -377,6 +426,13 @@ module DisassociateCreatedArtifact = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_created_artifact_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_created_artifact_request) =
+    let input = Json_serializers.disassociate_created_artifact_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.DisassociateCreatedArtifact" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_created_artifact_result_of_yojson
+      ~error_deserializer
 end
 
 module DisassociateDiscoveredResource = struct
@@ -426,6 +482,13 @@ module DisassociateDiscoveredResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_discovered_resource_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_discovered_resource_request) =
+    let input = Json_serializers.disassociate_discovered_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.DisassociateDiscoveredResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_discovered_resource_result_of_yojson
+      ~error_deserializer
 end
 
 module DisassociateSourceResource = struct
@@ -469,6 +532,13 @@ module DisassociateSourceResource = struct
     let input = Json_serializers.disassociate_source_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMigrationHub.DisassociateSourceResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_source_resource_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_source_resource_request) =
+    let input = Json_serializers.disassociate_source_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.DisassociateSourceResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_source_resource_result_of_yojson
       ~error_deserializer
 end
@@ -519,6 +589,13 @@ module ImportMigrationTask = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMigrationHub.ImportMigrationTask" ~service
       ~context ~input ~output_deserializer:Json_deserializers.import_migration_task_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : import_migration_task_request) =
+    let input = Json_serializers.import_migration_task_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.ImportMigrationTask" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.import_migration_task_result_of_yojson
+      ~error_deserializer
 end
 
 module ListApplicationStates = struct
@@ -556,6 +633,13 @@ module ListApplicationStates = struct
     let input = Json_serializers.list_application_states_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMigrationHub.ListApplicationStates" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_application_states_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_application_states_request) =
+    let input = Json_serializers.list_application_states_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.ListApplicationStates" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_application_states_result_of_yojson
       ~error_deserializer
 end
@@ -601,6 +685,13 @@ module ListCreatedArtifacts = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_created_artifacts_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_created_artifacts_request) =
+    let input = Json_serializers.list_created_artifacts_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.ListCreatedArtifacts" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_created_artifacts_result_of_yojson
+      ~error_deserializer
 end
 
 module ListDiscoveredResources = struct
@@ -644,6 +735,13 @@ module ListDiscoveredResources = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_discovered_resources_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_discovered_resources_request) =
+    let input = Json_serializers.list_discovered_resources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.ListDiscoveredResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_discovered_resources_result_of_yojson
+      ~error_deserializer
 end
 
 module ListMigrationTaskUpdates = struct
@@ -681,6 +779,13 @@ module ListMigrationTaskUpdates = struct
     let input = Json_serializers.list_migration_task_updates_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMigrationHub.ListMigrationTaskUpdates"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_migration_task_updates_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_migration_task_updates_request) =
+    let input = Json_serializers.list_migration_task_updates_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.ListMigrationTaskUpdates" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_migration_task_updates_result_of_yojson
       ~error_deserializer
 end
@@ -728,6 +833,13 @@ module ListMigrationTasks = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMigrationHub.ListMigrationTasks" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_migration_tasks_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_migration_tasks_request) =
+    let input = Json_serializers.list_migration_tasks_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.ListMigrationTasks" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_migration_tasks_result_of_yojson
+      ~error_deserializer
 end
 
 module ListProgressUpdateStreams = struct
@@ -767,6 +879,13 @@ module ListProgressUpdateStreams = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_progress_update_streams_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_progress_update_streams_request) =
+    let input = Json_serializers.list_progress_update_streams_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.ListProgressUpdateStreams" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_progress_update_streams_result_of_yojson
+      ~error_deserializer
 end
 
 module ListSourceResources = struct
@@ -804,6 +923,13 @@ module ListSourceResources = struct
     let input = Json_serializers.list_source_resources_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMigrationHub.ListSourceResources" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_source_resources_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_source_resources_request) =
+    let input = Json_serializers.list_source_resources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.ListSourceResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_source_resources_result_of_yojson
       ~error_deserializer
 end
 
@@ -857,6 +983,13 @@ module NotifyApplicationState = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.notify_application_state_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : notify_application_state_request) =
+    let input = Json_serializers.notify_application_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.NotifyApplicationState" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.notify_application_state_result_of_yojson
+      ~error_deserializer
 end
 
 module NotifyMigrationTaskState = struct
@@ -906,6 +1039,13 @@ module NotifyMigrationTaskState = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.notify_migration_task_state_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : notify_migration_task_state_request) =
+    let input = Json_serializers.notify_migration_task_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.NotifyMigrationTaskState" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.notify_migration_task_state_result_of_yojson
+      ~error_deserializer
 end
 
 module PutResourceAttributes = struct
@@ -953,6 +1093,13 @@ module PutResourceAttributes = struct
     let input = Json_serializers.put_resource_attributes_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSMigrationHub.PutResourceAttributes" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.put_resource_attributes_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_resource_attributes_request) =
+    let input = Json_serializers.put_resource_attributes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSMigrationHub.PutResourceAttributes" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_resource_attributes_result_of_yojson
       ~error_deserializer
 end

--- a/sdks/migration-hub/operations.mli
+++ b/sdks/migration-hub/operations.mli
@@ -29,6 +29,22 @@ module AssociateCreatedArtifact : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_created_artifact_request ->
+    ( associate_created_artifact_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Associates a created artifact of an AWS cloud resource, the target receiving the migration, \
@@ -81,6 +97,23 @@ module AssociateDiscoveredResource : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_discovered_resource_request ->
+    ( associate_discovered_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `PolicyErrorException of policy_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Associates a discovered resource ID from Application Discovery Service with a migration task.\n"]
@@ -102,6 +135,21 @@ module AssociateSourceResource : sig
     'http_type Smaws_Lib.Context.t ->
     associate_source_resource_request ->
     ( associate_source_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_source_resource_request ->
+    ( associate_source_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -144,6 +192,21 @@ module CreateProgressUpdateStream : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_progress_update_stream_request ->
+    ( create_progress_update_stream_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Creates a progress update stream which is an AWS resource used for access control as well as a \
@@ -169,6 +232,22 @@ module DeleteProgressUpdateStream : sig
     'http_type Smaws_Lib.Context.t ->
     delete_progress_update_stream_request ->
     ( delete_progress_update_stream_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_progress_update_stream_request ->
+    ( delete_progress_update_stream_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -237,6 +316,21 @@ module DescribeApplicationState : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_application_state_request ->
+    ( describe_application_state_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `PolicyErrorException of policy_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Gets the migration status of an application.\n"]
 
@@ -256,6 +350,20 @@ module DescribeMigrationTask : sig
     'http_type Smaws_Lib.Context.t ->
     describe_migration_task_request ->
     ( describe_migration_task_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_migration_task_request ->
+    ( describe_migration_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `HomeRegionNotSetException of home_region_not_set_exception
@@ -286,6 +394,22 @@ module DisassociateCreatedArtifact : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_created_artifact_request ->
     ( disassociate_created_artifact_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_created_artifact_request ->
+    ( disassociate_created_artifact_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -347,6 +471,22 @@ module DisassociateDiscoveredResource : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_discovered_resource_request ->
+    ( disassociate_discovered_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Disassociate an Application Discovery Service discovered resource from a migration task.\n"]
@@ -368,6 +508,21 @@ module DisassociateSourceResource : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_source_resource_request ->
     ( disassociate_source_resource_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_source_resource_request ->
+    ( disassociate_source_resource_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -410,6 +565,22 @@ module ImportMigrationTask : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    import_migration_task_request ->
+    ( import_migration_task_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Registers a new migration task which represents a server, database, etc., being migrated to AWS \
@@ -441,6 +612,19 @@ module ListApplicationStates : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_application_states_request ->
+    ( list_application_states_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all the migration statuses for your applications. If you use the optional \
@@ -462,6 +646,20 @@ module ListCreatedArtifacts : sig
     'http_type Smaws_Lib.Context.t ->
     list_created_artifacts_request ->
     ( list_created_artifacts_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_created_artifacts_request ->
+    ( list_created_artifacts_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `HomeRegionNotSetException of home_region_not_set_exception
@@ -514,6 +712,20 @@ module ListDiscoveredResources : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_discovered_resources_request ->
+    ( list_discovered_resources_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Lists discovered resources associated with the given [MigrationTask].\n"]
 
@@ -532,6 +744,19 @@ module ListMigrationTaskUpdates : sig
     'http_type Smaws_Lib.Context.t ->
     list_migration_task_updates_request ->
     ( list_migration_task_updates_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_migration_task_updates_request ->
+    ( list_migration_task_updates_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerError of internal_server_error
@@ -562,6 +787,21 @@ module ListMigrationTasks : sig
     'http_type Smaws_Lib.Context.t ->
     list_migration_tasks_request ->
     ( list_migration_tasks_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `PolicyErrorException of policy_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_migration_tasks_request ->
+    ( list_migration_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `HomeRegionNotSetException of home_region_not_set_exception
@@ -613,6 +853,19 @@ module ListProgressUpdateStreams : sig
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_progress_update_streams_request ->
+    ( list_progress_update_streams_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
 end
 [@@ocaml.doc "Lists progress update streams associated with the user account making this call.\n"]
 
@@ -631,6 +884,19 @@ module ListSourceResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_source_resources_request ->
     ( list_source_resources_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_source_resources_request ->
+    ( list_source_resources_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerError of internal_server_error
@@ -663,6 +929,23 @@ module NotifyApplicationState : sig
     'http_type Smaws_Lib.Context.t ->
     notify_application_state_request ->
     ( notify_application_state_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `PolicyErrorException of policy_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    notify_application_state_request ->
+    ( notify_application_state_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation
@@ -711,6 +994,22 @@ module NotifyMigrationTaskState : sig
       | `ThrottlingException of throttling_exception
       | `UnauthorizedOperation of unauthorized_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    notify_migration_task_state_request ->
+    ( notify_migration_task_state_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
 end
 [@@ocaml.doc
   "Notifies Migration Hub of the current status, progress, or other detail regarding a migration \
@@ -748,6 +1047,22 @@ module PutResourceAttributes : sig
     'http_type Smaws_Lib.Context.t ->
     put_resource_attributes_request ->
     ( put_resource_attributes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `DryRunOperation of dry_run_operation
+      | `HomeRegionNotSetException of home_region_not_set_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInputException of invalid_input_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceUnavailableException of service_unavailable_exception
+      | `ThrottlingException of throttling_exception
+      | `UnauthorizedOperation of unauthorized_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_attributes_request ->
+    ( put_resource_attributes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `DryRunOperation of dry_run_operation

--- a/sdks/migration-hub/operations.mli
+++ b/sdks/migration-hub/operations.mli
@@ -43,7 +43,8 @@ module AssociateCreatedArtifact : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -112,7 +113,8 @@ module AssociateDiscoveredResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -158,7 +160,8 @@ module AssociateSourceResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -205,7 +208,8 @@ module CreateProgressUpdateStream : sig
       | `InvalidInputException of invalid_input_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -257,7 +261,8 @@ module DeleteProgressUpdateStream : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -329,7 +334,8 @@ module DescribeApplicationState : sig
       | `PolicyErrorException of policy_error_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the migration status of an application.\n"]
@@ -371,7 +377,8 @@ module DescribeMigrationTask : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a list of all attributes associated with a specific migration task.\n"]
@@ -419,7 +426,8 @@ module DisassociateCreatedArtifact : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -485,7 +493,8 @@ module DisassociateDiscoveredResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -531,7 +540,8 @@ module DisassociateSourceResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the association between a source resource and a migration task.\n"]
@@ -579,7 +589,8 @@ module ImportMigrationTask : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -623,7 +634,8 @@ module ListApplicationStates : sig
       | `InternalServerError of internal_server_error
       | `InvalidInputException of invalid_input_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -667,7 +679,8 @@ module ListCreatedArtifacts : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -724,7 +737,8 @@ module ListDiscoveredResources : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists discovered resources associated with the given [MigrationTask].\n"]
@@ -763,7 +777,8 @@ module ListMigrationTaskUpdates : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -810,7 +825,8 @@ module ListMigrationTasks : sig
       | `PolicyErrorException of policy_error_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -864,7 +880,8 @@ module ListProgressUpdateStreams : sig
       | `InternalServerError of internal_server_error
       | `InvalidInputException of invalid_input_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists progress update streams associated with the user account making this call.\n"]
@@ -903,7 +920,8 @@ module ListSourceResources : sig
       | `InvalidInputException of invalid_input_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
-      | `ThrottlingException of throttling_exception ] )
+      | `ThrottlingException of throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -956,7 +974,8 @@ module NotifyApplicationState : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1008,7 +1027,8 @@ module NotifyMigrationTaskState : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1072,7 +1092,8 @@ module PutResourceAttributes : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceUnavailableException of service_unavailable_exception
       | `ThrottlingException of throttling_exception
-      | `UnauthorizedOperation of unauthorized_operation ] )
+      | `UnauthorizedOperation of unauthorized_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/opensearchserverless/Smaws_Client_OpenSearchServerless.mli
+++ b/sdks/opensearchserverless/Smaws_Client_OpenSearchServerless.mli
@@ -904,7 +904,8 @@ module CreateAccessPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -945,7 +946,8 @@ module CreateCollection : sig
       | `InternalServerException of internal_server_exception
       | `OcuLimitExceededException of ocu_limit_exceeded_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -981,7 +983,8 @@ module CreateCollectionGroup : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1021,7 +1024,8 @@ module CreateIndex : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1059,7 +1063,8 @@ module CreateSecurityConfig : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1095,7 +1100,8 @@ module CreateVpcEndpoint : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1131,7 +1137,8 @@ module DeleteAccessPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1167,7 +1174,8 @@ module DeleteCollection : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1203,7 +1211,8 @@ module DeleteCollectionGroup : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1237,7 +1246,8 @@ module DeleteIndex : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1275,7 +1285,8 @@ module DeleteLifecyclePolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1311,7 +1322,8 @@ module DeleteSecurityConfig : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1347,7 +1359,8 @@ module DeleteSecurityPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an OpenSearch Serverless security policy.\n"]
@@ -1380,7 +1393,8 @@ module DeleteVpcEndpoint : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1413,7 +1427,8 @@ module GetAccessPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1446,7 +1461,8 @@ module GetIndex : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1481,7 +1497,8 @@ module GetSecurityConfig : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1515,7 +1532,8 @@ module GetSecurityPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1548,7 +1566,8 @@ module ListAccessPolicies : sig
     ( list_access_policies_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a list of OpenSearch Serverless access policies.\n"]
@@ -1575,7 +1594,8 @@ module ListCollectionGroups : sig
     ( list_collection_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1605,7 +1625,8 @@ module ListCollections : sig
     ( list_collections_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1639,7 +1660,8 @@ module ListLifecyclePolicies : sig
     ( list_lifecycle_policies_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1669,7 +1691,8 @@ module ListSecurityConfigs : sig
     ( list_security_configs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1700,7 +1723,8 @@ module ListSecurityPolicies : sig
     ( list_security_policies_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about configured OpenSearch Serverless security policies.\n"]
@@ -1727,7 +1751,8 @@ module ListVpcEndpoints : sig
     ( list_vpc_endpoints_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1758,7 +1783,8 @@ module BatchGetCollection : sig
     ( batch_get_collection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1789,7 +1815,8 @@ module BatchGetCollectionGroup : sig
     ( batch_get_collection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1820,7 +1847,8 @@ module BatchGetEffectiveLifecyclePolicy : sig
     ( batch_get_effective_lifecycle_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1851,7 +1879,8 @@ module BatchGetLifecyclePolicy : sig
     ( batch_get_lifecycle_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1882,7 +1911,8 @@ module BatchGetVpcEndpoint : sig
     ( batch_get_vpc_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1919,7 +1949,8 @@ module CreateLifecyclePolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1957,7 +1988,8 @@ module CreateSecurityPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1992,7 +2024,8 @@ module GetAccountSettings : sig
     ( get_account_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns account-level settings related to OpenSearch Serverless.\n"]
@@ -2015,7 +2048,7 @@ module GetPoliciesStats : sig
     get_policies_stats_request ->
     ( get_policies_stats_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerException of internal_server_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2047,7 +2080,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2086,7 +2120,8 @@ module TagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2122,7 +2157,8 @@ module UntagResource : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2158,7 +2194,8 @@ module UpdateAccessPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2191,7 +2228,8 @@ module UpdateAccountSettings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2225,7 +2263,8 @@ module UpdateCollection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an OpenSearch Serverless collection.\n"]
@@ -2258,7 +2297,8 @@ module UpdateCollectionGroup : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the description and capacity limits of a collection group.\n"]
@@ -2288,7 +2328,8 @@ module UpdateIndex : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2329,7 +2370,8 @@ module UpdateLifecyclePolicy : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2365,7 +2407,8 @@ module UpdateSecurityConfig : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2404,7 +2447,8 @@ module UpdateSecurityPolicy : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2440,7 +2484,8 @@ module UpdateVpcEndpoint : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/opensearchserverless/Smaws_Client_OpenSearchServerless.mli
+++ b/sdks/opensearchserverless/Smaws_Client_OpenSearchServerless.mli
@@ -895,6 +895,17 @@ module CreateAccessPolicy : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_access_policy_request ->
+    ( create_access_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a data access policy for OpenSearch Serverless. Access policies limit access to \
@@ -924,6 +935,18 @@ module CreateCollection : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_collection_request ->
+    ( create_collection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `OcuLimitExceededException of ocu_limit_exceeded_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new OpenSearch Serverless collection. For more information, see \
@@ -943,6 +966,17 @@ module CreateCollectionGroup : sig
     'http_type Smaws_Lib.Context.t ->
     create_collection_group_request ->
     ( create_collection_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_collection_group_request ->
+    ( create_collection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -978,6 +1012,17 @@ module CreateIndex : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_index_request ->
+    ( create_index_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an index within an OpenSearch Serverless collection. Unlike other OpenSearch indexes, \
@@ -999,6 +1044,17 @@ module CreateSecurityConfig : sig
     'http_type Smaws_Lib.Context.t ->
     create_security_config_request ->
     ( create_security_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_security_config_request ->
+    ( create_security_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -1030,6 +1086,17 @@ module CreateVpcEndpoint : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vpc_endpoint_request ->
+    ( create_vpc_endpoint_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an OpenSearch Serverless-managed interface VPC endpoint. For more information, see \
@@ -1049,6 +1116,17 @@ module DeleteAccessPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_access_policy_request ->
     ( delete_access_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_access_policy_request ->
+    ( delete_access_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -1080,6 +1158,17 @@ module DeleteCollection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_collection_request ->
+    ( delete_collection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an OpenSearch Serverless collection. For more information, see \
@@ -1105,6 +1194,17 @@ module DeleteCollectionGroup : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_collection_group_request ->
+    ( delete_collection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a collection group. You can only delete empty collection groups that contain no \
@@ -1124,6 +1224,16 @@ module DeleteIndex : sig
     'http_type Smaws_Lib.Context.t ->
     delete_index_request ->
     ( delete_index_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_index_request ->
+    ( delete_index_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1156,6 +1266,17 @@ module DeleteLifecyclePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_lifecycle_policy_request ->
+    ( delete_lifecycle_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an OpenSearch Serverless lifecycle policy. For more information, see \
@@ -1175,6 +1296,17 @@ module DeleteSecurityConfig : sig
     'http_type Smaws_Lib.Context.t ->
     delete_security_config_request ->
     ( delete_security_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_security_config_request ->
+    ( delete_security_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -1206,6 +1338,17 @@ module DeleteSecurityPolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_security_policy_request ->
+    ( delete_security_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes an OpenSearch Serverless security policy.\n"]
 
@@ -1222,6 +1365,17 @@ module DeleteVpcEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     delete_vpc_endpoint_request ->
     ( delete_vpc_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vpc_endpoint_request ->
+    ( delete_vpc_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -1251,6 +1405,16 @@ module GetAccessPolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_access_policy_request ->
+    ( get_access_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an OpenSearch Serverless access policy. For more information, see \
@@ -1269,6 +1433,16 @@ module GetIndex : sig
     'http_type Smaws_Lib.Context.t ->
     get_index_request ->
     ( get_index_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_index_request ->
+    ( get_index_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1299,6 +1473,16 @@ module GetSecurityConfig : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_security_config_request ->
+    ( get_security_config_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about an OpenSearch Serverless security configuration. For more \
@@ -1318,6 +1502,16 @@ module GetSecurityPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     get_security_policy_request ->
     ( get_security_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_security_policy_request ->
+    ( get_security_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1347,6 +1541,15 @@ module ListAccessPolicies : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_access_policies_request ->
+    ( list_access_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a list of OpenSearch Serverless access policies.\n"]
 
@@ -1361,6 +1564,15 @@ module ListCollectionGroups : sig
     'http_type Smaws_Lib.Context.t ->
     list_collection_groups_request ->
     ( list_collection_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_collection_groups_request ->
+    ( list_collection_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -1382,6 +1594,15 @@ module ListCollections : sig
     'http_type Smaws_Lib.Context.t ->
     list_collections_request ->
     ( list_collections_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_collections_request ->
+    ( list_collections_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -1411,6 +1632,15 @@ module ListLifecyclePolicies : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_lifecycle_policies_request ->
+    ( list_lifecycle_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of OpenSearch Serverless lifecycle policies. For more information, see \
@@ -1428,6 +1658,15 @@ module ListSecurityConfigs : sig
     'http_type Smaws_Lib.Context.t ->
     list_security_configs_request ->
     ( list_security_configs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_security_configs_request ->
+    ( list_security_configs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -1454,6 +1693,15 @@ module ListSecurityPolicies : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_security_policies_request ->
+    ( list_security_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about configured OpenSearch Serverless security policies.\n"]
 
@@ -1468,6 +1716,15 @@ module ListVpcEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     list_vpc_endpoints_request ->
     ( list_vpc_endpoints_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vpc_endpoints_request ->
+    ( list_vpc_endpoints_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -1494,6 +1751,15 @@ module BatchGetCollection : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_collection_request ->
+    ( batch_get_collection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns attributes for one or more collections, including the collection endpoint, the \
@@ -1512,6 +1778,15 @@ module BatchGetCollectionGroup : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_collection_group_request ->
     ( batch_get_collection_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_collection_group_request ->
+    ( batch_get_collection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -1538,6 +1813,15 @@ module BatchGetEffectiveLifecyclePolicy : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_effective_lifecycle_policy_request ->
+    ( batch_get_effective_lifecycle_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of successful and failed retrievals for the OpenSearch Serverless indexes. For \
@@ -1556,6 +1840,15 @@ module BatchGetLifecyclePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_lifecycle_policy_request ->
     ( batch_get_lifecycle_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_lifecycle_policy_request ->
+    ( batch_get_lifecycle_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -1582,6 +1875,15 @@ module BatchGetVpcEndpoint : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_vpc_endpoint_request ->
+    ( batch_get_vpc_endpoint_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns attributes for one or more VPC endpoints associated with the current account. For more \
@@ -1602,6 +1904,17 @@ module CreateLifecyclePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     create_lifecycle_policy_request ->
     ( create_lifecycle_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_lifecycle_policy_request ->
+    ( create_lifecycle_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -1635,6 +1948,17 @@ module CreateSecurityPolicy : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_security_policy_request ->
+    ( create_security_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a security policy to be used by one or more OpenSearch Serverless collections. Security \
@@ -1661,6 +1985,15 @@ module GetAccountSettings : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_account_settings_request ->
+    ( get_account_settings_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns account-level settings related to OpenSearch Serverless.\n"]
 
@@ -1673,6 +2006,14 @@ module GetPoliciesStats : sig
     'http_type Smaws_Lib.Context.t ->
     get_policies_stats_request ->
     ( get_policies_stats_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerException of internal_server_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_policies_stats_request ->
+    ( get_policies_stats_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerException of internal_server_exception ]
     )
     result
@@ -1693,6 +2034,16 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1725,6 +2076,18 @@ module TagResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates tags with an OpenSearch Serverless resource. For more information, see \
@@ -1744,6 +2107,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -1775,6 +2149,17 @@ module UpdateAccessPolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_access_policy_request ->
+    ( update_access_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an OpenSearch Serverless access policy. For more information, see \
@@ -1793,6 +2178,16 @@ module UpdateAccountSettings : sig
     'http_type Smaws_Lib.Context.t ->
     update_account_settings_request ->
     ( update_account_settings_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_account_settings_request ->
+    ( update_account_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
@@ -1822,6 +2217,16 @@ module UpdateCollection : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_collection_request ->
+    ( update_collection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates an OpenSearch Serverless collection.\n"]
 
@@ -1844,6 +2249,17 @@ module UpdateCollectionGroup : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_collection_group_request ->
+    ( update_collection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates the description and capacity limits of a collection group.\n"]
 
@@ -1859,6 +2275,16 @@ module UpdateIndex : sig
     'http_type Smaws_Lib.Context.t ->
     update_index_request ->
     ( update_index_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_index_request ->
+    ( update_index_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1893,6 +2319,18 @@ module UpdateLifecyclePolicy : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_lifecycle_policy_request ->
+    ( update_lifecycle_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an OpenSearch Serverless access policy. For more information, see \
@@ -1912,6 +2350,17 @@ module UpdateSecurityConfig : sig
     'http_type Smaws_Lib.Context.t ->
     update_security_config_request ->
     ( update_security_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_security_config_request ->
+    ( update_security_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -1945,6 +2394,18 @@ module UpdateSecurityPolicy : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_security_policy_request ->
+    ( update_security_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an OpenSearch Serverless security policy. For more information, see \
@@ -1966,6 +2427,16 @@ module UpdateVpcEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     update_vpc_endpoint_request ->
     ( update_vpc_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_vpc_endpoint_request ->
+    ( update_vpc_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception

--- a/sdks/opensearchserverless/operations.ml
+++ b/sdks/opensearchserverless/operations.ml
@@ -33,6 +33,13 @@ module CreateAccessPolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_access_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_access_policy_request) =
+    let input = Json_serializers.create_access_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.CreateAccessPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_access_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateCollection = struct
@@ -70,6 +77,13 @@ module CreateCollection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.CreateCollection" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_collection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_collection_request) =
+    let input = Json_serializers.create_collection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.CreateCollection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_collection_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateCollectionGroup = struct
@@ -104,6 +118,13 @@ module CreateCollectionGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_collection_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_collection_group_request) =
+    let input = Json_serializers.create_collection_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.CreateCollectionGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_collection_group_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateIndex = struct
@@ -136,6 +157,12 @@ module CreateIndex = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.CreateIndex" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_index_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_index_request) =
+    let input = Json_serializers.create_index_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"OpenSearchServerless.CreateIndex"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_index_response_of_yojson ~error_deserializer
 end
 
 module CreateSecurityConfig = struct
@@ -168,6 +195,13 @@ module CreateSecurityConfig = struct
     let input = Json_serializers.create_security_config_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.CreateSecurityConfig"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_security_config_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_security_config_request) =
+    let input = Json_serializers.create_security_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.CreateSecurityConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_security_config_response_of_yojson
       ~error_deserializer
 end
@@ -204,6 +238,13 @@ module CreateVpcEndpoint = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_vpc_endpoint_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_vpc_endpoint_request) =
+    let input = Json_serializers.create_vpc_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.CreateVpcEndpoint" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_vpc_endpoint_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteAccessPolicy = struct
@@ -235,6 +276,13 @@ module DeleteAccessPolicy = struct
     let input = Json_serializers.delete_access_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.DeleteAccessPolicy"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_access_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_access_policy_request) =
+    let input = Json_serializers.delete_access_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.DeleteAccessPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_access_policy_response_of_yojson
       ~error_deserializer
 end
@@ -269,6 +317,13 @@ module DeleteCollection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.DeleteCollection" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_collection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_collection_request) =
+    let input = Json_serializers.delete_collection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.DeleteCollection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_collection_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteCollectionGroup = struct
@@ -302,6 +357,13 @@ module DeleteCollectionGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_collection_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_collection_group_request) =
+    let input = Json_serializers.delete_collection_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.DeleteCollectionGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_collection_group_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteIndex = struct
@@ -331,6 +393,12 @@ module DeleteIndex = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.DeleteIndex" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_index_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_index_request) =
+    let input = Json_serializers.delete_index_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"OpenSearchServerless.DeleteIndex"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_index_response_of_yojson ~error_deserializer
 end
 
 module DeleteLifecyclePolicy = struct
@@ -362,6 +430,13 @@ module DeleteLifecyclePolicy = struct
     let input = Json_serializers.delete_lifecycle_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.DeleteLifecyclePolicy"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_lifecycle_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_lifecycle_policy_request) =
+    let input = Json_serializers.delete_lifecycle_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.DeleteLifecyclePolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_lifecycle_policy_response_of_yojson
       ~error_deserializer
 end
@@ -397,6 +472,13 @@ module DeleteSecurityConfig = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_security_config_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_security_config_request) =
+    let input = Json_serializers.delete_security_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.DeleteSecurityConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_security_config_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteSecurityPolicy = struct
@@ -428,6 +510,13 @@ module DeleteSecurityPolicy = struct
     let input = Json_serializers.delete_security_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.DeleteSecurityPolicy"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_security_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_security_policy_request) =
+    let input = Json_serializers.delete_security_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.DeleteSecurityPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_security_policy_response_of_yojson
       ~error_deserializer
 end
@@ -463,6 +552,13 @@ module DeleteVpcEndpoint = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_vpc_endpoint_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_vpc_endpoint_request) =
+    let input = Json_serializers.delete_vpc_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.DeleteVpcEndpoint" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_vpc_endpoint_response_of_yojson
+      ~error_deserializer
 end
 
 module GetAccessPolicy = struct
@@ -491,6 +587,13 @@ module GetAccessPolicy = struct
     let input = Json_serializers.get_access_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.GetAccessPolicy" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_access_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_access_policy_request) =
+    let input = Json_serializers.get_access_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.GetAccessPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_access_policy_response_of_yojson
       ~error_deserializer
 end
 
@@ -521,6 +624,12 @@ module GetIndex = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.GetIndex" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_index_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_index_request) =
+    let input = Json_serializers.get_index_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"OpenSearchServerless.GetIndex"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_index_response_of_yojson
+      ~error_deserializer
 end
 
 module GetSecurityConfig = struct
@@ -549,6 +658,13 @@ module GetSecurityConfig = struct
     let input = Json_serializers.get_security_config_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.GetSecurityConfig"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_security_config_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_security_config_request) =
+    let input = Json_serializers.get_security_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.GetSecurityConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_security_config_response_of_yojson
       ~error_deserializer
 end
@@ -581,6 +697,13 @@ module GetSecurityPolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_security_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_security_policy_request) =
+    let input = Json_serializers.get_security_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.GetSecurityPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_security_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAccessPolicies = struct
@@ -605,6 +728,13 @@ module ListAccessPolicies = struct
     let input = Json_serializers.list_access_policies_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.ListAccessPolicies"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_access_policies_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_access_policies_request) =
+    let input = Json_serializers.list_access_policies_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.ListAccessPolicies" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_access_policies_response_of_yojson
       ~error_deserializer
 end
@@ -633,6 +763,13 @@ module ListCollectionGroups = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_collection_groups_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_collection_groups_request) =
+    let input = Json_serializers.list_collection_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.ListCollectionGroups" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_collection_groups_response_of_yojson
+      ~error_deserializer
 end
 
 module ListCollections = struct
@@ -658,6 +795,13 @@ module ListCollections = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.ListCollections" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_collections_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_collections_request) =
+    let input = Json_serializers.list_collections_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.ListCollections" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_collections_response_of_yojson
+      ~error_deserializer
 end
 
 module ListLifecyclePolicies = struct
@@ -682,6 +826,13 @@ module ListLifecyclePolicies = struct
     let input = Json_serializers.list_lifecycle_policies_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.ListLifecyclePolicies"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_lifecycle_policies_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_lifecycle_policies_request) =
+    let input = Json_serializers.list_lifecycle_policies_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.ListLifecyclePolicies" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_lifecycle_policies_response_of_yojson
       ~error_deserializer
 end
@@ -710,6 +861,13 @@ module ListSecurityConfigs = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_security_configs_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_security_configs_request) =
+    let input = Json_serializers.list_security_configs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.ListSecurityConfigs" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_security_configs_response_of_yojson
+      ~error_deserializer
 end
 
 module ListSecurityPolicies = struct
@@ -734,6 +892,13 @@ module ListSecurityPolicies = struct
     let input = Json_serializers.list_security_policies_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.ListSecurityPolicies"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_security_policies_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_security_policies_request) =
+    let input = Json_serializers.list_security_policies_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.ListSecurityPolicies" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_security_policies_response_of_yojson
       ~error_deserializer
 end
@@ -761,6 +926,13 @@ module ListVpcEndpoints = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.ListVpcEndpoints" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_vpc_endpoints_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_vpc_endpoints_request) =
+    let input = Json_serializers.list_vpc_endpoints_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.ListVpcEndpoints" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_vpc_endpoints_response_of_yojson
+      ~error_deserializer
 end
 
 module BatchGetCollection = struct
@@ -785,6 +957,13 @@ module BatchGetCollection = struct
     let input = Json_serializers.batch_get_collection_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.BatchGetCollection"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_get_collection_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : batch_get_collection_request) =
+    let input = Json_serializers.batch_get_collection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.BatchGetCollection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_get_collection_response_of_yojson
       ~error_deserializer
 end
@@ -813,6 +992,13 @@ module BatchGetCollectionGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_get_collection_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_get_collection_group_request) =
+    let input = Json_serializers.batch_get_collection_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.BatchGetCollectionGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_get_collection_group_response_of_yojson
+      ~error_deserializer
 end
 
 module BatchGetEffectiveLifecyclePolicy = struct
@@ -836,6 +1022,14 @@ module BatchGetEffectiveLifecyclePolicy = struct
   let request context (request : batch_get_effective_lifecycle_policy_request) =
     let input = Json_serializers.batch_get_effective_lifecycle_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"OpenSearchServerless.BatchGetEffectiveLifecyclePolicy" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.batch_get_effective_lifecycle_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : batch_get_effective_lifecycle_policy_request) =
+    let input = Json_serializers.batch_get_effective_lifecycle_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"OpenSearchServerless.BatchGetEffectiveLifecyclePolicy" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.batch_get_effective_lifecycle_policy_response_of_yojson
@@ -866,6 +1060,13 @@ module BatchGetLifecyclePolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_get_lifecycle_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : batch_get_lifecycle_policy_request) =
+    let input = Json_serializers.batch_get_lifecycle_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.BatchGetLifecyclePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_get_lifecycle_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module BatchGetVpcEndpoint = struct
@@ -890,6 +1091,13 @@ module BatchGetVpcEndpoint = struct
     let input = Json_serializers.batch_get_vpc_endpoint_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.BatchGetVpcEndpoint"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.batch_get_vpc_endpoint_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : batch_get_vpc_endpoint_request) =
+    let input = Json_serializers.batch_get_vpc_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.BatchGetVpcEndpoint" ~service ~context ~input
       ~output_deserializer:Json_deserializers.batch_get_vpc_endpoint_response_of_yojson
       ~error_deserializer
 end
@@ -926,6 +1134,13 @@ module CreateLifecyclePolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_lifecycle_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_lifecycle_policy_request) =
+    let input = Json_serializers.create_lifecycle_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.CreateLifecyclePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_lifecycle_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateSecurityPolicy = struct
@@ -960,6 +1175,13 @@ module CreateSecurityPolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_security_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_security_policy_request) =
+    let input = Json_serializers.create_security_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.CreateSecurityPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_security_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module GetAccountSettings = struct
@@ -986,6 +1208,13 @@ module GetAccountSettings = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_account_settings_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_account_settings_request) =
+    let input = Json_serializers.get_account_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.GetAccountSettings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_account_settings_response_of_yojson
+      ~error_deserializer
 end
 
 module GetPoliciesStats = struct
@@ -1007,6 +1236,13 @@ module GetPoliciesStats = struct
     let input = Json_serializers.get_policies_stats_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.GetPoliciesStats" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_policies_stats_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_policies_stats_request) =
+    let input = Json_serializers.get_policies_stats_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.GetPoliciesStats" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_policies_stats_response_of_yojson
       ~error_deserializer
 end
 
@@ -1036,6 +1272,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.ListTagsForResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
 end
@@ -1075,6 +1318,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.TagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"OpenSearchServerless.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1107,6 +1356,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.UntagResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
 module UpdateAccessPolicy = struct
@@ -1140,6 +1395,13 @@ module UpdateAccessPolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_access_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_access_policy_request) =
+    let input = Json_serializers.update_access_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.UpdateAccessPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_access_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateAccountSettings = struct
@@ -1171,6 +1433,13 @@ module UpdateAccountSettings = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_account_settings_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_account_settings_request) =
+    let input = Json_serializers.update_account_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.UpdateAccountSettings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_account_settings_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateCollection = struct
@@ -1198,6 +1467,13 @@ module UpdateCollection = struct
     let input = Json_serializers.update_collection_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.UpdateCollection" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_collection_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_collection_request) =
+    let input = Json_serializers.update_collection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.UpdateCollection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_collection_response_of_yojson
       ~error_deserializer
 end
 
@@ -1233,6 +1509,13 @@ module UpdateCollectionGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_collection_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_collection_group_request) =
+    let input = Json_serializers.update_collection_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.UpdateCollectionGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_collection_group_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateIndex = struct
@@ -1262,6 +1545,12 @@ module UpdateIndex = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.UpdateIndex" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_index_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_index_request) =
+    let input = Json_serializers.update_index_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"OpenSearchServerless.UpdateIndex"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_index_response_of_yojson ~error_deserializer
 end
 
 module UpdateLifecyclePolicy = struct
@@ -1300,6 +1589,13 @@ module UpdateLifecyclePolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_lifecycle_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_lifecycle_policy_request) =
+    let input = Json_serializers.update_lifecycle_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.UpdateLifecyclePolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_lifecycle_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateSecurityConfig = struct
@@ -1331,6 +1627,13 @@ module UpdateSecurityConfig = struct
     let input = Json_serializers.update_security_config_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.UpdateSecurityConfig"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_security_config_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_security_config_request) =
+    let input = Json_serializers.update_security_config_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.UpdateSecurityConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_security_config_response_of_yojson
       ~error_deserializer
 end
@@ -1371,6 +1674,13 @@ module UpdateSecurityPolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_security_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_security_policy_request) =
+    let input = Json_serializers.update_security_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.UpdateSecurityPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_security_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateVpcEndpoint = struct
@@ -1398,6 +1708,13 @@ module UpdateVpcEndpoint = struct
     let input = Json_serializers.update_vpc_endpoint_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"OpenSearchServerless.UpdateVpcEndpoint"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_vpc_endpoint_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_vpc_endpoint_request) =
+    let input = Json_serializers.update_vpc_endpoint_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"OpenSearchServerless.UpdateVpcEndpoint" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_vpc_endpoint_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/opensearchserverless/operations.mli
+++ b/sdks/opensearchserverless/operations.mli
@@ -28,7 +28,8 @@ module CreateAccessPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -69,7 +70,8 @@ module CreateCollection : sig
       | `InternalServerException of internal_server_exception
       | `OcuLimitExceededException of ocu_limit_exceeded_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -105,7 +107,8 @@ module CreateCollectionGroup : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -145,7 +148,8 @@ module CreateIndex : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -183,7 +187,8 @@ module CreateSecurityConfig : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -219,7 +224,8 @@ module CreateVpcEndpoint : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -255,7 +261,8 @@ module DeleteAccessPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -291,7 +298,8 @@ module DeleteCollection : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -327,7 +335,8 @@ module DeleteCollectionGroup : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -361,7 +370,8 @@ module DeleteIndex : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -399,7 +409,8 @@ module DeleteLifecyclePolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -435,7 +446,8 @@ module DeleteSecurityConfig : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -471,7 +483,8 @@ module DeleteSecurityPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an OpenSearch Serverless security policy.\n"]
@@ -504,7 +517,8 @@ module DeleteVpcEndpoint : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -537,7 +551,8 @@ module GetAccessPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -570,7 +585,8 @@ module GetIndex : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -605,7 +621,8 @@ module GetSecurityConfig : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -639,7 +656,8 @@ module GetSecurityPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -672,7 +690,8 @@ module ListAccessPolicies : sig
     ( list_access_policies_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about a list of OpenSearch Serverless access policies.\n"]
@@ -699,7 +718,8 @@ module ListCollectionGroups : sig
     ( list_collection_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -729,7 +749,8 @@ module ListCollections : sig
     ( list_collections_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -763,7 +784,8 @@ module ListLifecyclePolicies : sig
     ( list_lifecycle_policies_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -793,7 +815,8 @@ module ListSecurityConfigs : sig
     ( list_security_configs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -824,7 +847,8 @@ module ListSecurityPolicies : sig
     ( list_security_policies_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns information about configured OpenSearch Serverless security policies.\n"]
@@ -851,7 +875,8 @@ module ListVpcEndpoints : sig
     ( list_vpc_endpoints_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -882,7 +907,8 @@ module BatchGetCollection : sig
     ( batch_get_collection_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -913,7 +939,8 @@ module BatchGetCollectionGroup : sig
     ( batch_get_collection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -944,7 +971,8 @@ module BatchGetEffectiveLifecyclePolicy : sig
     ( batch_get_effective_lifecycle_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -975,7 +1003,8 @@ module BatchGetLifecyclePolicy : sig
     ( batch_get_lifecycle_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1006,7 +1035,8 @@ module BatchGetVpcEndpoint : sig
     ( batch_get_vpc_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1043,7 +1073,8 @@ module CreateLifecyclePolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1081,7 +1112,8 @@ module CreateSecurityPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1116,7 +1148,8 @@ module GetAccountSettings : sig
     ( get_account_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns account-level settings related to OpenSearch Serverless.\n"]
@@ -1139,7 +1172,7 @@ module GetPoliciesStats : sig
     get_policies_stats_request ->
     ( get_policies_stats_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerException of internal_server_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1171,7 +1204,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1210,7 +1244,8 @@ module TagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1246,7 +1281,8 @@ module UntagResource : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1282,7 +1318,8 @@ module UpdateAccessPolicy : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1315,7 +1352,8 @@ module UpdateAccountSettings : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1349,7 +1387,8 @@ module UpdateCollection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an OpenSearch Serverless collection.\n"]
@@ -1382,7 +1421,8 @@ module UpdateCollectionGroup : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the description and capacity limits of a collection group.\n"]
@@ -1412,7 +1452,8 @@ module UpdateIndex : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1453,7 +1494,8 @@ module UpdateLifecyclePolicy : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1489,7 +1531,8 @@ module UpdateSecurityConfig : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1528,7 +1571,8 @@ module UpdateSecurityPolicy : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1563,7 +1607,8 @@ module UpdateVpcEndpoint : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/opensearchserverless/operations.mli
+++ b/sdks/opensearchserverless/operations.mli
@@ -19,6 +19,17 @@ module CreateAccessPolicy : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_access_policy_request ->
+    ( create_access_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a data access policy for OpenSearch Serverless. Access policies limit access to \
@@ -48,6 +59,18 @@ module CreateCollection : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_collection_request ->
+    ( create_collection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `OcuLimitExceededException of ocu_limit_exceeded_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new OpenSearch Serverless collection. For more information, see \
@@ -67,6 +90,17 @@ module CreateCollectionGroup : sig
     'http_type Smaws_Lib.Context.t ->
     create_collection_group_request ->
     ( create_collection_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_collection_group_request ->
+    ( create_collection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -102,6 +136,17 @@ module CreateIndex : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_index_request ->
+    ( create_index_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an index within an OpenSearch Serverless collection. Unlike other OpenSearch indexes, \
@@ -123,6 +168,17 @@ module CreateSecurityConfig : sig
     'http_type Smaws_Lib.Context.t ->
     create_security_config_request ->
     ( create_security_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_security_config_request ->
+    ( create_security_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -154,6 +210,17 @@ module CreateVpcEndpoint : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vpc_endpoint_request ->
+    ( create_vpc_endpoint_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an OpenSearch Serverless-managed interface VPC endpoint. For more information, see \
@@ -173,6 +240,17 @@ module DeleteAccessPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_access_policy_request ->
     ( delete_access_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_access_policy_request ->
+    ( delete_access_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -204,6 +282,17 @@ module DeleteCollection : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_collection_request ->
+    ( delete_collection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an OpenSearch Serverless collection. For more information, see \
@@ -229,6 +318,17 @@ module DeleteCollectionGroup : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_collection_group_request ->
+    ( delete_collection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a collection group. You can only delete empty collection groups that contain no \
@@ -248,6 +348,16 @@ module DeleteIndex : sig
     'http_type Smaws_Lib.Context.t ->
     delete_index_request ->
     ( delete_index_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_index_request ->
+    ( delete_index_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -280,6 +390,17 @@ module DeleteLifecyclePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_lifecycle_policy_request ->
+    ( delete_lifecycle_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an OpenSearch Serverless lifecycle policy. For more information, see \
@@ -299,6 +420,17 @@ module DeleteSecurityConfig : sig
     'http_type Smaws_Lib.Context.t ->
     delete_security_config_request ->
     ( delete_security_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_security_config_request ->
+    ( delete_security_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -330,6 +462,17 @@ module DeleteSecurityPolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_security_policy_request ->
+    ( delete_security_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes an OpenSearch Serverless security policy.\n"]
 
@@ -346,6 +489,17 @@ module DeleteVpcEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     delete_vpc_endpoint_request ->
     ( delete_vpc_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vpc_endpoint_request ->
+    ( delete_vpc_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -375,6 +529,16 @@ module GetAccessPolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_access_policy_request ->
+    ( get_access_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an OpenSearch Serverless access policy. For more information, see \
@@ -393,6 +557,16 @@ module GetIndex : sig
     'http_type Smaws_Lib.Context.t ->
     get_index_request ->
     ( get_index_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_index_request ->
+    ( get_index_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -423,6 +597,16 @@ module GetSecurityConfig : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_security_config_request ->
+    ( get_security_config_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about an OpenSearch Serverless security configuration. For more \
@@ -442,6 +626,16 @@ module GetSecurityPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     get_security_policy_request ->
     ( get_security_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_security_policy_request ->
+    ( get_security_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -471,6 +665,15 @@ module ListAccessPolicies : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_access_policies_request ->
+    ( list_access_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about a list of OpenSearch Serverless access policies.\n"]
 
@@ -485,6 +688,15 @@ module ListCollectionGroups : sig
     'http_type Smaws_Lib.Context.t ->
     list_collection_groups_request ->
     ( list_collection_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_collection_groups_request ->
+    ( list_collection_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -506,6 +718,15 @@ module ListCollections : sig
     'http_type Smaws_Lib.Context.t ->
     list_collections_request ->
     ( list_collections_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_collections_request ->
+    ( list_collections_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -535,6 +756,15 @@ module ListLifecyclePolicies : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_lifecycle_policies_request ->
+    ( list_lifecycle_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of OpenSearch Serverless lifecycle policies. For more information, see \
@@ -552,6 +782,15 @@ module ListSecurityConfigs : sig
     'http_type Smaws_Lib.Context.t ->
     list_security_configs_request ->
     ( list_security_configs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_security_configs_request ->
+    ( list_security_configs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -578,6 +817,15 @@ module ListSecurityPolicies : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_security_policies_request ->
+    ( list_security_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns information about configured OpenSearch Serverless security policies.\n"]
 
@@ -592,6 +840,15 @@ module ListVpcEndpoints : sig
     'http_type Smaws_Lib.Context.t ->
     list_vpc_endpoints_request ->
     ( list_vpc_endpoints_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vpc_endpoints_request ->
+    ( list_vpc_endpoints_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -618,6 +875,15 @@ module BatchGetCollection : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_collection_request ->
+    ( batch_get_collection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns attributes for one or more collections, including the collection endpoint, the \
@@ -636,6 +902,15 @@ module BatchGetCollectionGroup : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_collection_group_request ->
     ( batch_get_collection_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_collection_group_request ->
+    ( batch_get_collection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -662,6 +937,15 @@ module BatchGetEffectiveLifecyclePolicy : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_effective_lifecycle_policy_request ->
+    ( batch_get_effective_lifecycle_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of successful and failed retrievals for the OpenSearch Serverless indexes. For \
@@ -680,6 +964,15 @@ module BatchGetLifecyclePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     batch_get_lifecycle_policy_request ->
     ( batch_get_lifecycle_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_lifecycle_policy_request ->
+    ( batch_get_lifecycle_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
@@ -706,6 +999,15 @@ module BatchGetVpcEndpoint : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    batch_get_vpc_endpoint_request ->
+    ( batch_get_vpc_endpoint_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns attributes for one or more VPC endpoints associated with the current account. For more \
@@ -726,6 +1028,17 @@ module CreateLifecyclePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     create_lifecycle_policy_request ->
     ( create_lifecycle_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_lifecycle_policy_request ->
+    ( create_lifecycle_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -759,6 +1072,17 @@ module CreateSecurityPolicy : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_security_policy_request ->
+    ( create_security_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a security policy to be used by one or more OpenSearch Serverless collections. Security \
@@ -785,6 +1109,15 @@ module GetAccountSettings : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_account_settings_request ->
+    ( get_account_settings_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns account-level settings related to OpenSearch Serverless.\n"]
 
@@ -797,6 +1130,14 @@ module GetPoliciesStats : sig
     'http_type Smaws_Lib.Context.t ->
     get_policies_stats_request ->
     ( get_policies_stats_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerException of internal_server_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_policies_stats_request ->
+    ( get_policies_stats_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerException of internal_server_exception ]
     )
     result
@@ -817,6 +1158,16 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -849,6 +1200,18 @@ module TagResource : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates tags with an OpenSearch Serverless resource. For more information, see \
@@ -868,6 +1231,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -899,6 +1273,17 @@ module UpdateAccessPolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_access_policy_request ->
+    ( update_access_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an OpenSearch Serverless access policy. For more information, see \
@@ -917,6 +1302,16 @@ module UpdateAccountSettings : sig
     'http_type Smaws_Lib.Context.t ->
     update_account_settings_request ->
     ( update_account_settings_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_account_settings_request ->
+    ( update_account_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
@@ -946,6 +1341,16 @@ module UpdateCollection : sig
       | `InternalServerException of internal_server_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_collection_request ->
+    ( update_collection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates an OpenSearch Serverless collection.\n"]
 
@@ -968,6 +1373,17 @@ module UpdateCollectionGroup : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_collection_group_request ->
+    ( update_collection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates the description and capacity limits of a collection group.\n"]
 
@@ -983,6 +1399,16 @@ module UpdateIndex : sig
     'http_type Smaws_Lib.Context.t ->
     update_index_request ->
     ( update_index_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_index_request ->
+    ( update_index_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
@@ -1017,6 +1443,18 @@ module UpdateLifecyclePolicy : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_lifecycle_policy_request ->
+    ( update_lifecycle_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an OpenSearch Serverless access policy. For more information, see \
@@ -1036,6 +1474,17 @@ module UpdateSecurityConfig : sig
     'http_type Smaws_Lib.Context.t ->
     update_security_config_request ->
     ( update_security_config_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_security_config_request ->
+    ( update_security_config_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
@@ -1069,6 +1518,18 @@ module UpdateSecurityPolicy : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_security_policy_request ->
+    ( update_security_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an OpenSearch Serverless security policy. For more information, see \
@@ -1089,6 +1550,16 @@ module UpdateVpcEndpoint : sig
     'http_type Smaws_Lib.Context.t ->
     update_vpc_endpoint_request ->
     ( update_vpc_endpoint_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_vpc_endpoint_request ->
+    ( update_vpc_endpoint_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception

--- a/sdks/pi/Smaws_Client_PI.mli
+++ b/sdks/pi/Smaws_Client_PI.mli
@@ -319,6 +319,16 @@ module CreatePerformanceAnalysisReport : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_performance_analysis_report_request ->
+    ( create_performance_analysis_report_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new performance analysis report for a specific time period for the DB instance.\n"]
@@ -340,6 +350,16 @@ module DeletePerformanceAnalysisReport : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_performance_analysis_report_request ->
+    ( delete_performance_analysis_report_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a performance analysis report.\n"]
 
@@ -355,6 +375,16 @@ module DescribeDimensionKeys : sig
     'http_type Smaws_Lib.Context.t ->
     describe_dimension_keys_request ->
     ( describe_dimension_keys_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_dimension_keys_request ->
+    ( describe_dimension_keys_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -385,6 +415,16 @@ module GetDimensionKeyDetails : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_dimension_key_details_request ->
+    ( get_dimension_key_details_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Get the attributes of the specified dimension group for a DB instance or data source. For \
@@ -405,6 +445,16 @@ module GetPerformanceAnalysisReport : sig
     'http_type Smaws_Lib.Context.t ->
     get_performance_analysis_report_request ->
     ( get_performance_analysis_report_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_performance_analysis_report_request ->
+    ( get_performance_analysis_report_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -433,6 +483,16 @@ module GetResourceMetadata : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_metadata_request ->
+    ( get_resource_metadata_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieve the metadata for different features. For example, the metadata might indicate that a \
@@ -450,6 +510,16 @@ module GetResourceMetrics : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_metrics_request ->
     ( get_resource_metrics_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_metrics_request ->
+    ( get_resource_metrics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -482,6 +552,16 @@ module ListAvailableResourceDimensions : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_available_resource_dimensions_request ->
+    ( list_available_resource_dimensions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieve the dimensions that can be queried for each specified metric type on a specified DB \
@@ -499,6 +579,16 @@ module ListAvailableResourceMetrics : sig
     'http_type Smaws_Lib.Context.t ->
     list_available_resource_metrics_request ->
     ( list_available_resource_metrics_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_available_resource_metrics_request ->
+    ( list_available_resource_metrics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -525,6 +615,16 @@ module ListPerformanceAnalysisReportRecommendations : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_performance_analysis_report_recommendations_request ->
+    ( list_performance_analysis_report_recommendations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves recommendations for a performance analysis report.\n"]
 
@@ -540,6 +640,16 @@ module ListPerformanceAnalysisReports : sig
     'http_type Smaws_Lib.Context.t ->
     list_performance_analysis_reports_request ->
     ( list_performance_analysis_reports_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_performance_analysis_reports_request ->
+    ( list_performance_analysis_reports_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -567,6 +677,16 @@ module ListTagsForResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves all the metadata tags associated with Amazon RDS Performance Insights resource.\n"]
@@ -588,6 +708,16 @@ module TagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc "Adds metadata tags to the Amazon RDS Performance Insights resource.\n"]
 
@@ -604,6 +734,16 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception

--- a/sdks/pi/Smaws_Client_PI.mli
+++ b/sdks/pi/Smaws_Client_PI.mli
@@ -327,7 +327,8 @@ module CreatePerformanceAnalysisReport : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -358,7 +359,8 @@ module DeletePerformanceAnalysisReport : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a performance analysis report.\n"]
@@ -388,7 +390,8 @@ module DescribeDimensionKeys : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -423,7 +426,8 @@ module GetDimensionKeyDetails : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -458,7 +462,8 @@ module GetPerformanceAnalysisReport : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -491,7 +496,8 @@ module GetResourceMetadata : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -523,7 +529,8 @@ module GetResourceMetrics : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -560,7 +567,8 @@ module ListAvailableResourceDimensions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -592,7 +600,8 @@ module ListAvailableResourceMetrics : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -623,7 +632,8 @@ module ListPerformanceAnalysisReportRecommendations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves recommendations for a performance analysis report.\n"]
@@ -653,7 +663,8 @@ module ListPerformanceAnalysisReports : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -685,7 +696,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -716,7 +728,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds metadata tags to the Amazon RDS Performance Insights resource.\n"]
@@ -747,7 +760,8 @@ module UntagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the metadata tags from the Amazon RDS Performance Insights resource.\n"]

--- a/sdks/pi/operations.ml
+++ b/sdks/pi/operations.ml
@@ -29,6 +29,14 @@ module CreatePerformanceAnalysisReport = struct
       ~input
       ~output_deserializer:Json_deserializers.create_performance_analysis_report_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_performance_analysis_report_request) =
+    let input = Json_serializers.create_performance_analysis_report_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"PerformanceInsightsv20180227.CreatePerformanceAnalysisReport" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.create_performance_analysis_report_response_of_yojson
+      ~error_deserializer
 end
 
 module DeletePerformanceAnalysisReport = struct
@@ -55,6 +63,14 @@ module DeletePerformanceAnalysisReport = struct
   let request context (request : delete_performance_analysis_report_request) =
     let input = Json_serializers.delete_performance_analysis_report_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"PerformanceInsightsv20180227.DeletePerformanceAnalysisReport" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.delete_performance_analysis_report_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_performance_analysis_report_request) =
+    let input = Json_serializers.delete_performance_analysis_report_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"PerformanceInsightsv20180227.DeletePerformanceAnalysisReport" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.delete_performance_analysis_report_response_of_yojson
@@ -88,6 +104,13 @@ module DescribeDimensionKeys = struct
       ~shape_name:"PerformanceInsightsv20180227.DescribeDimensionKeys" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_dimension_keys_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_dimension_keys_request) =
+    let input = Json_serializers.describe_dimension_keys_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"PerformanceInsightsv20180227.DescribeDimensionKeys" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_dimension_keys_response_of_yojson
+      ~error_deserializer
 end
 
 module GetDimensionKeyDetails = struct
@@ -114,6 +137,13 @@ module GetDimensionKeyDetails = struct
   let request context (request : get_dimension_key_details_request) =
     let input = Json_serializers.get_dimension_key_details_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"PerformanceInsightsv20180227.GetDimensionKeyDetails" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_dimension_key_details_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_dimension_key_details_request) =
+    let input = Json_serializers.get_dimension_key_details_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"PerformanceInsightsv20180227.GetDimensionKeyDetails" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_dimension_key_details_response_of_yojson
       ~error_deserializer
@@ -147,6 +177,14 @@ module GetPerformanceAnalysisReport = struct
       ~input
       ~output_deserializer:Json_deserializers.get_performance_analysis_report_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_performance_analysis_report_request) =
+    let input = Json_serializers.get_performance_analysis_report_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"PerformanceInsightsv20180227.GetPerformanceAnalysisReport" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.get_performance_analysis_report_response_of_yojson
+      ~error_deserializer
 end
 
 module GetResourceMetadata = struct
@@ -176,6 +214,13 @@ module GetResourceMetadata = struct
       ~shape_name:"PerformanceInsightsv20180227.GetResourceMetadata" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_resource_metadata_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_metadata_request) =
+    let input = Json_serializers.get_resource_metadata_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"PerformanceInsightsv20180227.GetResourceMetadata" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_metadata_response_of_yojson
+      ~error_deserializer
 end
 
 module GetResourceMetrics = struct
@@ -202,6 +247,13 @@ module GetResourceMetrics = struct
   let request context (request : get_resource_metrics_request) =
     let input = Json_serializers.get_resource_metrics_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"PerformanceInsightsv20180227.GetResourceMetrics" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_metrics_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_metrics_request) =
+    let input = Json_serializers.get_resource_metrics_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"PerformanceInsightsv20180227.GetResourceMetrics" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_resource_metrics_response_of_yojson
       ~error_deserializer
@@ -235,6 +287,14 @@ module ListAvailableResourceDimensions = struct
       ~input
       ~output_deserializer:Json_deserializers.list_available_resource_dimensions_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_available_resource_dimensions_request) =
+    let input = Json_serializers.list_available_resource_dimensions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"PerformanceInsightsv20180227.ListAvailableResourceDimensions" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.list_available_resource_dimensions_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAvailableResourceMetrics = struct
@@ -261,6 +321,14 @@ module ListAvailableResourceMetrics = struct
   let request context (request : list_available_resource_metrics_request) =
     let input = Json_serializers.list_available_resource_metrics_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"PerformanceInsightsv20180227.ListAvailableResourceMetrics" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.list_available_resource_metrics_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_available_resource_metrics_request) =
+    let input = Json_serializers.list_available_resource_metrics_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"PerformanceInsightsv20180227.ListAvailableResourceMetrics" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.list_available_resource_metrics_response_of_yojson
@@ -298,6 +366,18 @@ module ListPerformanceAnalysisReportRecommendations = struct
       ~output_deserializer:
         Json_deserializers.list_performance_analysis_report_recommendations_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : list_performance_analysis_report_recommendations_request) =
+    let input =
+      Json_serializers.list_performance_analysis_report_recommendations_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"PerformanceInsightsv20180227.ListPerformanceAnalysisReportRecommendations"
+      ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.list_performance_analysis_report_recommendations_response_of_yojson
+      ~error_deserializer
 end
 
 module ListPerformanceAnalysisReports = struct
@@ -324,6 +404,14 @@ module ListPerformanceAnalysisReports = struct
   let request context (request : list_performance_analysis_reports_request) =
     let input = Json_serializers.list_performance_analysis_reports_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"PerformanceInsightsv20180227.ListPerformanceAnalysisReports" ~service ~context
+      ~input
+      ~output_deserializer:Json_deserializers.list_performance_analysis_reports_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_performance_analysis_reports_request) =
+    let input = Json_serializers.list_performance_analysis_reports_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"PerformanceInsightsv20180227.ListPerformanceAnalysisReports" ~service ~context
       ~input
       ~output_deserializer:Json_deserializers.list_performance_analysis_reports_response_of_yojson
@@ -357,6 +445,13 @@ module ListTagsForResource = struct
       ~shape_name:"PerformanceInsightsv20180227.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"PerformanceInsightsv20180227.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -385,6 +480,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"PerformanceInsightsv20180227.TagResource"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"PerformanceInsightsv20180227.TagResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -412,5 +513,11 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"PerformanceInsightsv20180227.UntagResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"PerformanceInsightsv20180227.UntagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end

--- a/sdks/pi/operations.mli
+++ b/sdks/pi/operations.mli
@@ -17,6 +17,16 @@ module CreatePerformanceAnalysisReport : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_performance_analysis_report_request ->
+    ( create_performance_analysis_report_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new performance analysis report for a specific time period for the DB instance.\n"]
@@ -38,6 +48,16 @@ module DeletePerformanceAnalysisReport : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_performance_analysis_report_request ->
+    ( delete_performance_analysis_report_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a performance analysis report.\n"]
 
@@ -53,6 +73,16 @@ module DescribeDimensionKeys : sig
     'http_type Smaws_Lib.Context.t ->
     describe_dimension_keys_request ->
     ( describe_dimension_keys_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_dimension_keys_request ->
+    ( describe_dimension_keys_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -83,6 +113,16 @@ module GetDimensionKeyDetails : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_dimension_key_details_request ->
+    ( get_dimension_key_details_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Get the attributes of the specified dimension group for a DB instance or data source. For \
@@ -103,6 +143,16 @@ module GetPerformanceAnalysisReport : sig
     'http_type Smaws_Lib.Context.t ->
     get_performance_analysis_report_request ->
     ( get_performance_analysis_report_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_performance_analysis_report_request ->
+    ( get_performance_analysis_report_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -131,6 +181,16 @@ module GetResourceMetadata : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_metadata_request ->
+    ( get_resource_metadata_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieve the metadata for different features. For example, the metadata might indicate that a \
@@ -148,6 +208,16 @@ module GetResourceMetrics : sig
     'http_type Smaws_Lib.Context.t ->
     get_resource_metrics_request ->
     ( get_resource_metrics_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_metrics_request ->
+    ( get_resource_metrics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -180,6 +250,16 @@ module ListAvailableResourceDimensions : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_available_resource_dimensions_request ->
+    ( list_available_resource_dimensions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieve the dimensions that can be queried for each specified metric type on a specified DB \
@@ -197,6 +277,16 @@ module ListAvailableResourceMetrics : sig
     'http_type Smaws_Lib.Context.t ->
     list_available_resource_metrics_request ->
     ( list_available_resource_metrics_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_available_resource_metrics_request ->
+    ( list_available_resource_metrics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -223,6 +313,16 @@ module ListPerformanceAnalysisReportRecommendations : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_performance_analysis_report_recommendations_request ->
+    ( list_performance_analysis_report_recommendations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves recommendations for a performance analysis report.\n"]
 
@@ -238,6 +338,16 @@ module ListPerformanceAnalysisReports : sig
     'http_type Smaws_Lib.Context.t ->
     list_performance_analysis_reports_request ->
     ( list_performance_analysis_reports_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_performance_analysis_reports_request ->
+    ( list_performance_analysis_reports_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
@@ -265,6 +375,16 @@ module ListTagsForResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves all the metadata tags associated with Amazon RDS Performance Insights resource.\n"]
@@ -286,6 +406,16 @@ module TagResource : sig
       | `InvalidArgumentException of invalid_argument_exception
       | `NotAuthorizedException of not_authorized_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
 end
 [@@ocaml.doc "Adds metadata tags to the Amazon RDS Performance Insights resource.\n"]
 
@@ -301,6 +431,16 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceError of internal_service_error
+      | `InvalidArgumentException of invalid_argument_exception
+      | `NotAuthorizedException of not_authorized_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception

--- a/sdks/pi/operations.mli
+++ b/sdks/pi/operations.mli
@@ -25,7 +25,8 @@ module CreatePerformanceAnalysisReport : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -56,7 +57,8 @@ module DeletePerformanceAnalysisReport : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a performance analysis report.\n"]
@@ -86,7 +88,8 @@ module DescribeDimensionKeys : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -121,7 +124,8 @@ module GetDimensionKeyDetails : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -156,7 +160,8 @@ module GetPerformanceAnalysisReport : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -189,7 +194,8 @@ module GetResourceMetadata : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -221,7 +227,8 @@ module GetResourceMetrics : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -258,7 +265,8 @@ module ListAvailableResourceDimensions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -290,7 +298,8 @@ module ListAvailableResourceMetrics : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -321,7 +330,8 @@ module ListPerformanceAnalysisReportRecommendations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves recommendations for a performance analysis report.\n"]
@@ -351,7 +361,8 @@ module ListPerformanceAnalysisReports : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -383,7 +394,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -414,7 +426,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds metadata tags to the Amazon RDS Performance Insights resource.\n"]
@@ -444,7 +457,8 @@ module UntagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceError of internal_service_error
       | `InvalidArgumentException of invalid_argument_exception
-      | `NotAuthorizedException of not_authorized_exception ] )
+      | `NotAuthorizedException of not_authorized_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the metadata tags from the Amazon RDS Performance Insights resource.\n"]

--- a/sdks/proton/Smaws_Client_Proton.mli
+++ b/sdks/proton/Smaws_Client_Proton.mli
@@ -1488,6 +1488,19 @@ module AcceptEnvironmentAccountConnection : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_environment_account_connection_input ->
+    ( accept_environment_account_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "In a management account, an environment account connection request is accepted. When the \
@@ -1521,6 +1534,19 @@ module CancelComponentDeployment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_component_deployment_input ->
+    ( cancel_component_deployment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attempts to cancel a component deployment (for a component that is in the [IN_PROGRESS] \
@@ -1545,6 +1571,19 @@ module CancelEnvironmentDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_environment_deployment_input ->
     ( cancel_environment_deployment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_environment_deployment_input ->
+    ( cancel_environment_deployment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1599,6 +1638,19 @@ module CancelServiceInstanceDeployment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_service_instance_deployment_input ->
+    ( cancel_service_instance_deployment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attempts to cancel a service instance deployment on an [UpdateServiceInstance] action, if the \
@@ -1637,6 +1689,19 @@ module CancelServicePipelineDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_service_pipeline_deployment_input ->
     ( cancel_service_pipeline_deployment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_service_pipeline_deployment_input ->
+    ( cancel_service_pipeline_deployment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1693,6 +1758,20 @@ module CreateComponent : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_component_input ->
+    ( create_component_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an Proton component. A component is an infrastructure extension for a service instance.\n\n\
@@ -1717,6 +1796,20 @@ module CreateEnvironment : sig
     'http_type Smaws_Lib.Context.t ->
     create_environment_input ->
     ( create_environment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_environment_input ->
+    ( create_environment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1771,6 +1864,19 @@ module CreateEnvironmentAccountConnection : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_environment_account_connection_input ->
+    ( create_environment_account_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an environment account connection in an environment account so that environment \
@@ -1798,6 +1904,19 @@ module CreateEnvironmentTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     create_environment_template_input ->
     ( create_environment_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_environment_template_input ->
+    ( create_environment_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1855,6 +1974,20 @@ module CreateEnvironmentTemplateVersion : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_environment_template_version_input ->
+    ( create_environment_template_version_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create a new major or minor version of an environment template. A major version of an \
@@ -1876,6 +2009,19 @@ module CreateRepository : sig
     'http_type Smaws_Lib.Context.t ->
     create_repository_input ->
     ( create_repository_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_repository_input ->
+    ( create_repository_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1927,6 +2073,20 @@ module CreateService : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_input ->
+    ( create_service_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an Proton service. An Proton service is an instantiation of a service template and often \
@@ -1949,6 +2109,19 @@ module CreateServiceInstance : sig
     'http_type Smaws_Lib.Context.t ->
     create_service_instance_input ->
     ( create_service_instance_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_instance_input ->
+    ( create_service_instance_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -1983,6 +2156,19 @@ module CreateServiceSyncConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_sync_config_input ->
+    ( create_service_sync_config_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Create the Proton Ops configuration file.\n"]
 
@@ -2001,6 +2187,19 @@ module CreateServiceTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     create_service_template_input ->
     ( create_service_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_template_input ->
+    ( create_service_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2044,6 +2243,20 @@ module CreateServiceTemplateVersion : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_template_version_input ->
+    ( create_service_template_version_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create a new major or minor version of a service template. A major version of a service \
@@ -2065,6 +2278,19 @@ module CreateTemplateSyncConfig : sig
     'http_type Smaws_Lib.Context.t ->
     create_template_sync_config_input ->
     ( create_template_sync_config_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_template_sync_config_input ->
+    ( create_template_sync_config_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2109,6 +2335,19 @@ module DeleteComponent : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_component_input ->
+    ( delete_component_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Delete an Proton component resource.\n\n\
@@ -2131,6 +2370,18 @@ module DeleteDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     delete_deployment_input ->
     ( delete_deployment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_deployment_input ->
+    ( delete_deployment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2164,6 +2415,19 @@ module DeleteEnvironment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_environment_input ->
+    ( delete_environment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Delete an environment.\n"]
 
@@ -2182,6 +2446,19 @@ module DeleteEnvironmentAccountConnection : sig
     'http_type Smaws_Lib.Context.t ->
     delete_environment_account_connection_input ->
     ( delete_environment_account_connection_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_environment_account_connection_input ->
+    ( delete_environment_account_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2227,6 +2504,19 @@ module DeleteEnvironmentTemplate : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_environment_template_input ->
+    ( delete_environment_template_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "If no other major or minor versions of an environment template exist, delete the environment \
@@ -2247,6 +2537,19 @@ module DeleteEnvironmentTemplateVersion : sig
     'http_type Smaws_Lib.Context.t ->
     delete_environment_template_version_input ->
     ( delete_environment_template_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_environment_template_version_input ->
+    ( delete_environment_template_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2291,6 +2594,19 @@ module DeleteRepository : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_repository_input ->
+    ( delete_repository_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "De-register and unlink your repository.\n"]
 
@@ -2309,6 +2625,19 @@ module DeleteService : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_input ->
     ( delete_service_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_input ->
+    ( delete_service_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2352,6 +2681,19 @@ module DeleteServiceSyncConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_sync_config_input ->
+    ( delete_service_sync_config_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Delete the Proton Ops file.\n"]
 
@@ -2370,6 +2712,19 @@ module DeleteServiceTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_template_input ->
     ( delete_service_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_template_input ->
+    ( delete_service_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2397,6 +2752,19 @@ module DeleteServiceTemplateVersion : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_template_version_input ->
     ( delete_service_template_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_template_version_input ->
+    ( delete_service_template_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2439,6 +2807,19 @@ module DeleteTemplateSyncConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_template_sync_config_input ->
+    ( delete_template_sync_config_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Delete a template sync configuration.\n"]
 
@@ -2463,6 +2844,18 @@ module GetAccountSettings : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_account_settings_input ->
+    ( get_account_settings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detail data for Proton account-wide settings.\n"]
 
@@ -2480,6 +2873,18 @@ module GetComponent : sig
     'http_type Smaws_Lib.Context.t ->
     get_component_input ->
     ( get_component_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_component_input ->
+    ( get_component_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2516,6 +2921,18 @@ module GetDeployment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_deployment_input ->
+    ( get_deployment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for a deployment.\n"]
 
@@ -2540,6 +2957,18 @@ module GetEnvironment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_environment_input ->
+    ( get_environment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for an environment.\n"]
 
@@ -2557,6 +2986,18 @@ module GetEnvironmentAccountConnection : sig
     'http_type Smaws_Lib.Context.t ->
     get_environment_account_connection_input ->
     ( get_environment_account_connection_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_environment_account_connection_input ->
+    ( get_environment_account_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2593,6 +3034,18 @@ module GetEnvironmentTemplate : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_environment_template_input ->
+    ( get_environment_template_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for an environment template.\n"]
 
@@ -2610,6 +3063,18 @@ module GetEnvironmentTemplateVersion : sig
     'http_type Smaws_Lib.Context.t ->
     get_environment_template_version_input ->
     ( get_environment_template_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_environment_template_version_input ->
+    ( get_environment_template_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2641,6 +3106,18 @@ module GetRepository : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_repository_input ->
+    ( get_repository_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detail data for a linked repository.\n"]
 
@@ -2658,6 +3135,18 @@ module GetRepositorySyncStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_repository_sync_status_input ->
     ( get_repository_sync_status_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_repository_sync_status_input ->
+    ( get_repository_sync_status_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2693,6 +3182,17 @@ module GetResourcesSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_resources_summary_input ->
     ( get_resources_summary_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resources_summary_input ->
+    ( get_resources_summary_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2742,6 +3242,18 @@ module GetService : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_input ->
+    ( get_service_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for a service.\n"]
 
@@ -2759,6 +3271,18 @@ module GetServiceInstance : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_instance_input ->
     ( get_service_instance_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_instance_input ->
+    ( get_service_instance_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2792,6 +3316,18 @@ module GetServiceInstanceSyncStatus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_instance_sync_status_input ->
+    ( get_service_instance_sync_status_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get the status of the synced service instance.\n"]
 
@@ -2809,6 +3345,18 @@ module GetServiceSyncBlockerSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_sync_blocker_summary_input ->
     ( get_service_sync_blocker_summary_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_sync_blocker_summary_input ->
+    ( get_service_sync_blocker_summary_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2840,6 +3388,18 @@ module GetServiceSyncConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_sync_config_input ->
+    ( get_service_sync_config_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed information for the service sync configuration.\n"]
 
@@ -2857,6 +3417,18 @@ module GetServiceTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_template_input ->
     ( get_service_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_template_input ->
+    ( get_service_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2888,6 +3460,18 @@ module GetServiceTemplateVersion : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_template_version_input ->
+    ( get_service_template_version_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for a major or minor version of a service template.\n"]
 
@@ -2905,6 +3489,18 @@ module GetTemplateSyncConfig : sig
     'http_type Smaws_Lib.Context.t ->
     get_template_sync_config_input ->
     ( get_template_sync_config_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_template_sync_config_input ->
+    ( get_template_sync_config_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2936,6 +3532,18 @@ module GetTemplateSyncStatus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_template_sync_status_input ->
+    ( get_template_sync_status_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get the status of a template sync.\n"]
 
@@ -2953,6 +3561,18 @@ module ListComponentOutputs : sig
     'http_type Smaws_Lib.Context.t ->
     list_component_outputs_input ->
     ( list_component_outputs_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_component_outputs_input ->
+    ( list_component_outputs_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2989,6 +3609,18 @@ module ListComponentProvisionedResources : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_component_provisioned_resources_input ->
+    ( list_component_provisioned_resources_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "List provisioned resources for a component with details.\n\n\
@@ -3010,6 +3642,17 @@ module ListComponents : sig
     'http_type Smaws_Lib.Context.t ->
     list_components_input ->
     ( list_components_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_components_input ->
+    ( list_components_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3046,6 +3689,18 @@ module ListDeployments : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_deployments_input ->
+    ( list_deployments_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "List deployments. You can filter the result list by environment, service, or a single service \
@@ -3064,6 +3719,17 @@ module ListEnvironmentAccountConnections : sig
     'http_type Smaws_Lib.Context.t ->
     list_environment_account_connections_input ->
     ( list_environment_account_connections_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_account_connections_input ->
+    ( list_environment_account_connections_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3099,6 +3765,18 @@ module ListEnvironmentOutputs : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_outputs_input ->
+    ( list_environment_outputs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List the infrastructure as code outputs for your environment.\n"]
 
@@ -3116,6 +3794,18 @@ module ListEnvironmentProvisionedResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_environment_provisioned_resources_input ->
     ( list_environment_provisioned_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_provisioned_resources_input ->
+    ( list_environment_provisioned_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3147,6 +3837,18 @@ module ListEnvironmentTemplateVersions : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_template_versions_input ->
+    ( list_environment_template_versions_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List major or minor versions of an environment template with detail data.\n"]
 
@@ -3163,6 +3865,17 @@ module ListEnvironmentTemplates : sig
     'http_type Smaws_Lib.Context.t ->
     list_environment_templates_input ->
     ( list_environment_templates_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_templates_input ->
+    ( list_environment_templates_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3186,6 +3899,18 @@ module ListEnvironments : sig
     'http_type Smaws_Lib.Context.t ->
     list_environments_input ->
     ( list_environments_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environments_input ->
+    ( list_environments_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3217,6 +3942,18 @@ module ListRepositories : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_repositories_input ->
+    ( list_repositories_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List linked repositories with detail data.\n"]
 
@@ -3233,6 +3970,17 @@ module ListRepositorySyncDefinitions : sig
     'http_type Smaws_Lib.Context.t ->
     list_repository_sync_definitions_input ->
     ( list_repository_sync_definitions_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_repository_sync_definitions_input ->
+    ( list_repository_sync_definitions_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3256,6 +4004,18 @@ module ListServiceInstanceOutputs : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_instance_outputs_input ->
     ( list_service_instance_outputs_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_instance_outputs_input ->
+    ( list_service_instance_outputs_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3287,6 +4047,18 @@ module ListServiceInstanceProvisionedResources : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_instance_provisioned_resources_input ->
+    ( list_service_instance_provisioned_resources_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List provisioned resources for a service instance with details.\n"]
 
@@ -3304,6 +4076,18 @@ module ListServiceInstances : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_instances_input ->
     ( list_service_instances_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_instances_input ->
+    ( list_service_instances_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3337,6 +4121,18 @@ module ListServicePipelineOutputs : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_pipeline_outputs_input ->
+    ( list_service_pipeline_outputs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get a list of service pipeline Infrastructure as Code (IaC) outputs.\n"]
 
@@ -3354,6 +4150,18 @@ module ListServicePipelineProvisionedResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_pipeline_provisioned_resources_input ->
     ( list_service_pipeline_provisioned_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_pipeline_provisioned_resources_input ->
+    ( list_service_pipeline_provisioned_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3385,6 +4193,18 @@ module ListServiceTemplateVersions : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_template_versions_input ->
+    ( list_service_template_versions_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List major or minor versions of a service template with detail data.\n"]
 
@@ -3401,6 +4221,17 @@ module ListServiceTemplates : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_templates_input ->
     ( list_service_templates_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_templates_input ->
+    ( list_service_templates_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3429,6 +4260,17 @@ module ListServices : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_services_input ->
+    ( list_services_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List services with summaries of detail data.\n"]
 
@@ -3446,6 +4288,18 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_input ->
     ( list_tags_for_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -3484,6 +4338,20 @@ module NotifyResourceDeploymentStatusChange : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    notify_resource_deployment_status_change_input ->
+    ( notify_resource_deployment_status_change_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Notify Proton of status changes to a provisioned resource when you use self-managed \
@@ -3508,6 +4376,19 @@ module RejectEnvironmentAccountConnection : sig
     'http_type Smaws_Lib.Context.t ->
     reject_environment_account_connection_input ->
     ( reject_environment_account_connection_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reject_environment_account_connection_input ->
+    ( reject_environment_account_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3554,6 +4435,19 @@ module TagResource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Tag a resource. A tag is a key-value pair of metadata that you associate with an Proton \
@@ -3578,6 +4472,19 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_input ->
     ( untag_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3616,6 +4523,18 @@ module UpdateAccountSettings : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_account_settings_input ->
+    ( update_account_settings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Update Proton settings that are used for multiple services in the Amazon Web Services account.\n"]
@@ -3636,6 +4555,20 @@ module UpdateComponent : sig
     'http_type Smaws_Lib.Context.t ->
     update_component_input ->
     ( update_component_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_component_input ->
+    ( update_component_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3673,6 +4606,19 @@ module UpdateEnvironment : sig
     'http_type Smaws_Lib.Context.t ->
     update_environment_input ->
     ( update_environment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_environment_input ->
+    ( update_environment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3764,6 +4710,19 @@ module UpdateEnvironmentAccountConnection : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_environment_account_connection_input ->
+    ( update_environment_account_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "In an environment account, update an environment account connection to use a new IAM role.\n\n\
@@ -3787,6 +4746,19 @@ module UpdateEnvironmentTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     update_environment_template_input ->
     ( update_environment_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_environment_template_input ->
+    ( update_environment_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3821,6 +4793,19 @@ module UpdateEnvironmentTemplateVersion : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_environment_template_version_input ->
+    ( update_environment_template_version_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Update a major or minor version of an environment template.\n"]
 
@@ -3840,6 +4825,20 @@ module UpdateService : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_input ->
     ( update_service_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_input ->
+    ( update_service_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3891,6 +4890,19 @@ module UpdateServiceInstance : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_instance_input ->
+    ( update_service_instance_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Update a service instance.\n\n\
@@ -3921,6 +4933,19 @@ module UpdateServicePipeline : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_pipeline_input ->
     ( update_service_pipeline_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_pipeline_input ->
+    ( update_service_pipeline_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -3984,6 +5009,19 @@ module UpdateServiceSyncBlocker : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_sync_blocker_input ->
+    ( update_service_sync_blocker_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Update the service sync blocker by resolving it.\n"]
 
@@ -4002,6 +5040,19 @@ module UpdateServiceSyncConfig : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_sync_config_input ->
     ( update_service_sync_config_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_sync_config_input ->
+    ( update_service_sync_config_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -4036,6 +5087,19 @@ module UpdateServiceTemplate : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_template_input ->
+    ( update_service_template_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Update a service template.\n"]
 
@@ -4054,6 +5118,19 @@ module UpdateServiceTemplateVersion : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_template_version_input ->
     ( update_service_template_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_template_version_input ->
+    ( update_service_template_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -4081,6 +5158,19 @@ module UpdateTemplateSyncConfig : sig
     'http_type Smaws_Lib.Context.t ->
     update_template_sync_config_input ->
     ( update_template_sync_config_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_template_sync_config_input ->
+    ( update_template_sync_config_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/proton/Smaws_Client_Proton.mli
+++ b/sdks/proton/Smaws_Client_Proton.mli
@@ -1499,7 +1499,8 @@ module AcceptEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1545,7 +1546,8 @@ module CancelComponentDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1590,7 +1592,8 @@ module CancelEnvironmentDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1649,7 +1652,8 @@ module CancelServiceInstanceDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1708,7 +1712,8 @@ module CancelServicePipelineDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1770,7 +1775,8 @@ module CreateComponent : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1817,7 +1823,8 @@ module CreateEnvironment : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1875,7 +1882,8 @@ module CreateEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1923,7 +1931,8 @@ module CreateEnvironmentTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1986,7 +1995,8 @@ module CreateEnvironmentTemplateVersion : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2028,7 +2038,8 @@ module CreateRepository : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2085,7 +2096,8 @@ module CreateService : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2128,7 +2140,8 @@ module CreateServiceInstance : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Create a service instance.\n"]
@@ -2167,7 +2180,8 @@ module CreateServiceSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Create the Proton Ops configuration file.\n"]
@@ -2206,7 +2220,8 @@ module CreateServiceTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2255,7 +2270,8 @@ module CreateServiceTemplateVersion : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2297,7 +2313,8 @@ module CreateTemplateSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2346,7 +2363,8 @@ module DeleteComponent : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2387,7 +2405,8 @@ module DeleteDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete the deployment.\n"]
@@ -2426,7 +2445,8 @@ module DeleteEnvironment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete an environment.\n"]
@@ -2465,7 +2485,8 @@ module DeleteEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2515,7 +2536,8 @@ module DeleteEnvironmentTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2556,7 +2578,8 @@ module DeleteEnvironmentTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2605,7 +2628,8 @@ module DeleteRepository : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "De-register and unlink your repository.\n"]
@@ -2644,7 +2668,8 @@ module DeleteService : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2692,7 +2717,8 @@ module DeleteServiceSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete the Proton Ops file.\n"]
@@ -2731,7 +2757,8 @@ module DeleteServiceTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2771,7 +2798,8 @@ module DeleteServiceTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2818,7 +2846,8 @@ module DeleteTemplateSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete a template sync configuration.\n"]
@@ -2854,7 +2883,8 @@ module GetAccountSettings : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detail data for Proton account-wide settings.\n"]
@@ -2890,7 +2920,8 @@ module GetComponent : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2931,7 +2962,8 @@ module GetDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a deployment.\n"]
@@ -2967,7 +2999,8 @@ module GetEnvironment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for an environment.\n"]
@@ -3003,7 +3036,8 @@ module GetEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3044,7 +3078,8 @@ module GetEnvironmentTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for an environment template.\n"]
@@ -3080,7 +3115,8 @@ module GetEnvironmentTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a major or minor version of an environment template.\n"]
@@ -3116,7 +3152,8 @@ module GetRepository : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detail data for a linked repository.\n"]
@@ -3152,7 +3189,8 @@ module GetRepositorySyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3197,7 +3235,8 @@ module GetResourcesSummary : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3252,7 +3291,8 @@ module GetService : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a service.\n"]
@@ -3288,7 +3328,8 @@ module GetServiceInstance : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3326,7 +3367,8 @@ module GetServiceInstanceSyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get the status of the synced service instance.\n"]
@@ -3362,7 +3404,8 @@ module GetServiceSyncBlockerSummary : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for the service sync blocker summary.\n"]
@@ -3398,7 +3441,8 @@ module GetServiceSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed information for the service sync configuration.\n"]
@@ -3434,7 +3478,8 @@ module GetServiceTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a service template.\n"]
@@ -3470,7 +3515,8 @@ module GetServiceTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a major or minor version of a service template.\n"]
@@ -3506,7 +3552,8 @@ module GetTemplateSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detail data for a template sync configuration.\n"]
@@ -3542,7 +3589,8 @@ module GetTemplateSyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get the status of a template sync.\n"]
@@ -3578,7 +3626,8 @@ module ListComponentOutputs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3619,7 +3668,8 @@ module ListComponentProvisionedResources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3657,7 +3707,8 @@ module ListComponents : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3699,7 +3750,8 @@ module ListDeployments : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3734,7 +3786,8 @@ module ListEnvironmentAccountConnections : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3775,7 +3828,8 @@ module ListEnvironmentOutputs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List the infrastructure as code outputs for your environment.\n"]
@@ -3811,7 +3865,8 @@ module ListEnvironmentProvisionedResources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List the provisioned resources for your environment.\n"]
@@ -3847,7 +3902,8 @@ module ListEnvironmentTemplateVersions : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List major or minor versions of an environment template with detail data.\n"]
@@ -3880,7 +3936,8 @@ module ListEnvironmentTemplates : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List environment templates.\n"]
@@ -3916,7 +3973,8 @@ module ListEnvironments : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List environments with detail data summaries.\n"]
@@ -3952,7 +4010,8 @@ module ListRepositories : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List linked repositories with detail data.\n"]
@@ -3985,7 +4044,8 @@ module ListRepositorySyncDefinitions : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List repository sync definitions with detail data.\n"]
@@ -4021,7 +4081,8 @@ module ListServiceInstanceOutputs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get a list service of instance Infrastructure as Code (IaC) outputs.\n"]
@@ -4057,7 +4118,8 @@ module ListServiceInstanceProvisionedResources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List provisioned resources for a service instance with details.\n"]
@@ -4093,7 +4155,8 @@ module ListServiceInstances : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4131,7 +4194,8 @@ module ListServicePipelineOutputs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get a list of service pipeline Infrastructure as Code (IaC) outputs.\n"]
@@ -4167,7 +4231,8 @@ module ListServicePipelineProvisionedResources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List provisioned resources for a service and pipeline with details.\n"]
@@ -4203,7 +4268,8 @@ module ListServiceTemplateVersions : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List major or minor versions of a service template with detail data.\n"]
@@ -4236,7 +4302,8 @@ module ListServiceTemplates : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List service templates with detail data.\n"]
@@ -4269,7 +4336,8 @@ module ListServices : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List services with summaries of detail data.\n"]
@@ -4305,7 +4373,8 @@ module ListTagsForResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4350,7 +4419,8 @@ module NotifyResourceDeploymentStatusChange : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4395,7 +4465,8 @@ module RejectEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4446,7 +4517,8 @@ module TagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4491,7 +4563,8 @@ module UntagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4533,7 +4606,8 @@ module UpdateAccountSettings : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4576,7 +4650,8 @@ module UpdateComponent : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4625,7 +4700,8 @@ module UpdateEnvironment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4721,7 +4797,8 @@ module UpdateEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4765,7 +4842,8 @@ module UpdateEnvironmentTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update an environment template.\n"]
@@ -4804,7 +4882,8 @@ module UpdateEnvironmentTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update a major or minor version of an environment template.\n"]
@@ -4846,7 +4925,8 @@ module UpdateService : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4901,7 +4981,8 @@ module UpdateServiceInstance : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4952,7 +5033,8 @@ module UpdateServicePipeline : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5020,7 +5102,8 @@ module UpdateServiceSyncBlocker : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update the service sync blocker by resolving it.\n"]
@@ -5059,7 +5142,8 @@ module UpdateServiceSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update the Proton Ops config file.\n"]
@@ -5098,7 +5182,8 @@ module UpdateServiceTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update a service template.\n"]
@@ -5137,7 +5222,8 @@ module UpdateServiceTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update a major or minor version of a service template.\n"]
@@ -5177,7 +5263,8 @@ module UpdateTemplateSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/proton/operations.ml
+++ b/sdks/proton/operations.ml
@@ -38,6 +38,13 @@ module AcceptEnvironmentAccountConnection = struct
       ~shape_name:"AwsProton20200720.AcceptEnvironmentAccountConnection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.accept_environment_account_connection_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : accept_environment_account_connection_input) =
+    let input = Json_serializers.accept_environment_account_connection_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.AcceptEnvironmentAccountConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.accept_environment_account_connection_output_of_yojson
+      ~error_deserializer
 end
 
 module CancelComponentDeployment = struct
@@ -75,6 +82,13 @@ module CancelComponentDeployment = struct
     let input = Json_serializers.cancel_component_deployment_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.CancelComponentDeployment"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_component_deployment_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : cancel_component_deployment_input) =
+    let input = Json_serializers.cancel_component_deployment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CancelComponentDeployment" ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_component_deployment_output_of_yojson
       ~error_deserializer
 end
@@ -116,6 +130,13 @@ module CancelEnvironmentDeployment = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_environment_deployment_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : cancel_environment_deployment_input) =
+    let input = Json_serializers.cancel_environment_deployment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CancelEnvironmentDeployment" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_environment_deployment_output_of_yojson
+      ~error_deserializer
 end
 
 module CancelServiceInstanceDeployment = struct
@@ -155,6 +176,13 @@ module CancelServiceInstanceDeployment = struct
       ~shape_name:"AwsProton20200720.CancelServiceInstanceDeployment" ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_service_instance_deployment_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : cancel_service_instance_deployment_input) =
+    let input = Json_serializers.cancel_service_instance_deployment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CancelServiceInstanceDeployment" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_service_instance_deployment_output_of_yojson
+      ~error_deserializer
 end
 
 module CancelServicePipelineDeployment = struct
@@ -191,6 +219,13 @@ module CancelServicePipelineDeployment = struct
   let request context (request : cancel_service_pipeline_deployment_input) =
     let input = Json_serializers.cancel_service_pipeline_deployment_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.CancelServicePipelineDeployment" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_service_pipeline_deployment_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : cancel_service_pipeline_deployment_input) =
+    let input = Json_serializers.cancel_service_pipeline_deployment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.CancelServicePipelineDeployment" ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_service_pipeline_deployment_output_of_yojson
       ~error_deserializer
@@ -236,6 +271,12 @@ module CreateComponent = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.CreateComponent" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_component_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_component_input) =
+    let input = Json_serializers.create_component_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateComponent" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_component_output_of_yojson ~error_deserializer
 end
 
 module CreateEnvironment = struct
@@ -278,6 +319,13 @@ module CreateEnvironment = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.CreateEnvironment" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_environment_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_environment_input) =
+    let input = Json_serializers.create_environment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateEnvironment" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_environment_output_of_yojson
+      ~error_deserializer
 end
 
 module CreateEnvironmentAccountConnection = struct
@@ -314,6 +362,13 @@ module CreateEnvironmentAccountConnection = struct
   let request context (request : create_environment_account_connection_input) =
     let input = Json_serializers.create_environment_account_connection_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.CreateEnvironmentAccountConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_environment_account_connection_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_environment_account_connection_input) =
+    let input = Json_serializers.create_environment_account_connection_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.CreateEnvironmentAccountConnection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_environment_account_connection_output_of_yojson
       ~error_deserializer
@@ -354,6 +409,13 @@ module CreateEnvironmentTemplate = struct
     let input = Json_serializers.create_environment_template_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.CreateEnvironmentTemplate"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_environment_template_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_environment_template_input) =
+    let input = Json_serializers.create_environment_template_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateEnvironmentTemplate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_environment_template_output_of_yojson
       ~error_deserializer
 end
@@ -399,6 +461,13 @@ module CreateEnvironmentTemplateVersion = struct
       ~shape_name:"AwsProton20200720.CreateEnvironmentTemplateVersion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_environment_template_version_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_environment_template_version_input) =
+    let input = Json_serializers.create_environment_template_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateEnvironmentTemplateVersion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_environment_template_version_output_of_yojson
+      ~error_deserializer
 end
 
 module CreateRepository = struct
@@ -437,6 +506,12 @@ module CreateRepository = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.CreateRepository" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_repository_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_repository_input) =
+    let input = Json_serializers.create_repository_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateRepository" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_repository_output_of_yojson ~error_deserializer
 end
 
 module CreateService = struct
@@ -479,6 +554,12 @@ module CreateService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.CreateService" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_service_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_service_input) =
+    let input = Json_serializers.create_service_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.CreateService"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_service_output_of_yojson ~error_deserializer
 end
 
 module CreateServiceInstance = struct
@@ -516,6 +597,13 @@ module CreateServiceInstance = struct
     let input = Json_serializers.create_service_instance_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.CreateServiceInstance"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_service_instance_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_service_instance_input) =
+    let input = Json_serializers.create_service_instance_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateServiceInstance" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_service_instance_output_of_yojson
       ~error_deserializer
 end
@@ -557,6 +645,13 @@ module CreateServiceSyncConfig = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_service_sync_config_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_service_sync_config_input) =
+    let input = Json_serializers.create_service_sync_config_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateServiceSyncConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_service_sync_config_output_of_yojson
+      ~error_deserializer
 end
 
 module CreateServiceTemplate = struct
@@ -594,6 +689,13 @@ module CreateServiceTemplate = struct
     let input = Json_serializers.create_service_template_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.CreateServiceTemplate"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_service_template_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_service_template_input) =
+    let input = Json_serializers.create_service_template_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateServiceTemplate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_service_template_output_of_yojson
       ~error_deserializer
 end
@@ -639,6 +741,13 @@ module CreateServiceTemplateVersion = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_service_template_version_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_service_template_version_input) =
+    let input = Json_serializers.create_service_template_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateServiceTemplateVersion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_service_template_version_output_of_yojson
+      ~error_deserializer
 end
 
 module CreateTemplateSyncConfig = struct
@@ -676,6 +785,13 @@ module CreateTemplateSyncConfig = struct
     let input = Json_serializers.create_template_sync_config_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.CreateTemplateSyncConfig"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_template_sync_config_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_template_sync_config_input) =
+    let input = Json_serializers.create_template_sync_config_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.CreateTemplateSyncConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_template_sync_config_output_of_yojson
       ~error_deserializer
 end
@@ -716,6 +832,12 @@ module DeleteComponent = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.DeleteComponent" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_component_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_component_input) =
+    let input = Json_serializers.delete_component_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.DeleteComponent" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_component_output_of_yojson ~error_deserializer
 end
 
 module DeleteDeployment = struct
@@ -751,6 +873,12 @@ module DeleteDeployment = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.DeleteDeployment" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_deployment_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_deployment_input) =
+    let input = Json_serializers.delete_deployment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.DeleteDeployment" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_deployment_output_of_yojson ~error_deserializer
 end
 
 module DeleteEnvironment = struct
@@ -789,6 +917,13 @@ module DeleteEnvironment = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.DeleteEnvironment" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_environment_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_environment_input) =
+    let input = Json_serializers.delete_environment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.DeleteEnvironment" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_environment_output_of_yojson
+      ~error_deserializer
 end
 
 module DeleteEnvironmentAccountConnection = struct
@@ -825,6 +960,13 @@ module DeleteEnvironmentAccountConnection = struct
   let request context (request : delete_environment_account_connection_input) =
     let input = Json_serializers.delete_environment_account_connection_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.DeleteEnvironmentAccountConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_environment_account_connection_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_environment_account_connection_input) =
+    let input = Json_serializers.delete_environment_account_connection_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.DeleteEnvironmentAccountConnection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_environment_account_connection_output_of_yojson
       ~error_deserializer
@@ -867,6 +1009,13 @@ module DeleteEnvironmentTemplate = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_environment_template_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_environment_template_input) =
+    let input = Json_serializers.delete_environment_template_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.DeleteEnvironmentTemplate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_environment_template_output_of_yojson
+      ~error_deserializer
 end
 
 module DeleteEnvironmentTemplateVersion = struct
@@ -903,6 +1052,13 @@ module DeleteEnvironmentTemplateVersion = struct
   let request context (request : delete_environment_template_version_input) =
     let input = Json_serializers.delete_environment_template_version_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.DeleteEnvironmentTemplateVersion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_environment_template_version_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_environment_template_version_input) =
+    let input = Json_serializers.delete_environment_template_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.DeleteEnvironmentTemplateVersion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_environment_template_version_output_of_yojson
       ~error_deserializer
@@ -944,6 +1100,12 @@ module DeleteRepository = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.DeleteRepository" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_repository_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_repository_input) =
+    let input = Json_serializers.delete_repository_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.DeleteRepository" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_repository_output_of_yojson ~error_deserializer
 end
 
 module DeleteService = struct
@@ -982,6 +1144,12 @@ module DeleteService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.DeleteService" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_service_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_service_input) =
+    let input = Json_serializers.delete_service_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.DeleteService"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_service_output_of_yojson ~error_deserializer
 end
 
 module DeleteServiceSyncConfig = struct
@@ -1019,6 +1187,13 @@ module DeleteServiceSyncConfig = struct
     let input = Json_serializers.delete_service_sync_config_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.DeleteServiceSyncConfig"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_service_sync_config_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_service_sync_config_input) =
+    let input = Json_serializers.delete_service_sync_config_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.DeleteServiceSyncConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_service_sync_config_output_of_yojson
       ~error_deserializer
 end
@@ -1060,6 +1235,13 @@ module DeleteServiceTemplate = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_service_template_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_service_template_input) =
+    let input = Json_serializers.delete_service_template_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.DeleteServiceTemplate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_service_template_output_of_yojson
+      ~error_deserializer
 end
 
 module DeleteServiceTemplateVersion = struct
@@ -1097,6 +1279,13 @@ module DeleteServiceTemplateVersion = struct
     let input = Json_serializers.delete_service_template_version_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.DeleteServiceTemplateVersion"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_service_template_version_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_service_template_version_input) =
+    let input = Json_serializers.delete_service_template_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.DeleteServiceTemplateVersion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_service_template_version_output_of_yojson
       ~error_deserializer
 end
@@ -1138,6 +1327,13 @@ module DeleteTemplateSyncConfig = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_template_sync_config_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_template_sync_config_input) =
+    let input = Json_serializers.delete_template_sync_config_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.DeleteTemplateSyncConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_template_sync_config_output_of_yojson
+      ~error_deserializer
 end
 
 module GetAccountSettings = struct
@@ -1172,6 +1368,13 @@ module GetAccountSettings = struct
     let input = Json_serializers.get_account_settings_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetAccountSettings" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_account_settings_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_account_settings_input) =
+    let input = Json_serializers.get_account_settings_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetAccountSettings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_account_settings_output_of_yojson
       ~error_deserializer
 end
 
@@ -1208,6 +1411,12 @@ module GetComponent = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetComponent" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_component_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_component_input) =
+    let input = Json_serializers.get_component_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.GetComponent"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_component_output_of_yojson ~error_deserializer
 end
 
 module GetDeployment = struct
@@ -1243,6 +1452,12 @@ module GetDeployment = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetDeployment" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_deployment_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_deployment_input) =
+    let input = Json_serializers.get_deployment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.GetDeployment"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_deployment_output_of_yojson ~error_deserializer
 end
 
 module GetEnvironment = struct
@@ -1278,6 +1493,12 @@ module GetEnvironment = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetEnvironment" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_environment_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_environment_input) =
+    let input = Json_serializers.get_environment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.GetEnvironment"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_environment_output_of_yojson ~error_deserializer
 end
 
 module GetEnvironmentAccountConnection = struct
@@ -1311,6 +1532,13 @@ module GetEnvironmentAccountConnection = struct
   let request context (request : get_environment_account_connection_input) =
     let input = Json_serializers.get_environment_account_connection_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.GetEnvironmentAccountConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_environment_account_connection_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_environment_account_connection_input) =
+    let input = Json_serializers.get_environment_account_connection_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.GetEnvironmentAccountConnection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_environment_account_connection_output_of_yojson
       ~error_deserializer
@@ -1350,6 +1578,13 @@ module GetEnvironmentTemplate = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_environment_template_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_environment_template_input) =
+    let input = Json_serializers.get_environment_template_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetEnvironmentTemplate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_environment_template_output_of_yojson
+      ~error_deserializer
 end
 
 module GetEnvironmentTemplateVersion = struct
@@ -1383,6 +1618,13 @@ module GetEnvironmentTemplateVersion = struct
   let request context (request : get_environment_template_version_input) =
     let input = Json_serializers.get_environment_template_version_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.GetEnvironmentTemplateVersion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_environment_template_version_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_environment_template_version_input) =
+    let input = Json_serializers.get_environment_template_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.GetEnvironmentTemplateVersion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_environment_template_version_output_of_yojson
       ~error_deserializer
@@ -1421,6 +1663,12 @@ module GetRepository = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetRepository" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_repository_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_repository_input) =
+    let input = Json_serializers.get_repository_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.GetRepository"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_repository_output_of_yojson ~error_deserializer
 end
 
 module GetRepositorySyncStatus = struct
@@ -1457,6 +1705,13 @@ module GetRepositorySyncStatus = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_repository_sync_status_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_repository_sync_status_input) =
+    let input = Json_serializers.get_repository_sync_status_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetRepositorySyncStatus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_repository_sync_status_output_of_yojson
+      ~error_deserializer
 end
 
 module GetResourcesSummary = struct
@@ -1487,6 +1742,13 @@ module GetResourcesSummary = struct
     let input = Json_serializers.get_resources_summary_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetResourcesSummary" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_resources_summary_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_resources_summary_input) =
+    let input = Json_serializers.get_resources_summary_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetResourcesSummary" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resources_summary_output_of_yojson
       ~error_deserializer
 end
 
@@ -1523,6 +1785,12 @@ module GetService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetService" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_service_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_service_input) =
+    let input = Json_serializers.get_service_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.GetService"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_service_output_of_yojson
+      ~error_deserializer
 end
 
 module GetServiceInstance = struct
@@ -1558,6 +1826,13 @@ module GetServiceInstance = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetServiceInstance" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_service_instance_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_service_instance_input) =
+    let input = Json_serializers.get_service_instance_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetServiceInstance" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_service_instance_output_of_yojson
+      ~error_deserializer
 end
 
 module GetServiceInstanceSyncStatus = struct
@@ -1592,6 +1867,13 @@ module GetServiceInstanceSyncStatus = struct
     let input = Json_serializers.get_service_instance_sync_status_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetServiceInstanceSyncStatus"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_service_instance_sync_status_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_service_instance_sync_status_input) =
+    let input = Json_serializers.get_service_instance_sync_status_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetServiceInstanceSyncStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_service_instance_sync_status_output_of_yojson
       ~error_deserializer
 end
@@ -1630,6 +1912,13 @@ module GetServiceSyncBlockerSummary = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_service_sync_blocker_summary_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_service_sync_blocker_summary_input) =
+    let input = Json_serializers.get_service_sync_blocker_summary_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetServiceSyncBlockerSummary" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_service_sync_blocker_summary_output_of_yojson
+      ~error_deserializer
 end
 
 module GetServiceSyncConfig = struct
@@ -1664,6 +1953,13 @@ module GetServiceSyncConfig = struct
     let input = Json_serializers.get_service_sync_config_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetServiceSyncConfig"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_service_sync_config_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_service_sync_config_input) =
+    let input = Json_serializers.get_service_sync_config_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetServiceSyncConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_service_sync_config_output_of_yojson
       ~error_deserializer
 end
@@ -1701,6 +1997,13 @@ module GetServiceTemplate = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetServiceTemplate" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_service_template_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_service_template_input) =
+    let input = Json_serializers.get_service_template_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetServiceTemplate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_service_template_output_of_yojson
+      ~error_deserializer
 end
 
 module GetServiceTemplateVersion = struct
@@ -1735,6 +2038,13 @@ module GetServiceTemplateVersion = struct
     let input = Json_serializers.get_service_template_version_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetServiceTemplateVersion"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_service_template_version_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_service_template_version_input) =
+    let input = Json_serializers.get_service_template_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetServiceTemplateVersion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_service_template_version_output_of_yojson
       ~error_deserializer
 end
@@ -1773,6 +2083,13 @@ module GetTemplateSyncConfig = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_template_sync_config_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_template_sync_config_input) =
+    let input = Json_serializers.get_template_sync_config_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetTemplateSyncConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_template_sync_config_output_of_yojson
+      ~error_deserializer
 end
 
 module GetTemplateSyncStatus = struct
@@ -1807,6 +2124,13 @@ module GetTemplateSyncStatus = struct
     let input = Json_serializers.get_template_sync_status_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.GetTemplateSyncStatus"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_template_sync_status_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_template_sync_status_input) =
+    let input = Json_serializers.get_template_sync_status_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.GetTemplateSyncStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_template_sync_status_output_of_yojson
       ~error_deserializer
 end
@@ -1845,6 +2169,13 @@ module ListComponentOutputs = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_component_outputs_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_component_outputs_input) =
+    let input = Json_serializers.list_component_outputs_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListComponentOutputs" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_component_outputs_output_of_yojson
+      ~error_deserializer
 end
 
 module ListComponentProvisionedResources = struct
@@ -1881,6 +2212,13 @@ module ListComponentProvisionedResources = struct
       ~shape_name:"AwsProton20200720.ListComponentProvisionedResources" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_component_provisioned_resources_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_component_provisioned_resources_input) =
+    let input = Json_serializers.list_component_provisioned_resources_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListComponentProvisionedResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_component_provisioned_resources_output_of_yojson
+      ~error_deserializer
 end
 
 module ListComponents = struct
@@ -1912,6 +2250,12 @@ module ListComponents = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListComponents" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_components_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_components_input) =
+    let input = Json_serializers.list_components_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.ListComponents"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_components_output_of_yojson ~error_deserializer
 end
 
 module ListDeployments = struct
@@ -1947,6 +2291,12 @@ module ListDeployments = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListDeployments" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_deployments_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_deployments_input) =
+    let input = Json_serializers.list_deployments_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListDeployments" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_deployments_output_of_yojson ~error_deserializer
 end
 
 module ListEnvironmentAccountConnections = struct
@@ -1976,6 +2326,13 @@ module ListEnvironmentAccountConnections = struct
   let request context (request : list_environment_account_connections_input) =
     let input = Json_serializers.list_environment_account_connections_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.ListEnvironmentAccountConnections" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_environment_account_connections_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_environment_account_connections_input) =
+    let input = Json_serializers.list_environment_account_connections_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.ListEnvironmentAccountConnections" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_environment_account_connections_output_of_yojson
       ~error_deserializer
@@ -2015,6 +2372,13 @@ module ListEnvironmentOutputs = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_environment_outputs_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_environment_outputs_input) =
+    let input = Json_serializers.list_environment_outputs_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListEnvironmentOutputs" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_environment_outputs_output_of_yojson
+      ~error_deserializer
 end
 
 module ListEnvironmentProvisionedResources = struct
@@ -2048,6 +2412,14 @@ module ListEnvironmentProvisionedResources = struct
   let request context (request : list_environment_provisioned_resources_input) =
     let input = Json_serializers.list_environment_provisioned_resources_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.ListEnvironmentProvisionedResources" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.list_environment_provisioned_resources_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_environment_provisioned_resources_input) =
+    let input = Json_serializers.list_environment_provisioned_resources_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.ListEnvironmentProvisionedResources" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.list_environment_provisioned_resources_output_of_yojson
@@ -2088,6 +2460,13 @@ module ListEnvironmentTemplateVersions = struct
       ~shape_name:"AwsProton20200720.ListEnvironmentTemplateVersions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_environment_template_versions_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_environment_template_versions_input) =
+    let input = Json_serializers.list_environment_template_versions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListEnvironmentTemplateVersions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_environment_template_versions_output_of_yojson
+      ~error_deserializer
 end
 
 module ListEnvironmentTemplates = struct
@@ -2118,6 +2497,13 @@ module ListEnvironmentTemplates = struct
     let input = Json_serializers.list_environment_templates_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListEnvironmentTemplates"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_environment_templates_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_environment_templates_input) =
+    let input = Json_serializers.list_environment_templates_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListEnvironmentTemplates" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_environment_templates_output_of_yojson
       ~error_deserializer
 end
@@ -2155,6 +2541,12 @@ module ListEnvironments = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListEnvironments" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_environments_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_environments_input) =
+    let input = Json_serializers.list_environments_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListEnvironments" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_environments_output_of_yojson ~error_deserializer
 end
 
 module ListRepositories = struct
@@ -2190,6 +2582,12 @@ module ListRepositories = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListRepositories" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_repositories_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_repositories_input) =
+    let input = Json_serializers.list_repositories_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListRepositories" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_repositories_output_of_yojson ~error_deserializer
 end
 
 module ListRepositorySyncDefinitions = struct
@@ -2219,6 +2617,13 @@ module ListRepositorySyncDefinitions = struct
   let request context (request : list_repository_sync_definitions_input) =
     let input = Json_serializers.list_repository_sync_definitions_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.ListRepositorySyncDefinitions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_repository_sync_definitions_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_repository_sync_definitions_input) =
+    let input = Json_serializers.list_repository_sync_definitions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.ListRepositorySyncDefinitions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_repository_sync_definitions_output_of_yojson
       ~error_deserializer
@@ -2256,6 +2661,13 @@ module ListServiceInstanceOutputs = struct
     let input = Json_serializers.list_service_instance_outputs_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListServiceInstanceOutputs"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_service_instance_outputs_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_service_instance_outputs_input) =
+    let input = Json_serializers.list_service_instance_outputs_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListServiceInstanceOutputs" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_service_instance_outputs_output_of_yojson
       ~error_deserializer
 end
@@ -2298,6 +2710,17 @@ module ListServiceInstanceProvisionedResources = struct
       ~output_deserializer:
         Json_deserializers.list_service_instance_provisioned_resources_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_service_instance_provisioned_resources_input) =
+    let input =
+      Json_serializers.list_service_instance_provisioned_resources_input_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListServiceInstanceProvisionedResources" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.list_service_instance_provisioned_resources_output_of_yojson
+      ~error_deserializer
 end
 
 module ListServiceInstances = struct
@@ -2334,6 +2757,13 @@ module ListServiceInstances = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_service_instances_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_service_instances_input) =
+    let input = Json_serializers.list_service_instances_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListServiceInstances" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_service_instances_output_of_yojson
+      ~error_deserializer
 end
 
 module ListServicePipelineOutputs = struct
@@ -2368,6 +2798,13 @@ module ListServicePipelineOutputs = struct
     let input = Json_serializers.list_service_pipeline_outputs_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListServicePipelineOutputs"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_service_pipeline_outputs_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_service_pipeline_outputs_input) =
+    let input = Json_serializers.list_service_pipeline_outputs_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListServicePipelineOutputs" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_service_pipeline_outputs_output_of_yojson
       ~error_deserializer
 end
@@ -2410,6 +2847,17 @@ module ListServicePipelineProvisionedResources = struct
       ~output_deserializer:
         Json_deserializers.list_service_pipeline_provisioned_resources_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_service_pipeline_provisioned_resources_input) =
+    let input =
+      Json_serializers.list_service_pipeline_provisioned_resources_input_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListServicePipelineProvisionedResources" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.list_service_pipeline_provisioned_resources_output_of_yojson
+      ~error_deserializer
 end
 
 module ListServiceTemplateVersions = struct
@@ -2446,6 +2894,13 @@ module ListServiceTemplateVersions = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_service_template_versions_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_service_template_versions_input) =
+    let input = Json_serializers.list_service_template_versions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListServiceTemplateVersions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_service_template_versions_output_of_yojson
+      ~error_deserializer
 end
 
 module ListServiceTemplates = struct
@@ -2476,6 +2931,13 @@ module ListServiceTemplates = struct
     let input = Json_serializers.list_service_templates_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListServiceTemplates"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_service_templates_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_service_templates_input) =
+    let input = Json_serializers.list_service_templates_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListServiceTemplates" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_service_templates_output_of_yojson
       ~error_deserializer
 end
@@ -2509,6 +2971,12 @@ module ListServices = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListServices" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_services_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_services_input) =
+    let input = Json_serializers.list_services_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.ListServices"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_services_output_of_yojson ~error_deserializer
 end
 
 module ListTagsForResource = struct
@@ -2543,6 +3011,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.ListTagsForResource" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_input) =
+    let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
       ~error_deserializer
 end
@@ -2589,6 +3064,14 @@ module NotifyResourceDeploymentStatusChange = struct
       ~output_deserializer:
         Json_deserializers.notify_resource_deployment_status_change_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : notify_resource_deployment_status_change_input) =
+    let input = Json_serializers.notify_resource_deployment_status_change_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.NotifyResourceDeploymentStatusChange" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.notify_resource_deployment_status_change_output_of_yojson
+      ~error_deserializer
 end
 
 module RejectEnvironmentAccountConnection = struct
@@ -2625,6 +3108,13 @@ module RejectEnvironmentAccountConnection = struct
   let request context (request : reject_environment_account_connection_input) =
     let input = Json_serializers.reject_environment_account_connection_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.RejectEnvironmentAccountConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.reject_environment_account_connection_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : reject_environment_account_connection_input) =
+    let input = Json_serializers.reject_environment_account_connection_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.RejectEnvironmentAccountConnection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.reject_environment_account_connection_output_of_yojson
       ~error_deserializer
@@ -2666,6 +3156,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.TagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.tag_resource_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_input) =
+    let input = Json_serializers.tag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.TagResource"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.tag_resource_output_of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -2704,6 +3200,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_input) =
+    let input = Json_serializers.untag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_output_of_yojson ~error_deserializer
 end
 
 module UpdateAccountSettings = struct
@@ -2737,6 +3239,13 @@ module UpdateAccountSettings = struct
     let input = Json_serializers.update_account_settings_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.UpdateAccountSettings"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_account_settings_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_account_settings_input) =
+    let input = Json_serializers.update_account_settings_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateAccountSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_account_settings_output_of_yojson
       ~error_deserializer
 end
@@ -2781,6 +3290,12 @@ module UpdateComponent = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.UpdateComponent" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_component_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_component_input) =
+    let input = Json_serializers.update_component_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateComponent" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_component_output_of_yojson ~error_deserializer
 end
 
 module UpdateEnvironment = struct
@@ -2819,6 +3334,13 @@ module UpdateEnvironment = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.UpdateEnvironment" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_environment_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_environment_input) =
+    let input = Json_serializers.update_environment_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateEnvironment" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_environment_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateEnvironmentAccountConnection = struct
@@ -2855,6 +3377,13 @@ module UpdateEnvironmentAccountConnection = struct
   let request context (request : update_environment_account_connection_input) =
     let input = Json_serializers.update_environment_account_connection_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.UpdateEnvironmentAccountConnection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_environment_account_connection_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_environment_account_connection_input) =
+    let input = Json_serializers.update_environment_account_connection_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.UpdateEnvironmentAccountConnection" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_environment_account_connection_output_of_yojson
       ~error_deserializer
@@ -2897,6 +3426,13 @@ module UpdateEnvironmentTemplate = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_environment_template_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_environment_template_input) =
+    let input = Json_serializers.update_environment_template_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateEnvironmentTemplate" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_environment_template_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateEnvironmentTemplateVersion = struct
@@ -2933,6 +3469,13 @@ module UpdateEnvironmentTemplateVersion = struct
   let request context (request : update_environment_template_version_input) =
     let input = Json_serializers.update_environment_template_version_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AwsProton20200720.UpdateEnvironmentTemplateVersion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_environment_template_version_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_environment_template_version_input) =
+    let input = Json_serializers.update_environment_template_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AwsProton20200720.UpdateEnvironmentTemplateVersion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_environment_template_version_output_of_yojson
       ~error_deserializer
@@ -2978,6 +3521,12 @@ module UpdateService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.UpdateService" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_service_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_service_input) =
+    let input = Json_serializers.update_service_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AwsProton20200720.UpdateService"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_output_of_yojson ~error_deserializer
 end
 
 module UpdateServiceInstance = struct
@@ -3015,6 +3564,13 @@ module UpdateServiceInstance = struct
     let input = Json_serializers.update_service_instance_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.UpdateServiceInstance"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_instance_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_service_instance_input) =
+    let input = Json_serializers.update_service_instance_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateServiceInstance" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_service_instance_output_of_yojson
       ~error_deserializer
 end
@@ -3056,6 +3612,13 @@ module UpdateServicePipeline = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_service_pipeline_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_service_pipeline_input) =
+    let input = Json_serializers.update_service_pipeline_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateServicePipeline" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_pipeline_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateServiceSyncBlocker = struct
@@ -3093,6 +3656,13 @@ module UpdateServiceSyncBlocker = struct
     let input = Json_serializers.update_service_sync_blocker_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.UpdateServiceSyncBlocker"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_sync_blocker_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_service_sync_blocker_input) =
+    let input = Json_serializers.update_service_sync_blocker_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateServiceSyncBlocker" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_service_sync_blocker_output_of_yojson
       ~error_deserializer
 end
@@ -3134,6 +3704,13 @@ module UpdateServiceSyncConfig = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_service_sync_config_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_service_sync_config_input) =
+    let input = Json_serializers.update_service_sync_config_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateServiceSyncConfig" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_sync_config_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateServiceTemplate = struct
@@ -3171,6 +3748,13 @@ module UpdateServiceTemplate = struct
     let input = Json_serializers.update_service_template_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.UpdateServiceTemplate"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_template_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_service_template_input) =
+    let input = Json_serializers.update_service_template_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateServiceTemplate" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_service_template_output_of_yojson
       ~error_deserializer
 end
@@ -3212,6 +3796,13 @@ module UpdateServiceTemplateVersion = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_service_template_version_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_service_template_version_input) =
+    let input = Json_serializers.update_service_template_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateServiceTemplateVersion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_template_version_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateTemplateSyncConfig = struct
@@ -3249,6 +3840,13 @@ module UpdateTemplateSyncConfig = struct
     let input = Json_serializers.update_template_sync_config_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AwsProton20200720.UpdateTemplateSyncConfig"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_template_sync_config_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_template_sync_config_input) =
+    let input = Json_serializers.update_template_sync_config_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AwsProton20200720.UpdateTemplateSyncConfig" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_template_sync_config_output_of_yojson
       ~error_deserializer
 end

--- a/sdks/proton/operations.mli
+++ b/sdks/proton/operations.mli
@@ -34,7 +34,8 @@ module AcceptEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -80,7 +81,8 @@ module CancelComponentDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -125,7 +127,8 @@ module CancelEnvironmentDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -184,7 +187,8 @@ module CancelServiceInstanceDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -243,7 +247,8 @@ module CancelServicePipelineDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -305,7 +310,8 @@ module CreateComponent : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -352,7 +358,8 @@ module CreateEnvironment : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -410,7 +417,8 @@ module CreateEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -458,7 +466,8 @@ module CreateEnvironmentTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -521,7 +530,8 @@ module CreateEnvironmentTemplateVersion : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -563,7 +573,8 @@ module CreateRepository : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -620,7 +631,8 @@ module CreateService : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -663,7 +675,8 @@ module CreateServiceInstance : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Create a service instance.\n"]
@@ -702,7 +715,8 @@ module CreateServiceSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Create the Proton Ops configuration file.\n"]
@@ -741,7 +755,8 @@ module CreateServiceTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -790,7 +805,8 @@ module CreateServiceTemplateVersion : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -832,7 +848,8 @@ module CreateTemplateSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -881,7 +898,8 @@ module DeleteComponent : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -922,7 +940,8 @@ module DeleteDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete the deployment.\n"]
@@ -961,7 +980,8 @@ module DeleteEnvironment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete an environment.\n"]
@@ -1000,7 +1020,8 @@ module DeleteEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1050,7 +1071,8 @@ module DeleteEnvironmentTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1091,7 +1113,8 @@ module DeleteEnvironmentTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1140,7 +1163,8 @@ module DeleteRepository : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "De-register and unlink your repository.\n"]
@@ -1179,7 +1203,8 @@ module DeleteService : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1227,7 +1252,8 @@ module DeleteServiceSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete the Proton Ops file.\n"]
@@ -1266,7 +1292,8 @@ module DeleteServiceTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1306,7 +1333,8 @@ module DeleteServiceTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1353,7 +1381,8 @@ module DeleteTemplateSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete a template sync configuration.\n"]
@@ -1389,7 +1418,8 @@ module GetAccountSettings : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detail data for Proton account-wide settings.\n"]
@@ -1425,7 +1455,8 @@ module GetComponent : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1466,7 +1497,8 @@ module GetDeployment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a deployment.\n"]
@@ -1502,7 +1534,8 @@ module GetEnvironment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for an environment.\n"]
@@ -1538,7 +1571,8 @@ module GetEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1579,7 +1613,8 @@ module GetEnvironmentTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for an environment template.\n"]
@@ -1615,7 +1650,8 @@ module GetEnvironmentTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a major or minor version of an environment template.\n"]
@@ -1651,7 +1687,8 @@ module GetRepository : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detail data for a linked repository.\n"]
@@ -1687,7 +1724,8 @@ module GetRepositorySyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1732,7 +1770,8 @@ module GetResourcesSummary : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1787,7 +1826,8 @@ module GetService : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a service.\n"]
@@ -1823,7 +1863,8 @@ module GetServiceInstance : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1861,7 +1902,8 @@ module GetServiceInstanceSyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get the status of the synced service instance.\n"]
@@ -1897,7 +1939,8 @@ module GetServiceSyncBlockerSummary : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for the service sync blocker summary.\n"]
@@ -1933,7 +1976,8 @@ module GetServiceSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed information for the service sync configuration.\n"]
@@ -1969,7 +2013,8 @@ module GetServiceTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a service template.\n"]
@@ -2005,7 +2050,8 @@ module GetServiceTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed data for a major or minor version of a service template.\n"]
@@ -2041,7 +2087,8 @@ module GetTemplateSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detail data for a template sync configuration.\n"]
@@ -2077,7 +2124,8 @@ module GetTemplateSyncStatus : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get the status of a template sync.\n"]
@@ -2113,7 +2161,8 @@ module ListComponentOutputs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2154,7 +2203,8 @@ module ListComponentProvisionedResources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2192,7 +2242,8 @@ module ListComponents : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2234,7 +2285,8 @@ module ListDeployments : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2269,7 +2321,8 @@ module ListEnvironmentAccountConnections : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2310,7 +2363,8 @@ module ListEnvironmentOutputs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List the infrastructure as code outputs for your environment.\n"]
@@ -2346,7 +2400,8 @@ module ListEnvironmentProvisionedResources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List the provisioned resources for your environment.\n"]
@@ -2382,7 +2437,8 @@ module ListEnvironmentTemplateVersions : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List major or minor versions of an environment template with detail data.\n"]
@@ -2415,7 +2471,8 @@ module ListEnvironmentTemplates : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List environment templates.\n"]
@@ -2451,7 +2508,8 @@ module ListEnvironments : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List environments with detail data summaries.\n"]
@@ -2487,7 +2545,8 @@ module ListRepositories : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List linked repositories with detail data.\n"]
@@ -2520,7 +2579,8 @@ module ListRepositorySyncDefinitions : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List repository sync definitions with detail data.\n"]
@@ -2556,7 +2616,8 @@ module ListServiceInstanceOutputs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get a list service of instance Infrastructure as Code (IaC) outputs.\n"]
@@ -2592,7 +2653,8 @@ module ListServiceInstanceProvisionedResources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List provisioned resources for a service instance with details.\n"]
@@ -2628,7 +2690,8 @@ module ListServiceInstances : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2666,7 +2729,8 @@ module ListServicePipelineOutputs : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get a list of service pipeline Infrastructure as Code (IaC) outputs.\n"]
@@ -2702,7 +2766,8 @@ module ListServicePipelineProvisionedResources : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List provisioned resources for a service and pipeline with details.\n"]
@@ -2738,7 +2803,8 @@ module ListServiceTemplateVersions : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List major or minor versions of a service template with detail data.\n"]
@@ -2771,7 +2837,8 @@ module ListServiceTemplates : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List service templates with detail data.\n"]
@@ -2804,7 +2871,8 @@ module ListServices : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List services with summaries of detail data.\n"]
@@ -2840,7 +2908,8 @@ module ListTagsForResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2885,7 +2954,8 @@ module NotifyResourceDeploymentStatusChange : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2930,7 +3000,8 @@ module RejectEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2981,7 +3052,8 @@ module TagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3026,7 +3098,8 @@ module UntagResource : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3068,7 +3141,8 @@ module UpdateAccountSettings : sig
       | `ConflictException of conflict_exception
       | `InternalServerException of internal_server_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3111,7 +3185,8 @@ module UpdateComponent : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3160,7 +3235,8 @@ module UpdateEnvironment : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3256,7 +3332,8 @@ module UpdateEnvironmentAccountConnection : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3300,7 +3377,8 @@ module UpdateEnvironmentTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update an environment template.\n"]
@@ -3339,7 +3417,8 @@ module UpdateEnvironmentTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update a major or minor version of an environment template.\n"]
@@ -3381,7 +3460,8 @@ module UpdateService : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3436,7 +3516,8 @@ module UpdateServiceInstance : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3487,7 +3568,8 @@ module UpdateServicePipeline : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3555,7 +3637,8 @@ module UpdateServiceSyncBlocker : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update the service sync blocker by resolving it.\n"]
@@ -3594,7 +3677,8 @@ module UpdateServiceSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update the Proton Ops config file.\n"]
@@ -3633,7 +3717,8 @@ module UpdateServiceTemplate : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update a service template.\n"]
@@ -3672,7 +3757,8 @@ module UpdateServiceTemplateVersion : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Update a major or minor version of a service template.\n"]
@@ -3711,7 +3797,8 @@ module UpdateTemplateSyncConfig : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/proton/operations.mli
+++ b/sdks/proton/operations.mli
@@ -23,6 +23,19 @@ module AcceptEnvironmentAccountConnection : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    accept_environment_account_connection_input ->
+    ( accept_environment_account_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "In a management account, an environment account connection request is accepted. When the \
@@ -56,6 +69,19 @@ module CancelComponentDeployment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_component_deployment_input ->
+    ( cancel_component_deployment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attempts to cancel a component deployment (for a component that is in the [IN_PROGRESS] \
@@ -80,6 +106,19 @@ module CancelEnvironmentDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_environment_deployment_input ->
     ( cancel_environment_deployment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_environment_deployment_input ->
+    ( cancel_environment_deployment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -134,6 +173,19 @@ module CancelServiceInstanceDeployment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_service_instance_deployment_input ->
+    ( cancel_service_instance_deployment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Attempts to cancel a service instance deployment on an [UpdateServiceInstance] action, if the \
@@ -172,6 +224,19 @@ module CancelServicePipelineDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_service_pipeline_deployment_input ->
     ( cancel_service_pipeline_deployment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_service_pipeline_deployment_input ->
+    ( cancel_service_pipeline_deployment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -228,6 +293,20 @@ module CreateComponent : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_component_input ->
+    ( create_component_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an Proton component. A component is an infrastructure extension for a service instance.\n\n\
@@ -252,6 +331,20 @@ module CreateEnvironment : sig
     'http_type Smaws_Lib.Context.t ->
     create_environment_input ->
     ( create_environment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_environment_input ->
+    ( create_environment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -306,6 +399,19 @@ module CreateEnvironmentAccountConnection : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_environment_account_connection_input ->
+    ( create_environment_account_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an environment account connection in an environment account so that environment \
@@ -333,6 +439,19 @@ module CreateEnvironmentTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     create_environment_template_input ->
     ( create_environment_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_environment_template_input ->
+    ( create_environment_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -390,6 +509,20 @@ module CreateEnvironmentTemplateVersion : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_environment_template_version_input ->
+    ( create_environment_template_version_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create a new major or minor version of an environment template. A major version of an \
@@ -411,6 +544,19 @@ module CreateRepository : sig
     'http_type Smaws_Lib.Context.t ->
     create_repository_input ->
     ( create_repository_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_repository_input ->
+    ( create_repository_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -462,6 +608,20 @@ module CreateService : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_input ->
+    ( create_service_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create an Proton service. An Proton service is an instantiation of a service template and often \
@@ -484,6 +644,19 @@ module CreateServiceInstance : sig
     'http_type Smaws_Lib.Context.t ->
     create_service_instance_input ->
     ( create_service_instance_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_instance_input ->
+    ( create_service_instance_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -518,6 +691,19 @@ module CreateServiceSyncConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_sync_config_input ->
+    ( create_service_sync_config_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Create the Proton Ops configuration file.\n"]
 
@@ -536,6 +722,19 @@ module CreateServiceTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     create_service_template_input ->
     ( create_service_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_template_input ->
+    ( create_service_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -579,6 +778,20 @@ module CreateServiceTemplateVersion : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_template_version_input ->
+    ( create_service_template_version_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Create a new major or minor version of a service template. A major version of a service \
@@ -600,6 +813,19 @@ module CreateTemplateSyncConfig : sig
     'http_type Smaws_Lib.Context.t ->
     create_template_sync_config_input ->
     ( create_template_sync_config_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_template_sync_config_input ->
+    ( create_template_sync_config_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -644,6 +870,19 @@ module DeleteComponent : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_component_input ->
+    ( delete_component_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Delete an Proton component resource.\n\n\
@@ -666,6 +905,18 @@ module DeleteDeployment : sig
     'http_type Smaws_Lib.Context.t ->
     delete_deployment_input ->
     ( delete_deployment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_deployment_input ->
+    ( delete_deployment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -699,6 +950,19 @@ module DeleteEnvironment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_environment_input ->
+    ( delete_environment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Delete an environment.\n"]
 
@@ -717,6 +981,19 @@ module DeleteEnvironmentAccountConnection : sig
     'http_type Smaws_Lib.Context.t ->
     delete_environment_account_connection_input ->
     ( delete_environment_account_connection_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_environment_account_connection_input ->
+    ( delete_environment_account_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -762,6 +1039,19 @@ module DeleteEnvironmentTemplate : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_environment_template_input ->
+    ( delete_environment_template_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "If no other major or minor versions of an environment template exist, delete the environment \
@@ -782,6 +1072,19 @@ module DeleteEnvironmentTemplateVersion : sig
     'http_type Smaws_Lib.Context.t ->
     delete_environment_template_version_input ->
     ( delete_environment_template_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_environment_template_version_input ->
+    ( delete_environment_template_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -826,6 +1129,19 @@ module DeleteRepository : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_repository_input ->
+    ( delete_repository_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "De-register and unlink your repository.\n"]
 
@@ -844,6 +1160,19 @@ module DeleteService : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_input ->
     ( delete_service_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_input ->
+    ( delete_service_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -887,6 +1216,19 @@ module DeleteServiceSyncConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_sync_config_input ->
+    ( delete_service_sync_config_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Delete the Proton Ops file.\n"]
 
@@ -905,6 +1247,19 @@ module DeleteServiceTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_template_input ->
     ( delete_service_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_template_input ->
+    ( delete_service_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -932,6 +1287,19 @@ module DeleteServiceTemplateVersion : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_template_version_input ->
     ( delete_service_template_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_template_version_input ->
+    ( delete_service_template_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -974,6 +1342,19 @@ module DeleteTemplateSyncConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_template_sync_config_input ->
+    ( delete_template_sync_config_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Delete a template sync configuration.\n"]
 
@@ -998,6 +1379,18 @@ module GetAccountSettings : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_account_settings_input ->
+    ( get_account_settings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detail data for Proton account-wide settings.\n"]
 
@@ -1015,6 +1408,18 @@ module GetComponent : sig
     'http_type Smaws_Lib.Context.t ->
     get_component_input ->
     ( get_component_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_component_input ->
+    ( get_component_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1051,6 +1456,18 @@ module GetDeployment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_deployment_input ->
+    ( get_deployment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for a deployment.\n"]
 
@@ -1075,6 +1492,18 @@ module GetEnvironment : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_environment_input ->
+    ( get_environment_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for an environment.\n"]
 
@@ -1092,6 +1521,18 @@ module GetEnvironmentAccountConnection : sig
     'http_type Smaws_Lib.Context.t ->
     get_environment_account_connection_input ->
     ( get_environment_account_connection_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_environment_account_connection_input ->
+    ( get_environment_account_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1128,6 +1569,18 @@ module GetEnvironmentTemplate : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_environment_template_input ->
+    ( get_environment_template_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for an environment template.\n"]
 
@@ -1145,6 +1598,18 @@ module GetEnvironmentTemplateVersion : sig
     'http_type Smaws_Lib.Context.t ->
     get_environment_template_version_input ->
     ( get_environment_template_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_environment_template_version_input ->
+    ( get_environment_template_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1176,6 +1641,18 @@ module GetRepository : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_repository_input ->
+    ( get_repository_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detail data for a linked repository.\n"]
 
@@ -1193,6 +1670,18 @@ module GetRepositorySyncStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_repository_sync_status_input ->
     ( get_repository_sync_status_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_repository_sync_status_input ->
+    ( get_repository_sync_status_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1228,6 +1717,17 @@ module GetResourcesSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_resources_summary_input ->
     ( get_resources_summary_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resources_summary_input ->
+    ( get_resources_summary_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1277,6 +1777,18 @@ module GetService : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_input ->
+    ( get_service_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for a service.\n"]
 
@@ -1294,6 +1806,18 @@ module GetServiceInstance : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_instance_input ->
     ( get_service_instance_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_instance_input ->
+    ( get_service_instance_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1327,6 +1851,18 @@ module GetServiceInstanceSyncStatus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_instance_sync_status_input ->
+    ( get_service_instance_sync_status_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get the status of the synced service instance.\n"]
 
@@ -1344,6 +1880,18 @@ module GetServiceSyncBlockerSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_sync_blocker_summary_input ->
     ( get_service_sync_blocker_summary_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_sync_blocker_summary_input ->
+    ( get_service_sync_blocker_summary_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1375,6 +1923,18 @@ module GetServiceSyncConfig : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_sync_config_input ->
+    ( get_service_sync_config_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed information for the service sync configuration.\n"]
 
@@ -1392,6 +1952,18 @@ module GetServiceTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_template_input ->
     ( get_service_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_template_input ->
+    ( get_service_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1423,6 +1995,18 @@ module GetServiceTemplateVersion : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_template_version_input ->
+    ( get_service_template_version_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get detailed data for a major or minor version of a service template.\n"]
 
@@ -1440,6 +2024,18 @@ module GetTemplateSyncConfig : sig
     'http_type Smaws_Lib.Context.t ->
     get_template_sync_config_input ->
     ( get_template_sync_config_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_template_sync_config_input ->
+    ( get_template_sync_config_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1471,6 +2067,18 @@ module GetTemplateSyncStatus : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_template_sync_status_input ->
+    ( get_template_sync_status_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get the status of a template sync.\n"]
 
@@ -1488,6 +2096,18 @@ module ListComponentOutputs : sig
     'http_type Smaws_Lib.Context.t ->
     list_component_outputs_input ->
     ( list_component_outputs_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_component_outputs_input ->
+    ( list_component_outputs_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1524,6 +2144,18 @@ module ListComponentProvisionedResources : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_component_provisioned_resources_input ->
+    ( list_component_provisioned_resources_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "List provisioned resources for a component with details.\n\n\
@@ -1545,6 +2177,17 @@ module ListComponents : sig
     'http_type Smaws_Lib.Context.t ->
     list_components_input ->
     ( list_components_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_components_input ->
+    ( list_components_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1581,6 +2224,18 @@ module ListDeployments : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_deployments_input ->
+    ( list_deployments_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "List deployments. You can filter the result list by environment, service, or a single service \
@@ -1599,6 +2254,17 @@ module ListEnvironmentAccountConnections : sig
     'http_type Smaws_Lib.Context.t ->
     list_environment_account_connections_input ->
     ( list_environment_account_connections_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_account_connections_input ->
+    ( list_environment_account_connections_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1634,6 +2300,18 @@ module ListEnvironmentOutputs : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_outputs_input ->
+    ( list_environment_outputs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List the infrastructure as code outputs for your environment.\n"]
 
@@ -1651,6 +2329,18 @@ module ListEnvironmentProvisionedResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_environment_provisioned_resources_input ->
     ( list_environment_provisioned_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_provisioned_resources_input ->
+    ( list_environment_provisioned_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1682,6 +2372,18 @@ module ListEnvironmentTemplateVersions : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_template_versions_input ->
+    ( list_environment_template_versions_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List major or minor versions of an environment template with detail data.\n"]
 
@@ -1698,6 +2400,17 @@ module ListEnvironmentTemplates : sig
     'http_type Smaws_Lib.Context.t ->
     list_environment_templates_input ->
     ( list_environment_templates_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environment_templates_input ->
+    ( list_environment_templates_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1721,6 +2434,18 @@ module ListEnvironments : sig
     'http_type Smaws_Lib.Context.t ->
     list_environments_input ->
     ( list_environments_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_environments_input ->
+    ( list_environments_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1752,6 +2477,18 @@ module ListRepositories : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_repositories_input ->
+    ( list_repositories_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List linked repositories with detail data.\n"]
 
@@ -1768,6 +2505,17 @@ module ListRepositorySyncDefinitions : sig
     'http_type Smaws_Lib.Context.t ->
     list_repository_sync_definitions_input ->
     ( list_repository_sync_definitions_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_repository_sync_definitions_input ->
+    ( list_repository_sync_definitions_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1791,6 +2539,18 @@ module ListServiceInstanceOutputs : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_instance_outputs_input ->
     ( list_service_instance_outputs_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_instance_outputs_input ->
+    ( list_service_instance_outputs_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1822,6 +2582,18 @@ module ListServiceInstanceProvisionedResources : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_instance_provisioned_resources_input ->
+    ( list_service_instance_provisioned_resources_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List provisioned resources for a service instance with details.\n"]
 
@@ -1839,6 +2611,18 @@ module ListServiceInstances : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_instances_input ->
     ( list_service_instances_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_instances_input ->
+    ( list_service_instances_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1872,6 +2656,18 @@ module ListServicePipelineOutputs : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_pipeline_outputs_input ->
+    ( list_service_pipeline_outputs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Get a list of service pipeline Infrastructure as Code (IaC) outputs.\n"]
 
@@ -1889,6 +2685,18 @@ module ListServicePipelineProvisionedResources : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_pipeline_provisioned_resources_input ->
     ( list_service_pipeline_provisioned_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_pipeline_provisioned_resources_input ->
+    ( list_service_pipeline_provisioned_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1920,6 +2728,18 @@ module ListServiceTemplateVersions : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_template_versions_input ->
+    ( list_service_template_versions_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List major or minor versions of a service template with detail data.\n"]
 
@@ -1936,6 +2756,17 @@ module ListServiceTemplates : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_templates_input ->
     ( list_service_templates_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_templates_input ->
+    ( list_service_templates_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -1964,6 +2795,17 @@ module ListServices : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_services_input ->
+    ( list_services_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "List services with summaries of detail data.\n"]
 
@@ -1981,6 +2823,18 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_input ->
     ( list_tags_for_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `InternalServerException of internal_server_exception
@@ -2019,6 +2873,20 @@ module NotifyResourceDeploymentStatusChange : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    notify_resource_deployment_status_change_input ->
+    ( notify_resource_deployment_status_change_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Notify Proton of status changes to a provisioned resource when you use self-managed \
@@ -2043,6 +2911,19 @@ module RejectEnvironmentAccountConnection : sig
     'http_type Smaws_Lib.Context.t ->
     reject_environment_account_connection_input ->
     ( reject_environment_account_connection_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reject_environment_account_connection_input ->
+    ( reject_environment_account_connection_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2089,6 +2970,19 @@ module TagResource : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Tag a resource. A tag is a key-value pair of metadata that you associate with an Proton \
@@ -2113,6 +3007,19 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_input ->
     ( untag_resource_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2151,6 +3058,18 @@ module UpdateAccountSettings : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_account_settings_input ->
+    ( update_account_settings_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Update Proton settings that are used for multiple services in the Amazon Web Services account.\n"]
@@ -2171,6 +3090,20 @@ module UpdateComponent : sig
     'http_type Smaws_Lib.Context.t ->
     update_component_input ->
     ( update_component_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_component_input ->
+    ( update_component_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2208,6 +3141,19 @@ module UpdateEnvironment : sig
     'http_type Smaws_Lib.Context.t ->
     update_environment_input ->
     ( update_environment_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_environment_input ->
+    ( update_environment_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2299,6 +3245,19 @@ module UpdateEnvironmentAccountConnection : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_environment_account_connection_input ->
+    ( update_environment_account_connection_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "In an environment account, update an environment account connection to use a new IAM role.\n\n\
@@ -2322,6 +3281,19 @@ module UpdateEnvironmentTemplate : sig
     'http_type Smaws_Lib.Context.t ->
     update_environment_template_input ->
     ( update_environment_template_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_environment_template_input ->
+    ( update_environment_template_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2356,6 +3328,19 @@ module UpdateEnvironmentTemplateVersion : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_environment_template_version_input ->
+    ( update_environment_template_version_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Update a major or minor version of an environment template.\n"]
 
@@ -2375,6 +3360,20 @@ module UpdateService : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_input ->
     ( update_service_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_input ->
+    ( update_service_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2426,6 +3425,19 @@ module UpdateServiceInstance : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_instance_input ->
+    ( update_service_instance_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Update a service instance.\n\n\
@@ -2456,6 +3468,19 @@ module UpdateServicePipeline : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_pipeline_input ->
     ( update_service_pipeline_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_pipeline_input ->
+    ( update_service_pipeline_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2519,6 +3544,19 @@ module UpdateServiceSyncBlocker : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_sync_blocker_input ->
+    ( update_service_sync_blocker_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Update the service sync blocker by resolving it.\n"]
 
@@ -2537,6 +3575,19 @@ module UpdateServiceSyncConfig : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_sync_config_input ->
     ( update_service_sync_config_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_sync_config_input ->
+    ( update_service_sync_config_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception
@@ -2571,6 +3622,19 @@ module UpdateServiceTemplate : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_template_input ->
+    ( update_service_template_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Update a service template.\n"]
 
@@ -2597,6 +3661,19 @@ module UpdateServiceTemplateVersion : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_template_version_input ->
+    ( update_service_template_version_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Update a major or minor version of a service template.\n"]
 
@@ -2615,6 +3692,19 @@ module UpdateTemplateSyncConfig : sig
     'http_type Smaws_Lib.Context.t ->
     update_template_sync_config_input ->
     ( update_template_sync_config_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_template_sync_config_input ->
+    ( update_template_sync_config_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/resource-groups-tagging-api/Smaws_Client_ResourceGroupsTaggingAPI.mli
+++ b/sdks/resource-groups-tagging-api/Smaws_Client_ResourceGroupsTaggingAPI.mli
@@ -159,6 +159,17 @@ module DescribeReportCreation : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ThrottledException of throttled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_report_creation_input ->
+    ( describe_report_creation_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConstraintViolationException of constraint_violation_exception
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Describes the status of the [StartReportCreation] operation. \n\n\
@@ -179,6 +190,17 @@ module GetComplianceSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_compliance_summary_input ->
     ( get_compliance_summary_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConstraintViolationException of constraint_violation_exception
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_summary_input ->
+    ( get_compliance_summary_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConstraintViolationException of constraint_violation_exception
       | `InternalServiceException of internal_service_exception
@@ -215,6 +237,17 @@ module GetResources : sig
     'http_type Smaws_Lib.Context.t ->
     get_resources_input ->
     ( get_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `PaginationTokenExpiredException of pagination_token_expired_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resources_input ->
+    ( get_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -273,6 +306,17 @@ module GetTagKeys : sig
       | `PaginationTokenExpiredException of pagination_token_expired_exception
       | `ThrottledException of throttled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_tag_keys_input ->
+    ( get_tag_keys_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `PaginationTokenExpiredException of pagination_token_expired_exception
+      | `ThrottledException of throttled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns all tag keys currently in use in the specified Amazon Web Services Region for the \
@@ -297,6 +341,17 @@ module GetTagValues : sig
     'http_type Smaws_Lib.Context.t ->
     get_tag_values_input ->
     ( get_tag_values_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `PaginationTokenExpiredException of pagination_token_expired_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_tag_values_input ->
+    ( get_tag_values_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -333,6 +388,17 @@ module ListRequiredTags : sig
       | `PaginationTokenExpiredException of pagination_token_expired_exception
       | `ThrottledException of throttled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_required_tags_input ->
+    ( list_required_tags_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `PaginationTokenExpiredException of pagination_token_expired_exception
+      | `ThrottledException of throttled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the required tags for supported resource types in an Amazon Web Services account.\n"]
@@ -351,6 +417,18 @@ module StartReportCreation : sig
     'http_type Smaws_Lib.Context.t ->
     start_report_creation_input ->
     ( start_report_creation_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `ConstraintViolationException of constraint_violation_exception
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_report_creation_input ->
+    ( start_report_creation_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `ConstraintViolationException of constraint_violation_exception
@@ -396,6 +474,16 @@ module TagResources : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resources_input ->
     ( tag_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resources_input ->
+    ( tag_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -478,6 +566,16 @@ module UntagResources : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resources_input ->
     ( untag_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resources_input ->
+    ( untag_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception

--- a/sdks/resource-groups-tagging-api/Smaws_Client_ResourceGroupsTaggingAPI.mli
+++ b/sdks/resource-groups-tagging-api/Smaws_Client_ResourceGroupsTaggingAPI.mli
@@ -168,7 +168,8 @@ module DescribeReportCreation : sig
       | `ConstraintViolationException of constraint_violation_exception
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -205,7 +206,8 @@ module GetComplianceSummary : sig
       | `ConstraintViolationException of constraint_violation_exception
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -252,7 +254,8 @@ module GetResources : sig
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `PaginationTokenExpiredException of pagination_token_expired_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -315,7 +318,8 @@ module GetTagKeys : sig
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `PaginationTokenExpiredException of pagination_token_expired_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -356,7 +360,8 @@ module GetTagValues : sig
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `PaginationTokenExpiredException of pagination_token_expired_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -397,7 +402,8 @@ module ListRequiredTags : sig
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `PaginationTokenExpiredException of pagination_token_expired_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -434,7 +440,8 @@ module StartReportCreation : sig
       | `ConstraintViolationException of constraint_violation_exception
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -487,7 +494,8 @@ module TagResources : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -579,7 +587,8 @@ module UntagResources : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/resource-groups-tagging-api/operations.ml
+++ b/sdks/resource-groups-tagging-api/operations.ml
@@ -36,6 +36,13 @@ module DescribeReportCreation = struct
       ~shape_name:"ResourceGroupsTaggingAPI_20170126.DescribeReportCreation" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_report_creation_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_report_creation_input) =
+    let input = Json_serializers.describe_report_creation_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ResourceGroupsTaggingAPI_20170126.DescribeReportCreation" ~service ~context
+      ~input ~output_deserializer:Json_deserializers.describe_report_creation_output_of_yojson
+      ~error_deserializer
 end
 
 module GetComplianceSummary = struct
@@ -70,6 +77,13 @@ module GetComplianceSummary = struct
   let request context (request : get_compliance_summary_input) =
     let input = Json_serializers.get_compliance_summary_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"ResourceGroupsTaggingAPI_20170126.GetComplianceSummary" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_compliance_summary_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_compliance_summary_input) =
+    let input = Json_serializers.get_compliance_summary_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"ResourceGroupsTaggingAPI_20170126.GetComplianceSummary" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_compliance_summary_output_of_yojson
       ~error_deserializer
@@ -109,6 +123,12 @@ module GetResources = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"ResourceGroupsTaggingAPI_20170126.GetResources"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_resources_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_resources_input) =
+    let input = Json_serializers.get_resources_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ResourceGroupsTaggingAPI_20170126.GetResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resources_output_of_yojson ~error_deserializer
 end
 
 module GetTagKeys = struct
@@ -145,6 +165,12 @@ module GetTagKeys = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"ResourceGroupsTaggingAPI_20170126.GetTagKeys"
       ~service ~context ~input ~output_deserializer:Json_deserializers.get_tag_keys_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_tag_keys_input) =
+    let input = Json_serializers.get_tag_keys_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ResourceGroupsTaggingAPI_20170126.GetTagKeys" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_tag_keys_output_of_yojson ~error_deserializer
 end
 
 module GetTagValues = struct
@@ -181,6 +207,12 @@ module GetTagValues = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"ResourceGroupsTaggingAPI_20170126.GetTagValues"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_tag_values_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_tag_values_input) =
+    let input = Json_serializers.get_tag_values_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ResourceGroupsTaggingAPI_20170126.GetTagValues" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_tag_values_output_of_yojson ~error_deserializer
 end
 
 module ListRequiredTags = struct
@@ -215,6 +247,13 @@ module ListRequiredTags = struct
   let request context (request : list_required_tags_input) =
     let input = Json_serializers.list_required_tags_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"ResourceGroupsTaggingAPI_20170126.ListRequiredTags" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_required_tags_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_required_tags_input) =
+    let input = Json_serializers.list_required_tags_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"ResourceGroupsTaggingAPI_20170126.ListRequiredTags" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_required_tags_output_of_yojson
       ~error_deserializer
@@ -260,6 +299,13 @@ module StartReportCreation = struct
       ~shape_name:"ResourceGroupsTaggingAPI_20170126.StartReportCreation" ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_report_creation_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_report_creation_input) =
+    let input = Json_serializers.start_report_creation_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ResourceGroupsTaggingAPI_20170126.StartReportCreation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_report_creation_output_of_yojson
+      ~error_deserializer
 end
 
 module TagResources = struct
@@ -291,6 +337,12 @@ module TagResources = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"ResourceGroupsTaggingAPI_20170126.TagResources"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.tag_resources_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : tag_resources_input) =
+    let input = Json_serializers.tag_resources_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ResourceGroupsTaggingAPI_20170126.TagResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resources_output_of_yojson ~error_deserializer
 end
 
 module UntagResources = struct
@@ -320,6 +372,12 @@ module UntagResources = struct
   let request context (request : untag_resources_input) =
     let input = Json_serializers.untag_resources_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"ResourceGroupsTaggingAPI_20170126.UntagResources" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resources_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : untag_resources_input) =
+    let input = Json_serializers.untag_resources_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"ResourceGroupsTaggingAPI_20170126.UntagResources" ~service ~context ~input
       ~output_deserializer:Json_deserializers.untag_resources_output_of_yojson ~error_deserializer
 end

--- a/sdks/resource-groups-tagging-api/operations.mli
+++ b/sdks/resource-groups-tagging-api/operations.mli
@@ -28,7 +28,8 @@ module DescribeReportCreation : sig
       | `ConstraintViolationException of constraint_violation_exception
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -65,7 +66,8 @@ module GetComplianceSummary : sig
       | `ConstraintViolationException of constraint_violation_exception
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -112,7 +114,8 @@ module GetResources : sig
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `PaginationTokenExpiredException of pagination_token_expired_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -175,7 +178,8 @@ module GetTagKeys : sig
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `PaginationTokenExpiredException of pagination_token_expired_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -216,7 +220,8 @@ module GetTagValues : sig
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `PaginationTokenExpiredException of pagination_token_expired_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -257,7 +262,8 @@ module ListRequiredTags : sig
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `PaginationTokenExpiredException of pagination_token_expired_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -294,7 +300,8 @@ module StartReportCreation : sig
       | `ConstraintViolationException of constraint_violation_exception
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -347,7 +354,8 @@ module TagResources : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -438,7 +446,8 @@ module UntagResources : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ThrottledException of throttled_exception ] )
+      | `ThrottledException of throttled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/resource-groups-tagging-api/operations.mli
+++ b/sdks/resource-groups-tagging-api/operations.mli
@@ -19,6 +19,17 @@ module DescribeReportCreation : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ThrottledException of throttled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_report_creation_input ->
+    ( describe_report_creation_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConstraintViolationException of constraint_violation_exception
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Describes the status of the [StartReportCreation] operation. \n\n\
@@ -39,6 +50,17 @@ module GetComplianceSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_compliance_summary_input ->
     ( get_compliance_summary_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConstraintViolationException of constraint_violation_exception
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_compliance_summary_input ->
+    ( get_compliance_summary_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConstraintViolationException of constraint_violation_exception
       | `InternalServiceException of internal_service_exception
@@ -75,6 +97,17 @@ module GetResources : sig
     'http_type Smaws_Lib.Context.t ->
     get_resources_input ->
     ( get_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `PaginationTokenExpiredException of pagination_token_expired_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resources_input ->
+    ( get_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -133,6 +166,17 @@ module GetTagKeys : sig
       | `PaginationTokenExpiredException of pagination_token_expired_exception
       | `ThrottledException of throttled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_tag_keys_input ->
+    ( get_tag_keys_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `PaginationTokenExpiredException of pagination_token_expired_exception
+      | `ThrottledException of throttled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns all tag keys currently in use in the specified Amazon Web Services Region for the \
@@ -157,6 +201,17 @@ module GetTagValues : sig
     'http_type Smaws_Lib.Context.t ->
     get_tag_values_input ->
     ( get_tag_values_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `PaginationTokenExpiredException of pagination_token_expired_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_tag_values_input ->
+    ( get_tag_values_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -193,6 +248,17 @@ module ListRequiredTags : sig
       | `PaginationTokenExpiredException of pagination_token_expired_exception
       | `ThrottledException of throttled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_required_tags_input ->
+    ( list_required_tags_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `PaginationTokenExpiredException of pagination_token_expired_exception
+      | `ThrottledException of throttled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the required tags for supported resource types in an Amazon Web Services account.\n"]
@@ -211,6 +277,18 @@ module StartReportCreation : sig
     'http_type Smaws_Lib.Context.t ->
     start_report_creation_input ->
     ( start_report_creation_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConcurrentModificationException of concurrent_modification_exception
+      | `ConstraintViolationException of constraint_violation_exception
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_report_creation_input ->
+    ( start_report_creation_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConcurrentModificationException of concurrent_modification_exception
       | `ConstraintViolationException of constraint_violation_exception
@@ -256,6 +334,16 @@ module TagResources : sig
     'http_type Smaws_Lib.Context.t ->
     tag_resources_input ->
     ( tag_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resources_input ->
+    ( tag_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -337,6 +425,16 @@ module UntagResources : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resources_input ->
     ( untag_resources_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServiceException of internal_service_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ThrottledException of throttled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resources_input ->
+    ( untag_resources_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServiceException of internal_service_exception
       | `InvalidParameterException of invalid_parameter_exception

--- a/sdks/route53-recovery-cluster/Smaws_Client_Route53RecoveryCluster.mli
+++ b/sdks/route53-recovery-cluster/Smaws_Client_Route53RecoveryCluster.mli
@@ -102,7 +102,8 @@ module GetRoutingControlState : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -175,7 +176,8 @@ module ListRoutingControls : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -251,7 +253,8 @@ module UpdateRoutingControlState : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -335,7 +338,8 @@ module UpdateRoutingControlStates : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceLimitExceededException of service_limit_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/route53-recovery-cluster/Smaws_Client_Route53RecoveryCluster.mli
+++ b/sdks/route53-recovery-cluster/Smaws_Client_Route53RecoveryCluster.mli
@@ -91,6 +91,19 @@ module GetRoutingControlState : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_routing_control_state_request ->
+    ( get_routing_control_state_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Get the state for a routing control. A routing control is a simple on/off switch that you can \
@@ -143,6 +156,19 @@ module ListRoutingControls : sig
     'http_type Smaws_Lib.Context.t ->
     list_routing_controls_request ->
     ( list_routing_controls_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_routing_controls_request ->
+    ( list_routing_controls_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
@@ -213,6 +239,20 @@ module UpdateRoutingControlState : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_routing_control_state_request ->
+    ( update_routing_control_state_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Set the state of the routing control to reroute traffic. You can set the value to ON or OFF. \
@@ -272,6 +312,21 @@ module UpdateRoutingControlStates : sig
     'http_type Smaws_Lib.Context.t ->
     update_routing_control_states_request ->
     ( update_routing_control_states_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceLimitExceededException of service_limit_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_routing_control_states_request ->
+    ( update_routing_control_states_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/route53-recovery-cluster/operations.ml
+++ b/sdks/route53-recovery-cluster/operations.ml
@@ -41,6 +41,13 @@ module GetRoutingControlState = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_routing_control_state_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_routing_control_state_request) =
+    let input = Json_serializers.get_routing_control_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ToggleCustomerAPI.GetRoutingControlState" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_routing_control_state_response_of_yojson
+      ~error_deserializer
 end
 
 module ListRoutingControls = struct
@@ -81,6 +88,13 @@ module ListRoutingControls = struct
     let input = Json_serializers.list_routing_controls_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"ToggleCustomerAPI.ListRoutingControls" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_routing_controls_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_routing_controls_request) =
+    let input = Json_serializers.list_routing_controls_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ToggleCustomerAPI.ListRoutingControls" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_routing_controls_response_of_yojson
       ~error_deserializer
 end
@@ -126,6 +140,13 @@ module UpdateRoutingControlState = struct
     let input = Json_serializers.update_routing_control_state_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"ToggleCustomerAPI.UpdateRoutingControlState"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_routing_control_state_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_routing_control_state_request) =
+    let input = Json_serializers.update_routing_control_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ToggleCustomerAPI.UpdateRoutingControlState" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_routing_control_state_response_of_yojson
       ~error_deserializer
 end
@@ -176,6 +197,13 @@ module UpdateRoutingControlStates = struct
     let input = Json_serializers.update_routing_control_states_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"ToggleCustomerAPI.UpdateRoutingControlStates"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_routing_control_states_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_routing_control_states_request) =
+    let input = Json_serializers.update_routing_control_states_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"ToggleCustomerAPI.UpdateRoutingControlStates" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_routing_control_states_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/route53-recovery-cluster/operations.mli
+++ b/sdks/route53-recovery-cluster/operations.mli
@@ -23,6 +23,19 @@ module GetRoutingControlState : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_routing_control_state_request ->
+    ( get_routing_control_state_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Get the state for a routing control. A routing control is a simple on/off switch that you can \
@@ -75,6 +88,19 @@ module ListRoutingControls : sig
     'http_type Smaws_Lib.Context.t ->
     list_routing_controls_request ->
     ( list_routing_controls_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_routing_controls_request ->
+    ( list_routing_controls_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
@@ -145,6 +171,20 @@ module UpdateRoutingControlState : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_routing_control_state_request ->
+    ( update_routing_control_state_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Set the state of the routing control to reroute traffic. You can set the value to ON or OFF. \
@@ -203,6 +243,21 @@ module UpdateRoutingControlStates : sig
     'http_type Smaws_Lib.Context.t ->
     update_routing_control_states_request ->
     ( update_routing_control_states_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `ConflictException of conflict_exception
+      | `EndpointTemporarilyUnavailableException of endpoint_temporarily_unavailable_exception
+      | `InternalServerException of internal_server_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceLimitExceededException of service_limit_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_routing_control_states_request ->
+    ( update_routing_control_states_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
       | `ConflictException of conflict_exception

--- a/sdks/route53-recovery-cluster/operations.mli
+++ b/sdks/route53-recovery-cluster/operations.mli
@@ -34,7 +34,8 @@ module GetRoutingControlState : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -107,7 +108,8 @@ module ListRoutingControls : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -183,7 +185,8 @@ module UpdateRoutingControlState : sig
       | `InternalServerException of internal_server_exception
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -266,7 +269,8 @@ module UpdateRoutingControlStates : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceLimitExceededException of service_limit_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/servicediscovery/Smaws_Client_ServiceDiscovery.mli
+++ b/sdks/servicediscovery/Smaws_Client_ServiceDiscovery.mli
@@ -492,7 +492,8 @@ module CreateHttpNamespace : sig
       | `InvalidInput of invalid_input
       | `NamespaceAlreadyExists of namespace_already_exists
       | `ResourceLimitExceeded of resource_limit_exceeded
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -535,7 +536,8 @@ module CreatePrivateDnsNamespace : sig
       | `InvalidInput of invalid_input
       | `NamespaceAlreadyExists of namespace_already_exists
       | `ResourceLimitExceeded of resource_limit_exceeded
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -579,7 +581,8 @@ module CreatePublicDnsNamespace : sig
       | `InvalidInput of invalid_input
       | `NamespaceAlreadyExists of namespace_already_exists
       | `ResourceLimitExceeded of resource_limit_exceeded
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -627,7 +630,8 @@ module CreateService : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceLimitExceeded of resource_limit_exceeded
       | `ServiceAlreadyExists of service_already_exists
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -697,7 +701,8 @@ module DeleteNamespace : sig
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
-      | `ResourceInUse of resource_in_use ] )
+      | `ResourceInUse of resource_in_use ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -729,7 +734,8 @@ module DeleteService : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ResourceInUse of resource_in_use
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -758,7 +764,8 @@ module DeleteServiceAttributes : sig
     ( delete_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes specific attributes associated with a service.\n"]
@@ -794,7 +801,8 @@ module DeregisterInstance : sig
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
       | `ResourceInUse of resource_in_use
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -829,7 +837,8 @@ module DiscoverInstances : sig
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
       | `RequestLimitExceeded of request_limit_exceeded
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -867,7 +876,8 @@ module DiscoverInstancesRevision : sig
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
       | `RequestLimitExceeded of request_limit_exceeded
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Discovers the increasing revision associated with an instance.\n"]
@@ -897,7 +907,8 @@ module GetInstance : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about a specified instance.\n"]
@@ -927,7 +938,8 @@ module GetInstancesHealthStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -960,7 +972,8 @@ module GetNamespace : sig
     ( get_namespace_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `NamespaceNotFound of namespace_not_found ] )
+      | `NamespaceNotFound of namespace_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about a namespace.\n"]
@@ -987,7 +1000,8 @@ module GetOperation : sig
     ( get_operation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `OperationNotFound of operation_not_found ] )
+      | `OperationNotFound of operation_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1020,7 +1034,8 @@ module GetService : sig
     ( get_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the settings for a specified service.\n"]
@@ -1047,7 +1062,8 @@ module GetServiceAttributes : sig
     ( get_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the attributes associated with a specified service.\n"]
@@ -1074,7 +1090,8 @@ module ListInstances : sig
     ( list_instances_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1095,7 +1112,8 @@ module ListNamespaces : sig
     'http_type Smaws_Lib.Context.t ->
     list_namespaces_request ->
     ( list_namespaces_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1117,7 +1135,8 @@ module ListOperations : sig
     'http_type Smaws_Lib.Context.t ->
     list_operations_request ->
     ( list_operations_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists operations that match the criteria that you specify.\n"]
@@ -1137,7 +1156,8 @@ module ListServices : sig
     'http_type Smaws_Lib.Context.t ->
     list_services_request ->
     ( list_services_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1165,7 +1185,8 @@ module ListTagsForResource : sig
     ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists tags for the specified resource.\n"]
@@ -1201,7 +1222,8 @@ module RegisterInstance : sig
       | `InvalidInput of invalid_input
       | `ResourceInUse of resource_in_use
       | `ResourceLimitExceeded of resource_limit_exceeded
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1275,7 +1297,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds one or more tags to the specified resource.\n"]
@@ -1302,7 +1325,8 @@ module UntagResource : sig
     ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes one or more tags from the specified resource.\n"]
@@ -1335,7 +1359,8 @@ module UpdateHttpNamespace : sig
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
-      | `ResourceInUse of resource_in_use ] )
+      | `ResourceInUse of resource_in_use ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an HTTP namespace.\n"]
@@ -1368,7 +1393,8 @@ module UpdateInstanceCustomHealthStatus : sig
       | `CustomHealthNotFound of custom_health_not_found
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1410,7 +1436,8 @@ module UpdatePrivateDnsNamespace : sig
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
-      | `ResourceInUse of resource_in_use ] )
+      | `ResourceInUse of resource_in_use ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a private DNS namespace.\n"]
@@ -1443,7 +1470,8 @@ module UpdatePublicDnsNamespace : sig
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
-      | `ResourceInUse of resource_in_use ] )
+      | `ResourceInUse of resource_in_use ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a public DNS namespace.\n"]
@@ -1473,7 +1501,8 @@ module UpdateService : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1542,7 +1571,8 @@ module UpdateServiceAttributes : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ServiceAttributesLimitExceededException of service_attributes_limit_exceeded_exception
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Submits a request to update a specified service to add service-level attributes.\n"]

--- a/sdks/servicediscovery/Smaws_Client_ServiceDiscovery.mli
+++ b/sdks/servicediscovery/Smaws_Client_ServiceDiscovery.mli
@@ -482,6 +482,18 @@ module CreateHttpNamespace : sig
       | `ResourceLimitExceeded of resource_limit_exceeded
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_http_namespace_request ->
+    ( create_http_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceAlreadyExists of namespace_already_exists
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an HTTP namespace. Service instances registered using an HTTP namespace can be \
@@ -506,6 +518,18 @@ module CreatePrivateDnsNamespace : sig
     'http_type Smaws_Lib.Context.t ->
     create_private_dns_namespace_request ->
     ( create_private_dns_namespace_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceAlreadyExists of namespace_already_exists
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_private_dns_namespace_request ->
+    ( create_private_dns_namespace_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
@@ -545,6 +569,18 @@ module CreatePublicDnsNamespace : sig
       | `ResourceLimitExceeded of resource_limit_exceeded
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_public_dns_namespace_request ->
+    ( create_public_dns_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceAlreadyExists of namespace_already_exists
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a public namespace based on DNS, which is visible on the internet. The namespace \
@@ -574,6 +610,18 @@ module CreateService : sig
     'http_type Smaws_Lib.Context.t ->
     create_service_request ->
     ( create_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `ServiceAlreadyExists of service_already_exists
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_request ->
+    ( create_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
@@ -640,6 +688,17 @@ module DeleteNamespace : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceInUse of resource_in_use ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_namespace_request ->
+    ( delete_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceInUse of resource_in_use ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a namespace from the current account. If the namespace still contains one or more \
@@ -662,6 +721,16 @@ module DeleteService : sig
       | `ResourceInUse of resource_in_use
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_request ->
+    ( delete_service_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ResourceInUse of resource_in_use
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a specified service and all associated service attributes. If the service still \
@@ -678,6 +747,15 @@ module DeleteServiceAttributes : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_attributes_request ->
     ( delete_service_attributes_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_attributes_request ->
+    ( delete_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
@@ -706,6 +784,18 @@ module DeregisterInstance : sig
       | `ResourceInUse of resource_in_use
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_instance_request ->
+    ( deregister_instance_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InstanceNotFound of instance_not_found
+      | `InvalidInput of invalid_input
+      | `ResourceInUse of resource_in_use
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the Amazon Route\194\16053 DNS records and health check, if any, that Cloud Map created \
@@ -724,6 +814,17 @@ module DiscoverInstances : sig
     'http_type Smaws_Lib.Context.t ->
     discover_instances_request ->
     ( discover_instances_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    discover_instances_request ->
+    ( discover_instances_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
@@ -757,6 +858,17 @@ module DiscoverInstancesRevision : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    discover_instances_revision_request ->
+    ( discover_instances_revision_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc "Discovers the increasing revision associated with an instance.\n"]
 
@@ -777,6 +889,16 @@ module GetInstance : sig
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_request ->
+    ( get_instance_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InstanceNotFound of instance_not_found
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc "Gets information about a specified instance.\n"]
 
@@ -792,6 +914,16 @@ module GetInstancesHealthStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_instances_health_status_request ->
     ( get_instances_health_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InstanceNotFound of instance_not_found
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instances_health_status_request ->
+    ( get_instances_health_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
@@ -821,6 +953,15 @@ module GetNamespace : sig
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_namespace_request ->
+    ( get_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found ] )
+    result
 end
 [@@ocaml.doc "Gets information about a namespace.\n"]
 
@@ -835,6 +976,15 @@ module GetOperation : sig
     'http_type Smaws_Lib.Context.t ->
     get_operation_request ->
     ( get_operation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `OperationNotFound of operation_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_operation_request ->
+    ( get_operation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `OperationNotFound of operation_not_found ] )
@@ -863,6 +1013,15 @@ module GetService : sig
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_request ->
+    ( get_service_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc "Gets the settings for a specified service.\n"]
 
@@ -877,6 +1036,15 @@ module GetServiceAttributes : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_attributes_request ->
     ( get_service_attributes_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_attributes_request ->
+    ( get_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
@@ -899,6 +1067,15 @@ module ListInstances : sig
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_instances_request ->
+    ( list_instances_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Lists summary information about the instances that you registered by using a specified service.\n"]
@@ -911,6 +1088,13 @@ module ListNamespaces : sig
     'http_type Smaws_Lib.Context.t ->
     list_namespaces_request ->
     ( list_namespaces_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_namespaces_request ->
+    ( list_namespaces_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
     result
 end
@@ -928,6 +1112,13 @@ module ListOperations : sig
     ( list_operations_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_operations_request ->
+    ( list_operations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+    result
 end
 [@@ocaml.doc "Lists operations that match the criteria that you specify.\n"]
 
@@ -939,6 +1130,13 @@ module ListServices : sig
     'http_type Smaws_Lib.Context.t ->
     list_services_request ->
     ( list_services_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_services_request ->
+    ( list_services_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
     result
 end
@@ -960,6 +1158,15 @@ module ListTagsForResource : sig
       | `InvalidInput of invalid_input
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Lists tags for the specified resource.\n"]
 
@@ -977,6 +1184,18 @@ module RegisterInstance : sig
     'http_type Smaws_Lib.Context.t ->
     register_instance_request ->
     ( register_instance_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `ResourceInUse of resource_in_use
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_instance_request ->
+    ( register_instance_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
@@ -1048,6 +1267,16 @@ module TagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc "Adds one or more tags to the specified resource.\n"]
 
@@ -1062,6 +1291,15 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -1088,6 +1326,17 @@ module UpdateHttpNamespace : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceInUse of resource_in_use ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_http_namespace_request ->
+    ( update_http_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceInUse of resource_in_use ] )
+    result
 end
 [@@ocaml.doc "Updates an HTTP namespace.\n"]
 
@@ -1104,6 +1353,17 @@ module UpdateInstanceCustomHealthStatus : sig
     'http_type Smaws_Lib.Context.t ->
     update_instance_custom_health_status_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomHealthNotFound of custom_health_not_found
+      | `InstanceNotFound of instance_not_found
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_instance_custom_health_status_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CustomHealthNotFound of custom_health_not_found
       | `InstanceNotFound of instance_not_found
@@ -1141,6 +1401,17 @@ module UpdatePrivateDnsNamespace : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceInUse of resource_in_use ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_private_dns_namespace_request ->
+    ( update_private_dns_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceInUse of resource_in_use ] )
+    result
 end
 [@@ocaml.doc "Updates a private DNS namespace.\n"]
 
@@ -1163,6 +1434,17 @@ module UpdatePublicDnsNamespace : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceInUse of resource_in_use ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_public_dns_namespace_request ->
+    ( update_public_dns_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceInUse of resource_in_use ] )
+    result
 end
 [@@ocaml.doc "Updates a public DNS namespace.\n"]
 
@@ -1178,6 +1460,16 @@ module UpdateService : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_request ->
     ( update_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_request ->
+    ( update_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
@@ -1237,6 +1529,16 @@ module UpdateServiceAttributes : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_attributes_request ->
     ( update_service_attributes_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceAttributesLimitExceededException of service_attributes_limit_exceeded_exception
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_attributes_request ->
+    ( update_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ServiceAttributesLimitExceededException of service_attributes_limit_exceeded_exception

--- a/sdks/servicediscovery/operations.ml
+++ b/sdks/servicediscovery/operations.ml
@@ -32,6 +32,13 @@ module CreateHttpNamespace = struct
       ~shape_name:"Route53AutoNaming_v20170314.CreateHttpNamespace" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_http_namespace_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_http_namespace_request) =
+    let input = Json_serializers.create_http_namespace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.CreateHttpNamespace" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_http_namespace_response_of_yojson
+      ~error_deserializer
 end
 
 module CreatePrivateDnsNamespace = struct
@@ -62,6 +69,13 @@ module CreatePrivateDnsNamespace = struct
   let request context (request : create_private_dns_namespace_request) =
     let input = Json_serializers.create_private_dns_namespace_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Route53AutoNaming_v20170314.CreatePrivateDnsNamespace" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_private_dns_namespace_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_private_dns_namespace_request) =
+    let input = Json_serializers.create_private_dns_namespace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Route53AutoNaming_v20170314.CreatePrivateDnsNamespace" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_private_dns_namespace_response_of_yojson
       ~error_deserializer
@@ -98,6 +112,13 @@ module CreatePublicDnsNamespace = struct
       ~shape_name:"Route53AutoNaming_v20170314.CreatePublicDnsNamespace" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_public_dns_namespace_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_public_dns_namespace_request) =
+    let input = Json_serializers.create_public_dns_namespace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.CreatePublicDnsNamespace" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_public_dns_namespace_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateService = struct
@@ -130,6 +151,12 @@ module CreateService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.CreateService"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_service_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_service_request) =
+    let input = Json_serializers.create_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.CreateService" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_service_response_of_yojson ~error_deserializer
 end
 
 module DeleteNamespace = struct
@@ -160,6 +187,13 @@ module DeleteNamespace = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_namespace_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_namespace_request) =
+    let input = Json_serializers.delete_namespace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.DeleteNamespace" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_namespace_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteService = struct
@@ -186,6 +220,12 @@ module DeleteService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.DeleteService"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_service_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : delete_service_request) =
+    let input = Json_serializers.delete_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.DeleteService" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_service_response_of_yojson ~error_deserializer
 end
 
 module DeleteServiceAttributes = struct
@@ -207,6 +247,13 @@ module DeleteServiceAttributes = struct
   let request context (request : delete_service_attributes_request) =
     let input = Json_serializers.delete_service_attributes_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Route53AutoNaming_v20170314.DeleteServiceAttributes" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_service_attributes_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_service_attributes_request) =
+    let input = Json_serializers.delete_service_attributes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Route53AutoNaming_v20170314.DeleteServiceAttributes" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_service_attributes_response_of_yojson
       ~error_deserializer
@@ -243,6 +290,13 @@ module DeregisterInstance = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.deregister_instance_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deregister_instance_request) =
+    let input = Json_serializers.deregister_instance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.DeregisterInstance" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.deregister_instance_response_of_yojson
+      ~error_deserializer
 end
 
 module DiscoverInstances = struct
@@ -271,6 +325,13 @@ module DiscoverInstances = struct
     let input = Json_serializers.discover_instances_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.DiscoverInstances"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.discover_instances_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : discover_instances_request) =
+    let input = Json_serializers.discover_instances_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.DiscoverInstances" ~service ~context ~input
       ~output_deserializer:Json_deserializers.discover_instances_response_of_yojson
       ~error_deserializer
 end
@@ -303,6 +364,13 @@ module DiscoverInstancesRevision = struct
       ~shape_name:"Route53AutoNaming_v20170314.DiscoverInstancesRevision" ~service ~context ~input
       ~output_deserializer:Json_deserializers.discover_instances_revision_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : discover_instances_revision_request) =
+    let input = Json_serializers.discover_instances_revision_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.DiscoverInstancesRevision" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.discover_instances_revision_response_of_yojson
+      ~error_deserializer
 end
 
 module GetInstance = struct
@@ -328,6 +396,12 @@ module GetInstance = struct
     let input = Json_serializers.get_instance_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.GetInstance"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_instance_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_instance_request) =
+    let input = Json_serializers.get_instance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.GetInstance" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_instance_response_of_yojson ~error_deserializer
 end
 
@@ -356,6 +430,13 @@ module GetInstancesHealthStatus = struct
       ~shape_name:"Route53AutoNaming_v20170314.GetInstancesHealthStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_instances_health_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_instances_health_status_request) =
+    let input = Json_serializers.get_instances_health_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.GetInstancesHealthStatus" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_instances_health_status_response_of_yojson
+      ~error_deserializer
 end
 
 module GetNamespace = struct
@@ -378,6 +459,12 @@ module GetNamespace = struct
     let input = Json_serializers.get_namespace_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.GetNamespace"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_namespace_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_namespace_request) =
+    let input = Json_serializers.get_namespace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.GetNamespace" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_namespace_response_of_yojson ~error_deserializer
 end
 
@@ -402,6 +489,12 @@ module GetOperation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.GetOperation"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_operation_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_operation_request) =
+    let input = Json_serializers.get_operation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.GetOperation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_operation_response_of_yojson ~error_deserializer
 end
 
 module GetService = struct
@@ -425,6 +518,12 @@ module GetService = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.GetService"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_service_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_service_request) =
+    let input = Json_serializers.get_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.GetService" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_service_response_of_yojson ~error_deserializer
 end
 
 module GetServiceAttributes = struct
@@ -446,6 +545,13 @@ module GetServiceAttributes = struct
   let request context (request : get_service_attributes_request) =
     let input = Json_serializers.get_service_attributes_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Route53AutoNaming_v20170314.GetServiceAttributes" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_service_attributes_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_service_attributes_request) =
+    let input = Json_serializers.get_service_attributes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Route53AutoNaming_v20170314.GetServiceAttributes" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_service_attributes_response_of_yojson
       ~error_deserializer
@@ -472,6 +578,12 @@ module ListInstances = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.ListInstances"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_instances_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_instances_request) =
+    let input = Json_serializers.list_instances_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.ListInstances" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_instances_response_of_yojson ~error_deserializer
 end
 
 module ListNamespaces = struct
@@ -491,6 +603,12 @@ module ListNamespaces = struct
     let input = Json_serializers.list_namespaces_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.ListNamespaces"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_namespaces_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_namespaces_request) =
+    let input = Json_serializers.list_namespaces_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.ListNamespaces" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_namespaces_response_of_yojson ~error_deserializer
 end
 
@@ -512,6 +630,12 @@ module ListOperations = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.ListOperations"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_operations_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_operations_request) =
+    let input = Json_serializers.list_operations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.ListOperations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_operations_response_of_yojson ~error_deserializer
 end
 
 module ListServices = struct
@@ -531,6 +655,12 @@ module ListServices = struct
     let input = Json_serializers.list_services_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.ListServices"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_services_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_services_request) =
+    let input = Json_serializers.list_services_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.ListServices" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_services_response_of_yojson ~error_deserializer
 end
 
@@ -554,6 +684,13 @@ module ListTagsForResource = struct
   let request context (request : list_tags_for_resource_request) =
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Route53AutoNaming_v20170314.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Route53AutoNaming_v20170314.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
@@ -590,6 +727,13 @@ module RegisterInstance = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.register_instance_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : register_instance_request) =
+    let input = Json_serializers.register_instance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.RegisterInstance" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.register_instance_response_of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -617,6 +761,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.TagResource"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.TagResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -640,6 +790,12 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.UntagResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.UntagResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
@@ -668,6 +824,13 @@ module UpdateHttpNamespace = struct
   let request context (request : update_http_namespace_request) =
     let input = Json_serializers.update_http_namespace_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Route53AutoNaming_v20170314.UpdateHttpNamespace" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_http_namespace_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_http_namespace_request) =
+    let input = Json_serializers.update_http_namespace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Route53AutoNaming_v20170314.UpdateHttpNamespace" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_http_namespace_response_of_yojson
       ~error_deserializer
@@ -701,6 +864,13 @@ module UpdateInstanceCustomHealthStatus = struct
       ~shape_name:"Route53AutoNaming_v20170314.UpdateInstanceCustomHealthStatus" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_instance_custom_health_status_request) =
+    let input = Json_serializers.update_instance_custom_health_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.UpdateInstanceCustomHealthStatus" ~service ~context
+      ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UpdatePrivateDnsNamespace = struct
@@ -728,6 +898,13 @@ module UpdatePrivateDnsNamespace = struct
   let request context (request : update_private_dns_namespace_request) =
     let input = Json_serializers.update_private_dns_namespace_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Route53AutoNaming_v20170314.UpdatePrivateDnsNamespace" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_private_dns_namespace_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_private_dns_namespace_request) =
+    let input = Json_serializers.update_private_dns_namespace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Route53AutoNaming_v20170314.UpdatePrivateDnsNamespace" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_private_dns_namespace_response_of_yojson
       ~error_deserializer
@@ -761,6 +938,13 @@ module UpdatePublicDnsNamespace = struct
       ~shape_name:"Route53AutoNaming_v20170314.UpdatePublicDnsNamespace" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_public_dns_namespace_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_public_dns_namespace_request) =
+    let input = Json_serializers.update_public_dns_namespace_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.UpdatePublicDnsNamespace" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_public_dns_namespace_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateService = struct
@@ -786,6 +970,12 @@ module UpdateService = struct
     let input = Json_serializers.update_service_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Route53AutoNaming_v20170314.UpdateService"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : update_service_request) =
+    let input = Json_serializers.update_service_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Route53AutoNaming_v20170314.UpdateService" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_service_response_of_yojson ~error_deserializer
 end
 
@@ -813,6 +1003,13 @@ module UpdateServiceAttributes = struct
   let request context (request : update_service_attributes_request) =
     let input = Json_serializers.update_service_attributes_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"Route53AutoNaming_v20170314.UpdateServiceAttributes" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_attributes_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_service_attributes_request) =
+    let input = Json_serializers.update_service_attributes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"Route53AutoNaming_v20170314.UpdateServiceAttributes" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_service_attributes_response_of_yojson
       ~error_deserializer

--- a/sdks/servicediscovery/operations.mli
+++ b/sdks/servicediscovery/operations.mli
@@ -21,6 +21,18 @@ module CreateHttpNamespace : sig
       | `ResourceLimitExceeded of resource_limit_exceeded
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_http_namespace_request ->
+    ( create_http_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceAlreadyExists of namespace_already_exists
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an HTTP namespace. Service instances registered using an HTTP namespace can be \
@@ -45,6 +57,18 @@ module CreatePrivateDnsNamespace : sig
     'http_type Smaws_Lib.Context.t ->
     create_private_dns_namespace_request ->
     ( create_private_dns_namespace_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceAlreadyExists of namespace_already_exists
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_private_dns_namespace_request ->
+    ( create_private_dns_namespace_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
@@ -84,6 +108,18 @@ module CreatePublicDnsNamespace : sig
       | `ResourceLimitExceeded of resource_limit_exceeded
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_public_dns_namespace_request ->
+    ( create_public_dns_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceAlreadyExists of namespace_already_exists
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a public namespace based on DNS, which is visible on the internet. The namespace \
@@ -113,6 +149,18 @@ module CreateService : sig
     'http_type Smaws_Lib.Context.t ->
     create_service_request ->
     ( create_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `ServiceAlreadyExists of service_already_exists
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_service_request ->
+    ( create_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
@@ -179,6 +227,17 @@ module DeleteNamespace : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceInUse of resource_in_use ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_namespace_request ->
+    ( delete_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceInUse of resource_in_use ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a namespace from the current account. If the namespace still contains one or more \
@@ -201,6 +260,16 @@ module DeleteService : sig
       | `ResourceInUse of resource_in_use
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_request ->
+    ( delete_service_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ResourceInUse of resource_in_use
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a specified service and all associated service attributes. If the service still \
@@ -217,6 +286,15 @@ module DeleteServiceAttributes : sig
     'http_type Smaws_Lib.Context.t ->
     delete_service_attributes_request ->
     ( delete_service_attributes_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_service_attributes_request ->
+    ( delete_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
@@ -245,6 +323,18 @@ module DeregisterInstance : sig
       | `ResourceInUse of resource_in_use
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_instance_request ->
+    ( deregister_instance_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InstanceNotFound of instance_not_found
+      | `InvalidInput of invalid_input
+      | `ResourceInUse of resource_in_use
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the Amazon Route\194\16053 DNS records and health check, if any, that Cloud Map created \
@@ -263,6 +353,17 @@ module DiscoverInstances : sig
     'http_type Smaws_Lib.Context.t ->
     discover_instances_request ->
     ( discover_instances_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    discover_instances_request ->
+    ( discover_instances_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
@@ -296,6 +397,17 @@ module DiscoverInstancesRevision : sig
       | `RequestLimitExceeded of request_limit_exceeded
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    discover_instances_revision_request ->
+    ( discover_instances_revision_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `RequestLimitExceeded of request_limit_exceeded
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc "Discovers the increasing revision associated with an instance.\n"]
 
@@ -316,6 +428,16 @@ module GetInstance : sig
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instance_request ->
+    ( get_instance_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InstanceNotFound of instance_not_found
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc "Gets information about a specified instance.\n"]
 
@@ -331,6 +453,16 @@ module GetInstancesHealthStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_instances_health_status_request ->
     ( get_instances_health_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InstanceNotFound of instance_not_found
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_instances_health_status_request ->
+    ( get_instances_health_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
@@ -360,6 +492,15 @@ module GetNamespace : sig
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_namespace_request ->
+    ( get_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found ] )
+    result
 end
 [@@ocaml.doc "Gets information about a namespace.\n"]
 
@@ -374,6 +515,15 @@ module GetOperation : sig
     'http_type Smaws_Lib.Context.t ->
     get_operation_request ->
     ( get_operation_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `OperationNotFound of operation_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_operation_request ->
+    ( get_operation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `OperationNotFound of operation_not_found ] )
@@ -402,6 +552,15 @@ module GetService : sig
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_request ->
+    ( get_service_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc "Gets the settings for a specified service.\n"]
 
@@ -416,6 +575,15 @@ module GetServiceAttributes : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_attributes_request ->
     ( get_service_attributes_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_attributes_request ->
+    ( get_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
@@ -438,6 +606,15 @@ module ListInstances : sig
       | `InvalidInput of invalid_input
       | `ServiceNotFound of service_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_instances_request ->
+    ( list_instances_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Lists summary information about the instances that you registered by using a specified service.\n"]
@@ -450,6 +627,13 @@ module ListNamespaces : sig
     'http_type Smaws_Lib.Context.t ->
     list_namespaces_request ->
     ( list_namespaces_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_namespaces_request ->
+    ( list_namespaces_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
     result
 end
@@ -467,6 +651,13 @@ module ListOperations : sig
     ( list_operations_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_operations_request ->
+    ( list_operations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+    result
 end
 [@@ocaml.doc "Lists operations that match the criteria that you specify.\n"]
 
@@ -478,6 +669,13 @@ module ListServices : sig
     'http_type Smaws_Lib.Context.t ->
     list_services_request ->
     ( list_services_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_services_request ->
+    ( list_services_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
     result
 end
@@ -499,6 +697,15 @@ module ListTagsForResource : sig
       | `InvalidInput of invalid_input
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Lists tags for the specified resource.\n"]
 
@@ -516,6 +723,18 @@ module RegisterInstance : sig
     'http_type Smaws_Lib.Context.t ->
     register_instance_request ->
     ( register_instance_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `ResourceInUse of resource_in_use
+      | `ResourceLimitExceeded of resource_limit_exceeded
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_instance_request ->
+    ( register_instance_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
@@ -587,6 +806,16 @@ module TagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc "Adds one or more tags to the specified resource.\n"]
 
@@ -601,6 +830,15 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -627,6 +865,17 @@ module UpdateHttpNamespace : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceInUse of resource_in_use ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_http_namespace_request ->
+    ( update_http_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceInUse of resource_in_use ] )
+    result
 end
 [@@ocaml.doc "Updates an HTTP namespace.\n"]
 
@@ -643,6 +892,17 @@ module UpdateInstanceCustomHealthStatus : sig
     'http_type Smaws_Lib.Context.t ->
     update_instance_custom_health_status_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomHealthNotFound of custom_health_not_found
+      | `InstanceNotFound of instance_not_found
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_instance_custom_health_status_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `CustomHealthNotFound of custom_health_not_found
       | `InstanceNotFound of instance_not_found
@@ -680,6 +940,17 @@ module UpdatePrivateDnsNamespace : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceInUse of resource_in_use ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_private_dns_namespace_request ->
+    ( update_private_dns_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceInUse of resource_in_use ] )
+    result
 end
 [@@ocaml.doc "Updates a private DNS namespace.\n"]
 
@@ -702,6 +973,17 @@ module UpdatePublicDnsNamespace : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceInUse of resource_in_use ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_public_dns_namespace_request ->
+    ( update_public_dns_namespace_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `NamespaceNotFound of namespace_not_found
+      | `ResourceInUse of resource_in_use ] )
+    result
 end
 [@@ocaml.doc "Updates a public DNS namespace.\n"]
 
@@ -717,6 +999,16 @@ module UpdateService : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_request ->
     ( update_service_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateRequest of duplicate_request
+      | `InvalidInput of invalid_input
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_request ->
+    ( update_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
@@ -775,6 +1067,16 @@ module UpdateServiceAttributes : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_attributes_request ->
     ( update_service_attributes_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidInput of invalid_input
+      | `ServiceAttributesLimitExceededException of service_attributes_limit_exceeded_exception
+      | `ServiceNotFound of service_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_attributes_request ->
+    ( update_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ServiceAttributesLimitExceededException of service_attributes_limit_exceeded_exception

--- a/sdks/servicediscovery/operations.mli
+++ b/sdks/servicediscovery/operations.mli
@@ -31,7 +31,8 @@ module CreateHttpNamespace : sig
       | `InvalidInput of invalid_input
       | `NamespaceAlreadyExists of namespace_already_exists
       | `ResourceLimitExceeded of resource_limit_exceeded
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -74,7 +75,8 @@ module CreatePrivateDnsNamespace : sig
       | `InvalidInput of invalid_input
       | `NamespaceAlreadyExists of namespace_already_exists
       | `ResourceLimitExceeded of resource_limit_exceeded
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -118,7 +120,8 @@ module CreatePublicDnsNamespace : sig
       | `InvalidInput of invalid_input
       | `NamespaceAlreadyExists of namespace_already_exists
       | `ResourceLimitExceeded of resource_limit_exceeded
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -166,7 +169,8 @@ module CreateService : sig
       | `NamespaceNotFound of namespace_not_found
       | `ResourceLimitExceeded of resource_limit_exceeded
       | `ServiceAlreadyExists of service_already_exists
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -236,7 +240,8 @@ module DeleteNamespace : sig
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
-      | `ResourceInUse of resource_in_use ] )
+      | `ResourceInUse of resource_in_use ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -268,7 +273,8 @@ module DeleteService : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ResourceInUse of resource_in_use
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -297,7 +303,8 @@ module DeleteServiceAttributes : sig
     ( delete_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes specific attributes associated with a service.\n"]
@@ -333,7 +340,8 @@ module DeregisterInstance : sig
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
       | `ResourceInUse of resource_in_use
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -368,7 +376,8 @@ module DiscoverInstances : sig
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
       | `RequestLimitExceeded of request_limit_exceeded
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -406,7 +415,8 @@ module DiscoverInstancesRevision : sig
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
       | `RequestLimitExceeded of request_limit_exceeded
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Discovers the increasing revision associated with an instance.\n"]
@@ -436,7 +446,8 @@ module GetInstance : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about a specified instance.\n"]
@@ -466,7 +477,8 @@ module GetInstancesHealthStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -499,7 +511,8 @@ module GetNamespace : sig
     ( get_namespace_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `NamespaceNotFound of namespace_not_found ] )
+      | `NamespaceNotFound of namespace_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets information about a namespace.\n"]
@@ -526,7 +539,8 @@ module GetOperation : sig
     ( get_operation_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `OperationNotFound of operation_not_found ] )
+      | `OperationNotFound of operation_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -559,7 +573,8 @@ module GetService : sig
     ( get_service_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the settings for a specified service.\n"]
@@ -586,7 +601,8 @@ module GetServiceAttributes : sig
     ( get_service_attributes_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the attributes associated with a specified service.\n"]
@@ -613,7 +629,8 @@ module ListInstances : sig
     ( list_instances_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -634,7 +651,8 @@ module ListNamespaces : sig
     'http_type Smaws_Lib.Context.t ->
     list_namespaces_request ->
     ( list_namespaces_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -656,7 +674,8 @@ module ListOperations : sig
     'http_type Smaws_Lib.Context.t ->
     list_operations_request ->
     ( list_operations_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists operations that match the criteria that you specify.\n"]
@@ -676,7 +695,8 @@ module ListServices : sig
     'http_type Smaws_Lib.Context.t ->
     list_services_request ->
     ( list_services_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidInput of invalid_input ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -704,7 +724,8 @@ module ListTagsForResource : sig
     ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists tags for the specified resource.\n"]
@@ -740,7 +761,8 @@ module RegisterInstance : sig
       | `InvalidInput of invalid_input
       | `ResourceInUse of resource_in_use
       | `ResourceLimitExceeded of resource_limit_exceeded
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -814,7 +836,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds one or more tags to the specified resource.\n"]
@@ -841,7 +864,8 @@ module UntagResource : sig
     ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes one or more tags from the specified resource.\n"]
@@ -874,7 +898,8 @@ module UpdateHttpNamespace : sig
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
-      | `ResourceInUse of resource_in_use ] )
+      | `ResourceInUse of resource_in_use ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an HTTP namespace.\n"]
@@ -907,7 +932,8 @@ module UpdateInstanceCustomHealthStatus : sig
       | `CustomHealthNotFound of custom_health_not_found
       | `InstanceNotFound of instance_not_found
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -949,7 +975,8 @@ module UpdatePrivateDnsNamespace : sig
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
-      | `ResourceInUse of resource_in_use ] )
+      | `ResourceInUse of resource_in_use ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a private DNS namespace.\n"]
@@ -982,7 +1009,8 @@ module UpdatePublicDnsNamespace : sig
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
       | `NamespaceNotFound of namespace_not_found
-      | `ResourceInUse of resource_in_use ] )
+      | `ResourceInUse of resource_in_use ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a public DNS namespace.\n"]
@@ -1012,7 +1040,8 @@ module UpdateService : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateRequest of duplicate_request
       | `InvalidInput of invalid_input
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1080,7 +1109,8 @@ module UpdateServiceAttributes : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidInput of invalid_input
       | `ServiceAttributesLimitExceededException of service_attributes_limit_exceeded_exception
-      | `ServiceNotFound of service_not_found ] )
+      | `ServiceNotFound of service_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Submits a request to update a specified service to add service-level attributes.\n"]

--- a/sdks/sfn/Smaws_Client_SFN.mli
+++ b/sdks/sfn/Smaws_Client_SFN.mli
@@ -880,6 +880,20 @@ module CreateActivity : sig
       | `KmsThrottlingException of kms_throttling_exception
       | `TooManyTags of too_many_tags ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_activity_input ->
+    ( create_activity_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ActivityAlreadyExists of activity_already_exists
+      | `ActivityLimitExceeded of activity_limit_exceeded
+      | `InvalidEncryptionConfiguration of invalid_encryption_configuration
+      | `InvalidName of invalid_name
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `TooManyTags of too_many_tags ] )
+    result
 end
 [@@ocaml.doc
   "Creates an activity. An activity is a task that you write in any programming language and host \
@@ -922,6 +936,28 @@ module CreateStateMachine : sig
     'http_type Smaws_Lib.Context.t ->
     create_state_machine_input ->
     ( create_state_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `InvalidDefinition of invalid_definition
+      | `InvalidEncryptionConfiguration of invalid_encryption_configuration
+      | `InvalidLoggingConfiguration of invalid_logging_configuration
+      | `InvalidName of invalid_name
+      | `InvalidTracingConfiguration of invalid_tracing_configuration
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `StateMachineAlreadyExists of state_machine_already_exists
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineLimitExceeded of state_machine_limit_exceeded
+      | `StateMachineTypeNotSupported of state_machine_type_not_supported
+      | `TooManyTags of too_many_tags
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_state_machine_input ->
+    ( create_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
@@ -994,6 +1030,20 @@ module CreateStateMachineAlias : sig
       | `StateMachineDeleting of state_machine_deleting
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_state_machine_alias_input ->
+    ( create_state_machine_alias_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `InvalidName of invalid_name
+      | `ResourceNotFound of resource_not_found
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an \
@@ -1046,6 +1096,13 @@ module DeleteActivity : sig
     ( delete_activity_output,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidArn of invalid_arn ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_activity_input ->
+    ( delete_activity_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidArn of invalid_arn ] )
+    result
 end
 [@@ocaml.doc "Deletes an activity.\n"]
 
@@ -1060,6 +1117,15 @@ module DeleteStateMachine : sig
     'http_type Smaws_Lib.Context.t ->
     delete_state_machine_input ->
     ( delete_state_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_state_machine_input ->
+    ( delete_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ValidationException of validation_exception ] )
@@ -1123,6 +1189,17 @@ module DeleteStateMachineAlias : sig
       | `ResourceNotFound of resource_not_found
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_state_machine_alias_input ->
+    ( delete_state_machine_alias_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a state machine \
@@ -1161,6 +1238,16 @@ module DeleteStateMachineVersion : sig
     'http_type Smaws_Lib.Context.t ->
     delete_state_machine_version_input ->
     ( delete_state_machine_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_state_machine_version_input ->
+    ( delete_state_machine_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
@@ -1206,6 +1293,15 @@ module DescribeActivity : sig
       | `ActivityDoesNotExist of activity_does_not_exist
       | `InvalidArn of invalid_arn ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_activity_input ->
+    ( describe_activity_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ActivityDoesNotExist of activity_does_not_exist
+      | `InvalidArn of invalid_arn ] )
+    result
 end
 [@@ocaml.doc
   "Describes an activity.\n\n\
@@ -1228,6 +1324,18 @@ module DescribeExecution : sig
     'http_type Smaws_Lib.Context.t ->
     describe_execution_input ->
     ( describe_execution_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_execution_input ->
+    ( describe_execution_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionDoesNotExist of execution_does_not_exist
       | `InvalidArn of invalid_arn
@@ -1268,6 +1376,15 @@ module DescribeMapRun : sig
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_map_run_input ->
+    ( describe_map_run_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about a Map Run's configuration, progress, and results. If you've \
@@ -1291,6 +1408,18 @@ module DescribeStateMachine : sig
     'http_type Smaws_Lib.Context.t ->
     describe_state_machine_input ->
     ( describe_state_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `StateMachineDoesNotExist of state_machine_does_not_exist ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_state_machine_input ->
+    ( describe_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `KmsAccessDeniedException of kms_access_denied_exception
@@ -1366,6 +1495,16 @@ module DescribeStateMachineAlias : sig
       | `ResourceNotFound of resource_not_found
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_state_machine_alias_input ->
+    ( describe_state_machine_alias_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns details about a state machine \
@@ -1409,6 +1548,18 @@ module DescribeStateMachineForExecution : sig
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_state_machine_for_execution_input ->
+    ( describe_state_machine_for_execution_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about a state machine's definition, its execution role ARN, and \
@@ -1436,6 +1587,19 @@ module GetActivityTask : sig
     'http_type Smaws_Lib.Context.t ->
     get_activity_task_input ->
     ( get_activity_task_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ActivityDoesNotExist of activity_does_not_exist
+      | `ActivityWorkerLimitExceeded of activity_worker_limit_exceeded
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_activity_task_input ->
+    ( get_activity_task_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ActivityDoesNotExist of activity_does_not_exist
       | `ActivityWorkerLimitExceeded of activity_worker_limit_exceeded
@@ -1486,6 +1650,19 @@ module GetExecutionHistory : sig
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_execution_history_input ->
+    ( get_execution_history_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the history of the specified execution as a list of events. By default, the results are \
@@ -1507,6 +1684,13 @@ module ListActivities : sig
     'http_type Smaws_Lib.Context.t ->
     list_activities_input ->
     ( list_activities_output,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_activities_input ->
+    ( list_activities_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
     result
 end
@@ -1537,6 +1721,19 @@ module ListExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     list_executions_input ->
     ( list_executions_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token
+      | `ResourceNotFound of resource_not_found
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `StateMachineTypeNotSupported of state_machine_type_not_supported
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_executions_input ->
+    ( list_executions_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `InvalidToken of invalid_token
@@ -1588,6 +1785,16 @@ module ListMapRuns : sig
       | `InvalidArn of invalid_arn
       | `InvalidToken of invalid_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_map_runs_input ->
+    ( list_map_runs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token ] )
+    result
 end
 [@@ocaml.doc
   "Lists all Map Runs that were started by a given state machine execution. Use this API action to \
@@ -1607,6 +1814,18 @@ module ListStateMachineAliases : sig
     'http_type Smaws_Lib.Context.t ->
     list_state_machine_aliases_input ->
     ( list_state_machine_aliases_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token
+      | `ResourceNotFound of resource_not_found
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_state_machine_aliases_input ->
+    ( list_state_machine_aliases_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `InvalidToken of invalid_token
@@ -1664,6 +1883,16 @@ module ListStateMachineVersions : sig
       | `InvalidToken of invalid_token
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_state_machine_versions_input ->
+    ( list_state_machine_versions_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists \
@@ -1698,6 +1927,13 @@ module ListStateMachines : sig
     ( list_state_machines_output,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_state_machines_input ->
+    ( list_state_machines_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
+    result
 end
 [@@ocaml.doc
   "Lists the existing state machines.\n\n\
@@ -1726,6 +1962,15 @@ module ListTagsForResource : sig
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found ] )
+    result
 end
 [@@ocaml.doc
   "List tags for a given resource.\n\n\
@@ -1747,6 +1992,19 @@ module PublishStateMachineVersion : sig
     'http_type Smaws_Lib.Context.t ->
     publish_state_machine_version_input ->
     ( publish_state_machine_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    publish_state_machine_version_input ->
+    ( publish_state_machine_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
@@ -1798,6 +2056,18 @@ module RedriveExecution : sig
     'http_type Smaws_Lib.Context.t ->
     redrive_execution_input ->
     ( redrive_execution_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `ExecutionLimitExceeded of execution_limit_exceeded
+      | `ExecutionNotRedrivable of execution_not_redrivable
+      | `InvalidArn of invalid_arn
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    redrive_execution_input ->
+    ( redrive_execution_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionDoesNotExist of execution_does_not_exist
       | `ExecutionLimitExceeded of execution_limit_exceeded
@@ -1885,6 +2155,19 @@ module SendTaskFailure : sig
       | `TaskDoesNotExist of task_does_not_exist
       | `TaskTimedOut of task_timed_out ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_task_failure_input ->
+    ( send_task_failure_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidToken of invalid_token
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `TaskDoesNotExist of task_does_not_exist
+      | `TaskTimedOut of task_timed_out ] )
+    result
 end
 [@@ocaml.doc
   "Used by activity workers, Task states using the \
@@ -1912,6 +2195,16 @@ module SendTaskHeartbeat : sig
     'http_type Smaws_Lib.Context.t ->
     send_task_heartbeat_input ->
     ( send_task_heartbeat_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidToken of invalid_token
+      | `TaskDoesNotExist of task_does_not_exist
+      | `TaskTimedOut of task_timed_out ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_task_heartbeat_input ->
+    ( send_task_heartbeat_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidToken of invalid_token
       | `TaskDoesNotExist of task_does_not_exist
@@ -1964,6 +2257,20 @@ module SendTaskSuccess : sig
       | `TaskDoesNotExist of task_does_not_exist
       | `TaskTimedOut of task_timed_out ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_task_success_input ->
+    ( send_task_success_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidOutput of invalid_output
+      | `InvalidToken of invalid_token
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `TaskDoesNotExist of task_does_not_exist
+      | `TaskTimedOut of task_timed_out ] )
+    result
 end
 [@@ocaml.doc
   "Used by activity workers, Task states using the \
@@ -1992,6 +2299,24 @@ module StartExecution : sig
     'http_type Smaws_Lib.Context.t ->
     start_execution_input ->
     ( start_execution_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionAlreadyExists of execution_already_exists
+      | `ExecutionLimitExceeded of execution_limit_exceeded
+      | `InvalidArn of invalid_arn
+      | `InvalidExecutionInput of invalid_execution_input
+      | `InvalidName of invalid_name
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_execution_input ->
+    ( start_execution_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionAlreadyExists of execution_already_exists
       | `ExecutionLimitExceeded of execution_limit_exceeded
@@ -2095,6 +2420,22 @@ module StartSyncExecution : sig
       | `StateMachineDoesNotExist of state_machine_does_not_exist
       | `StateMachineTypeNotSupported of state_machine_type_not_supported ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_sync_execution_input ->
+    ( start_sync_execution_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidExecutionInput of invalid_execution_input
+      | `InvalidName of invalid_name
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `StateMachineTypeNotSupported of state_machine_type_not_supported ] )
+    result
 end
 [@@ocaml.doc
   "Starts a Synchronous Express state machine execution. [StartSyncExecution] is not available for \
@@ -2123,6 +2464,19 @@ module StopExecution : sig
     'http_type Smaws_Lib.Context.t ->
     stop_execution_input ->
     ( stop_execution_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_execution_input ->
+    ( stop_execution_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionDoesNotExist of execution_does_not_exist
       | `InvalidArn of invalid_arn
@@ -2161,6 +2515,16 @@ module TagResource : sig
       | `ResourceNotFound of resource_not_found
       | `TooManyTags of too_many_tags ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `TooManyTags of too_many_tags ] )
+    result
 end
 [@@ocaml.doc
   "Add a tag to a Step Functions resource.\n\n\
@@ -2187,6 +2551,17 @@ module TestState : sig
     'http_type Smaws_Lib.Context.t ->
     test_state_input ->
     ( test_state_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidDefinition of invalid_definition
+      | `InvalidExecutionInput of invalid_execution_input
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_state_input ->
+    ( test_state_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `InvalidDefinition of invalid_definition
@@ -2280,6 +2655,15 @@ module UntagResource : sig
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found ] )
+    result
 end
 [@@ocaml.doc "Remove a tag from a Step Functions resource\n"]
 
@@ -2295,6 +2679,16 @@ module UpdateMapRun : sig
     'http_type Smaws_Lib.Context.t ->
     update_map_run_input ->
     ( update_map_run_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_map_run_input ->
+    ( update_map_run_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
@@ -2327,6 +2721,26 @@ module UpdateStateMachine : sig
     'http_type Smaws_Lib.Context.t ->
     update_state_machine_input ->
     ( update_state_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `InvalidDefinition of invalid_definition
+      | `InvalidEncryptionConfiguration of invalid_encryption_configuration
+      | `InvalidLoggingConfiguration of invalid_logging_configuration
+      | `InvalidTracingConfiguration of invalid_tracing_configuration
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `MissingRequiredParameter of missing_required_parameter
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_state_machine_input ->
+    ( update_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
@@ -2428,6 +2842,18 @@ module UpdateStateMachineAlias : sig
       | `StateMachineDeleting of state_machine_deleting
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_state_machine_alias_input ->
+    ( update_state_machine_alias_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `StateMachineDeleting of state_machine_deleting
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the configuration of an existing state machine \
@@ -2471,6 +2897,13 @@ module ValidateStateMachineDefinition : sig
     'http_type Smaws_Lib.Context.t ->
     validate_state_machine_definition_input ->
     ( validate_state_machine_definition_output,
+      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    validate_state_machine_definition_input ->
+    ( validate_state_machine_definition_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
     result
 end

--- a/sdks/sfn/Smaws_Client_SFN.mli
+++ b/sdks/sfn/Smaws_Client_SFN.mli
@@ -892,7 +892,8 @@ module CreateActivity : sig
       | `InvalidName of invalid_name
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsThrottlingException of kms_throttling_exception
-      | `TooManyTags of too_many_tags ] )
+      | `TooManyTags of too_many_tags ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -973,7 +974,8 @@ module CreateStateMachine : sig
       | `StateMachineLimitExceeded of state_machine_limit_exceeded
       | `StateMachineTypeNotSupported of state_machine_type_not_supported
       | `TooManyTags of too_many_tags
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1042,7 +1044,8 @@ module CreateStateMachineAlias : sig
       | `ResourceNotFound of resource_not_found
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `StateMachineDeleting of state_machine_deleting
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1101,7 +1104,8 @@ module DeleteActivity : sig
     'http_type Smaws_Lib.Context.t ->
     delete_activity_input ->
     ( delete_activity_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidArn of invalid_arn ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidArn of invalid_arn ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an activity.\n"]
@@ -1128,7 +1132,8 @@ module DeleteStateMachine : sig
     ( delete_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1198,7 +1203,8 @@ module DeleteStateMachineAlias : sig
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1251,7 +1257,8 @@ module DeleteStateMachineVersion : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1300,7 +1307,8 @@ module DescribeActivity : sig
     ( describe_activity_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ActivityDoesNotExist of activity_does_not_exist
-      | `InvalidArn of invalid_arn ] )
+      | `InvalidArn of invalid_arn ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1341,7 +1349,8 @@ module DescribeExecution : sig
       | `InvalidArn of invalid_arn
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
-      | `KmsThrottlingException of kms_throttling_exception ] )
+      | `KmsThrottlingException of kms_throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1383,7 +1392,8 @@ module DescribeMapRun : sig
     ( describe_map_run_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
-      | `ResourceNotFound of resource_not_found ] )
+      | `ResourceNotFound of resource_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1425,7 +1435,8 @@ module DescribeStateMachine : sig
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception
-      | `StateMachineDoesNotExist of state_machine_does_not_exist ] )
+      | `StateMachineDoesNotExist of state_machine_does_not_exist ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1503,7 +1514,8 @@ module DescribeStateMachineAlias : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1558,7 +1570,8 @@ module DescribeStateMachineForExecution : sig
       | `InvalidArn of invalid_arn
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
-      | `KmsThrottlingException of kms_throttling_exception ] )
+      | `KmsThrottlingException of kms_throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1606,7 +1619,8 @@ module GetActivityTask : sig
       | `InvalidArn of invalid_arn
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
-      | `KmsThrottlingException of kms_throttling_exception ] )
+      | `KmsThrottlingException of kms_throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1661,7 +1675,8 @@ module GetExecutionHistory : sig
       | `InvalidToken of invalid_token
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
-      | `KmsThrottlingException of kms_throttling_exception ] )
+      | `KmsThrottlingException of kms_throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1691,7 +1706,8 @@ module ListActivities : sig
     'http_type Smaws_Lib.Context.t ->
     list_activities_input ->
     ( list_activities_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1740,7 +1756,8 @@ module ListExecutions : sig
       | `ResourceNotFound of resource_not_found
       | `StateMachineDoesNotExist of state_machine_does_not_exist
       | `StateMachineTypeNotSupported of state_machine_type_not_supported
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1793,7 +1810,8 @@ module ListMapRuns : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionDoesNotExist of execution_does_not_exist
       | `InvalidArn of invalid_arn
-      | `InvalidToken of invalid_token ] )
+      | `InvalidToken of invalid_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1831,7 +1849,8 @@ module ListStateMachineAliases : sig
       | `InvalidToken of invalid_token
       | `ResourceNotFound of resource_not_found
       | `StateMachineDeleting of state_machine_deleting
-      | `StateMachineDoesNotExist of state_machine_does_not_exist ] )
+      | `StateMachineDoesNotExist of state_machine_does_not_exist ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1891,7 +1910,8 @@ module ListStateMachineVersions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `InvalidToken of invalid_token
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1932,7 +1952,8 @@ module ListStateMachines : sig
     'http_type Smaws_Lib.Context.t ->
     list_state_machines_input ->
     ( list_state_machines_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1969,7 +1990,8 @@ module ListTagsForResource : sig
     ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
-      | `ResourceNotFound of resource_not_found ] )
+      | `ResourceNotFound of resource_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2011,7 +2033,8 @@ module PublishStateMachineVersion : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `StateMachineDeleting of state_machine_deleting
       | `StateMachineDoesNotExist of state_machine_does_not_exist
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2073,7 +2096,8 @@ module RedriveExecution : sig
       | `ExecutionLimitExceeded of execution_limit_exceeded
       | `ExecutionNotRedrivable of execution_not_redrivable
       | `InvalidArn of invalid_arn
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2166,7 +2190,8 @@ module SendTaskFailure : sig
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception
       | `TaskDoesNotExist of task_does_not_exist
-      | `TaskTimedOut of task_timed_out ] )
+      | `TaskTimedOut of task_timed_out ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2208,7 +2233,8 @@ module SendTaskHeartbeat : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidToken of invalid_token
       | `TaskDoesNotExist of task_does_not_exist
-      | `TaskTimedOut of task_timed_out ] )
+      | `TaskTimedOut of task_timed_out ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2269,7 +2295,8 @@ module SendTaskSuccess : sig
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception
       | `TaskDoesNotExist of task_does_not_exist
-      | `TaskTimedOut of task_timed_out ] )
+      | `TaskTimedOut of task_timed_out ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2328,7 +2355,8 @@ module StartExecution : sig
       | `KmsThrottlingException of kms_throttling_exception
       | `StateMachineDeleting of state_machine_deleting
       | `StateMachineDoesNotExist of state_machine_does_not_exist
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2434,7 +2462,8 @@ module StartSyncExecution : sig
       | `KmsThrottlingException of kms_throttling_exception
       | `StateMachineDeleting of state_machine_deleting
       | `StateMachineDoesNotExist of state_machine_does_not_exist
-      | `StateMachineTypeNotSupported of state_machine_type_not_supported ] )
+      | `StateMachineTypeNotSupported of state_machine_type_not_supported ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2483,7 +2512,8 @@ module StopExecution : sig
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2523,7 +2553,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
-      | `TooManyTags of too_many_tags ] )
+      | `TooManyTags of too_many_tags ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2566,7 +2597,8 @@ module TestState : sig
       | `InvalidArn of invalid_arn
       | `InvalidDefinition of invalid_definition
       | `InvalidExecutionInput of invalid_execution_input
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2662,7 +2694,8 @@ module UntagResource : sig
     ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
-      | `ResourceNotFound of resource_not_found ] )
+      | `ResourceNotFound of resource_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Remove a tag from a Step Functions resource\n"]
@@ -2692,7 +2725,8 @@ module UpdateMapRun : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2754,7 +2788,8 @@ module UpdateStateMachine : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `StateMachineDeleting of state_machine_deleting
       | `StateMachineDoesNotExist of state_machine_does_not_exist
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2852,7 +2887,8 @@ module UpdateStateMachineAlias : sig
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
       | `StateMachineDeleting of state_machine_deleting
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2904,7 +2940,8 @@ module ValidateStateMachineDefinition : sig
     'http_type Smaws_Lib.Context.t ->
     validate_state_machine_definition_input ->
     ( validate_state_machine_definition_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/sfn/operations.ml
+++ b/sdks/sfn/operations.ml
@@ -38,6 +38,12 @@ module CreateActivity = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.CreateActivity" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_activity_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_activity_input) =
+    let input = Json_serializers.create_activity_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.CreateActivity"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_activity_output_of_yojson ~error_deserializer
 end
 
 module CreateStateMachine = struct
@@ -105,6 +111,13 @@ module CreateStateMachine = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.CreateStateMachine" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_state_machine_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_state_machine_input) =
+    let input = Json_serializers.create_state_machine_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.CreateStateMachine" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_state_machine_output_of_yojson
+      ~error_deserializer
 end
 
 module CreateStateMachineAlias = struct
@@ -144,6 +157,13 @@ module CreateStateMachineAlias = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_state_machine_alias_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_state_machine_alias_input) =
+    let input = Json_serializers.create_state_machine_alias_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.CreateStateMachineAlias" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_state_machine_alias_output_of_yojson
+      ~error_deserializer
 end
 
 module DeleteActivity = struct
@@ -164,6 +184,12 @@ module DeleteActivity = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.DeleteActivity" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_activity_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_activity_input) =
+    let input = Json_serializers.delete_activity_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.DeleteActivity"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_activity_output_of_yojson ~error_deserializer
 end
 
 module DeleteStateMachine = struct
@@ -186,6 +212,13 @@ module DeleteStateMachine = struct
     let input = Json_serializers.delete_state_machine_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.DeleteStateMachine" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_state_machine_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_state_machine_input) =
+    let input = Json_serializers.delete_state_machine_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.DeleteStateMachine" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_state_machine_output_of_yojson
       ~error_deserializer
 end
 
@@ -217,6 +250,13 @@ module DeleteStateMachineAlias = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_state_machine_alias_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_state_machine_alias_input) =
+    let input = Json_serializers.delete_state_machine_alias_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.DeleteStateMachineAlias" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_state_machine_alias_output_of_yojson
+      ~error_deserializer
 end
 
 module DeleteStateMachineVersion = struct
@@ -244,6 +284,13 @@ module DeleteStateMachineVersion = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_state_machine_version_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_state_machine_version_input) =
+    let input = Json_serializers.delete_state_machine_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.DeleteStateMachineVersion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_state_machine_version_output_of_yojson
+      ~error_deserializer
 end
 
 module DescribeActivity = struct
@@ -267,6 +314,12 @@ module DescribeActivity = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.DescribeActivity" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_activity_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_activity_input) =
+    let input = Json_serializers.describe_activity_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.DescribeActivity" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_activity_output_of_yojson ~error_deserializer
 end
 
 module DescribeExecution = struct
@@ -301,6 +354,13 @@ module DescribeExecution = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.DescribeExecution" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_execution_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_execution_input) =
+    let input = Json_serializers.describe_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.DescribeExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_execution_output_of_yojson
+      ~error_deserializer
 end
 
 module DescribeMapRun = struct
@@ -324,6 +384,12 @@ module DescribeMapRun = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.DescribeMapRun" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_map_run_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_map_run_input) =
+    let input = Json_serializers.describe_map_run_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.DescribeMapRun"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_map_run_output_of_yojson ~error_deserializer
 end
 
 module DescribeStateMachine = struct
@@ -360,6 +426,13 @@ module DescribeStateMachine = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.describe_state_machine_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_state_machine_input) =
+    let input = Json_serializers.describe_state_machine_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.DescribeStateMachine" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_state_machine_output_of_yojson
+      ~error_deserializer
 end
 
 module DescribeStateMachineAlias = struct
@@ -385,6 +458,13 @@ module DescribeStateMachineAlias = struct
     let input = Json_serializers.describe_state_machine_alias_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.DescribeStateMachineAlias"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_state_machine_alias_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_state_machine_alias_input) =
+    let input = Json_serializers.describe_state_machine_alias_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.DescribeStateMachineAlias" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_state_machine_alias_output_of_yojson
       ~error_deserializer
 end
@@ -419,6 +499,13 @@ module DescribeStateMachineForExecution = struct
   let request context (request : describe_state_machine_for_execution_input) =
     let input = Json_serializers.describe_state_machine_for_execution_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSStepFunctions.DescribeStateMachineForExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_state_machine_for_execution_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_state_machine_for_execution_input) =
+    let input = Json_serializers.describe_state_machine_for_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSStepFunctions.DescribeStateMachineForExecution" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_state_machine_for_execution_output_of_yojson
       ~error_deserializer
@@ -460,6 +547,12 @@ module GetActivityTask = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.GetActivityTask" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_activity_task_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_activity_task_input) =
+    let input = Json_serializers.get_activity_task_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.GetActivityTask"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_activity_task_output_of_yojson ~error_deserializer
 end
 
 module GetExecutionHistory = struct
@@ -496,6 +589,13 @@ module GetExecutionHistory = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.GetExecutionHistory" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_execution_history_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_execution_history_input) =
+    let input = Json_serializers.get_execution_history_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.GetExecutionHistory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_execution_history_output_of_yojson
+      ~error_deserializer
 end
 
 module ListActivities = struct
@@ -516,6 +616,12 @@ module ListActivities = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.ListActivities" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_activities_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_activities_input) =
+    let input = Json_serializers.list_activities_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.ListActivities"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_activities_output_of_yojson ~error_deserializer
 end
 
 module ListExecutions = struct
@@ -552,6 +658,12 @@ module ListExecutions = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.ListExecutions" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_executions_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_executions_input) =
+    let input = Json_serializers.list_executions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.ListExecutions"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_executions_output_of_yojson ~error_deserializer
 end
 
 module ListMapRuns = struct
@@ -577,6 +689,12 @@ module ListMapRuns = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.ListMapRuns" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_map_runs_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_map_runs_input) =
+    let input = Json_serializers.list_map_runs_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.ListMapRuns"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_map_runs_output_of_yojson ~error_deserializer
 end
 
 module ListStateMachineAliases = struct
@@ -610,6 +728,13 @@ module ListStateMachineAliases = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_state_machine_aliases_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_state_machine_aliases_input) =
+    let input = Json_serializers.list_state_machine_aliases_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.ListStateMachineAliases" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_state_machine_aliases_output_of_yojson
+      ~error_deserializer
 end
 
 module ListStateMachineVersions = struct
@@ -636,6 +761,13 @@ module ListStateMachineVersions = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_state_machine_versions_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_state_machine_versions_input) =
+    let input = Json_serializers.list_state_machine_versions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.ListStateMachineVersions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_state_machine_versions_output_of_yojson
+      ~error_deserializer
 end
 
 module ListStateMachines = struct
@@ -655,6 +787,13 @@ module ListStateMachines = struct
     let input = Json_serializers.list_state_machines_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.ListStateMachines" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_state_machines_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_state_machines_input) =
+    let input = Json_serializers.list_state_machines_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.ListStateMachines" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_state_machines_output_of_yojson
       ~error_deserializer
 end
 
@@ -678,6 +817,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.ListTagsForResource" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_input) =
+    let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
       ~error_deserializer
 end
@@ -718,6 +864,13 @@ module PublishStateMachineVersion = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.publish_state_machine_version_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : publish_state_machine_version_input) =
+    let input = Json_serializers.publish_state_machine_version_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.PublishStateMachineVersion" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.publish_state_machine_version_output_of_yojson
+      ~error_deserializer
 end
 
 module RedriveExecution = struct
@@ -750,6 +903,12 @@ module RedriveExecution = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.RedriveExecution" ~service
       ~context ~input ~output_deserializer:Json_deserializers.redrive_execution_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : redrive_execution_input) =
+    let input = Json_serializers.redrive_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.RedriveExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.redrive_execution_output_of_yojson ~error_deserializer
 end
 
 module SendTaskFailure = struct
@@ -786,6 +945,12 @@ module SendTaskFailure = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.SendTaskFailure" ~service
       ~context ~input ~output_deserializer:Json_deserializers.send_task_failure_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : send_task_failure_input) =
+    let input = Json_serializers.send_task_failure_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.SendTaskFailure"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.send_task_failure_output_of_yojson ~error_deserializer
 end
 
 module SendTaskHeartbeat = struct
@@ -810,6 +975,13 @@ module SendTaskHeartbeat = struct
     let input = Json_serializers.send_task_heartbeat_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.SendTaskHeartbeat" ~service
       ~context ~input ~output_deserializer:Json_deserializers.send_task_heartbeat_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : send_task_heartbeat_input) =
+    let input = Json_serializers.send_task_heartbeat_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.SendTaskHeartbeat" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.send_task_heartbeat_output_of_yojson
       ~error_deserializer
 end
 
@@ -849,6 +1021,12 @@ module SendTaskSuccess = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.SendTaskSuccess" ~service
       ~context ~input ~output_deserializer:Json_deserializers.send_task_success_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : send_task_success_input) =
+    let input = Json_serializers.send_task_success_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.SendTaskSuccess"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.send_task_success_output_of_yojson ~error_deserializer
 end
 
 module StartExecution = struct
@@ -901,6 +1079,12 @@ module StartExecution = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.StartExecution" ~service
       ~context ~input ~output_deserializer:Json_deserializers.start_execution_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_execution_input) =
+    let input = Json_serializers.start_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.StartExecution"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_execution_output_of_yojson ~error_deserializer
 end
 
 module StartSyncExecution = struct
@@ -948,6 +1132,13 @@ module StartSyncExecution = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.StartSyncExecution" ~service
       ~context ~input ~output_deserializer:Json_deserializers.start_sync_execution_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_sync_execution_input) =
+    let input = Json_serializers.start_sync_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.StartSyncExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_sync_execution_output_of_yojson
+      ~error_deserializer
 end
 
 module StopExecution = struct
@@ -985,6 +1176,12 @@ module StopExecution = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.StopExecution" ~service
       ~context ~input ~output_deserializer:Json_deserializers.stop_execution_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : stop_execution_input) =
+    let input = Json_serializers.stop_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.StopExecution"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_execution_output_of_yojson ~error_deserializer
 end
 
 module TagResource = struct
@@ -1009,6 +1206,12 @@ module TagResource = struct
     let input = Json_serializers.tag_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.TagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.tag_resource_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_input) =
+    let input = Json_serializers.tag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.TagResource"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.tag_resource_output_of_yojson
       ~error_deserializer
 end
 
@@ -1038,6 +1241,12 @@ module TestState = struct
     let input = Json_serializers.test_state_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.TestState" ~service ~context
       ~input ~output_deserializer:Json_deserializers.test_state_output_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : test_state_input) =
+    let input = Json_serializers.test_state_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.TestState"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.test_state_output_of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1061,6 +1270,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_input) =
+    let input = Json_serializers.untag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_output_of_yojson ~error_deserializer
 end
 
 module UpdateMapRun = struct
@@ -1087,6 +1302,12 @@ module UpdateMapRun = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.UpdateMapRun" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_map_run_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_map_run_input) =
+    let input = Json_serializers.update_map_run_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSStepFunctions.UpdateMapRun"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_map_run_output_of_yojson ~error_deserializer
 end
 
 module UpdateStateMachine = struct
@@ -1150,6 +1371,13 @@ module UpdateStateMachine = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSStepFunctions.UpdateStateMachine" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_state_machine_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_state_machine_input) =
+    let input = Json_serializers.update_state_machine_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.UpdateStateMachine" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_state_machine_output_of_yojson
+      ~error_deserializer
 end
 
 module UpdateStateMachineAlias = struct
@@ -1183,6 +1411,13 @@ module UpdateStateMachineAlias = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_state_machine_alias_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_state_machine_alias_input) =
+    let input = Json_serializers.update_state_machine_alias_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSStepFunctions.UpdateStateMachineAlias" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_state_machine_alias_output_of_yojson
+      ~error_deserializer
 end
 
 module ValidateStateMachineDefinition = struct
@@ -1202,6 +1437,13 @@ module ValidateStateMachineDefinition = struct
   let request context (request : validate_state_machine_definition_input) =
     let input = Json_serializers.validate_state_machine_definition_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSStepFunctions.ValidateStateMachineDefinition" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.validate_state_machine_definition_output_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : validate_state_machine_definition_input) =
+    let input = Json_serializers.validate_state_machine_definition_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSStepFunctions.ValidateStateMachineDefinition" ~service ~context ~input
       ~output_deserializer:Json_deserializers.validate_state_machine_definition_output_of_yojson
       ~error_deserializer

--- a/sdks/sfn/operations.mli
+++ b/sdks/sfn/operations.mli
@@ -25,6 +25,20 @@ module CreateActivity : sig
       | `KmsThrottlingException of kms_throttling_exception
       | `TooManyTags of too_many_tags ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_activity_input ->
+    ( create_activity_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ActivityAlreadyExists of activity_already_exists
+      | `ActivityLimitExceeded of activity_limit_exceeded
+      | `InvalidEncryptionConfiguration of invalid_encryption_configuration
+      | `InvalidName of invalid_name
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `TooManyTags of too_many_tags ] )
+    result
 end
 [@@ocaml.doc
   "Creates an activity. An activity is a task that you write in any programming language and host \
@@ -67,6 +81,28 @@ module CreateStateMachine : sig
     'http_type Smaws_Lib.Context.t ->
     create_state_machine_input ->
     ( create_state_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `InvalidDefinition of invalid_definition
+      | `InvalidEncryptionConfiguration of invalid_encryption_configuration
+      | `InvalidLoggingConfiguration of invalid_logging_configuration
+      | `InvalidName of invalid_name
+      | `InvalidTracingConfiguration of invalid_tracing_configuration
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `StateMachineAlreadyExists of state_machine_already_exists
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineLimitExceeded of state_machine_limit_exceeded
+      | `StateMachineTypeNotSupported of state_machine_type_not_supported
+      | `TooManyTags of too_many_tags
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_state_machine_input ->
+    ( create_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
@@ -139,6 +175,20 @@ module CreateStateMachineAlias : sig
       | `StateMachineDeleting of state_machine_deleting
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_state_machine_alias_input ->
+    ( create_state_machine_alias_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `InvalidName of invalid_name
+      | `ResourceNotFound of resource_not_found
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an \
@@ -191,6 +241,13 @@ module DeleteActivity : sig
     ( delete_activity_output,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidArn of invalid_arn ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_activity_input ->
+    ( delete_activity_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidArn of invalid_arn ] )
+    result
 end
 [@@ocaml.doc "Deletes an activity.\n"]
 
@@ -205,6 +262,15 @@ module DeleteStateMachine : sig
     'http_type Smaws_Lib.Context.t ->
     delete_state_machine_input ->
     ( delete_state_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_state_machine_input ->
+    ( delete_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ValidationException of validation_exception ] )
@@ -268,6 +334,17 @@ module DeleteStateMachineAlias : sig
       | `ResourceNotFound of resource_not_found
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_state_machine_alias_input ->
+    ( delete_state_machine_alias_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a state machine \
@@ -306,6 +383,16 @@ module DeleteStateMachineVersion : sig
     'http_type Smaws_Lib.Context.t ->
     delete_state_machine_version_input ->
     ( delete_state_machine_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_state_machine_version_input ->
+    ( delete_state_machine_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
@@ -351,6 +438,15 @@ module DescribeActivity : sig
       | `ActivityDoesNotExist of activity_does_not_exist
       | `InvalidArn of invalid_arn ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_activity_input ->
+    ( describe_activity_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ActivityDoesNotExist of activity_does_not_exist
+      | `InvalidArn of invalid_arn ] )
+    result
 end
 [@@ocaml.doc
   "Describes an activity.\n\n\
@@ -373,6 +469,18 @@ module DescribeExecution : sig
     'http_type Smaws_Lib.Context.t ->
     describe_execution_input ->
     ( describe_execution_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_execution_input ->
+    ( describe_execution_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionDoesNotExist of execution_does_not_exist
       | `InvalidArn of invalid_arn
@@ -413,6 +521,15 @@ module DescribeMapRun : sig
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_map_run_input ->
+    ( describe_map_run_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about a Map Run's configuration, progress, and results. If you've \
@@ -436,6 +553,18 @@ module DescribeStateMachine : sig
     'http_type Smaws_Lib.Context.t ->
     describe_state_machine_input ->
     ( describe_state_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `StateMachineDoesNotExist of state_machine_does_not_exist ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_state_machine_input ->
+    ( describe_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `KmsAccessDeniedException of kms_access_denied_exception
@@ -511,6 +640,16 @@ module DescribeStateMachineAlias : sig
       | `ResourceNotFound of resource_not_found
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_state_machine_alias_input ->
+    ( describe_state_machine_alias_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns details about a state machine \
@@ -554,6 +693,18 @@ module DescribeStateMachineForExecution : sig
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_state_machine_for_execution_input ->
+    ( describe_state_machine_for_execution_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about a state machine's definition, its execution role ARN, and \
@@ -581,6 +732,19 @@ module GetActivityTask : sig
     'http_type Smaws_Lib.Context.t ->
     get_activity_task_input ->
     ( get_activity_task_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ActivityDoesNotExist of activity_does_not_exist
+      | `ActivityWorkerLimitExceeded of activity_worker_limit_exceeded
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_activity_task_input ->
+    ( get_activity_task_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ActivityDoesNotExist of activity_does_not_exist
       | `ActivityWorkerLimitExceeded of activity_worker_limit_exceeded
@@ -631,6 +795,19 @@ module GetExecutionHistory : sig
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_execution_history_input ->
+    ( get_execution_history_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the history of the specified execution as a list of events. By default, the results are \
@@ -652,6 +829,13 @@ module ListActivities : sig
     'http_type Smaws_Lib.Context.t ->
     list_activities_input ->
     ( list_activities_output,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_activities_input ->
+    ( list_activities_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
     result
 end
@@ -682,6 +866,19 @@ module ListExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     list_executions_input ->
     ( list_executions_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token
+      | `ResourceNotFound of resource_not_found
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `StateMachineTypeNotSupported of state_machine_type_not_supported
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_executions_input ->
+    ( list_executions_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `InvalidToken of invalid_token
@@ -733,6 +930,16 @@ module ListMapRuns : sig
       | `InvalidArn of invalid_arn
       | `InvalidToken of invalid_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_map_runs_input ->
+    ( list_map_runs_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token ] )
+    result
 end
 [@@ocaml.doc
   "Lists all Map Runs that were started by a given state machine execution. Use this API action to \
@@ -752,6 +959,18 @@ module ListStateMachineAliases : sig
     'http_type Smaws_Lib.Context.t ->
     list_state_machine_aliases_input ->
     ( list_state_machine_aliases_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token
+      | `ResourceNotFound of resource_not_found
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_state_machine_aliases_input ->
+    ( list_state_machine_aliases_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `InvalidToken of invalid_token
@@ -809,6 +1028,16 @@ module ListStateMachineVersions : sig
       | `InvalidToken of invalid_token
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_state_machine_versions_input ->
+    ( list_state_machine_versions_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidToken of invalid_token
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists \
@@ -843,6 +1072,13 @@ module ListStateMachines : sig
     ( list_state_machines_output,
       [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_state_machines_input ->
+    ( list_state_machines_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
+    result
 end
 [@@ocaml.doc
   "Lists the existing state machines.\n\n\
@@ -871,6 +1107,15 @@ module ListTagsForResource : sig
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found ] )
+    result
 end
 [@@ocaml.doc
   "List tags for a given resource.\n\n\
@@ -892,6 +1137,19 @@ module PublishStateMachineVersion : sig
     'http_type Smaws_Lib.Context.t ->
     publish_state_machine_version_input ->
     ( publish_state_machine_version_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    publish_state_machine_version_input ->
+    ( publish_state_machine_version_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
@@ -943,6 +1201,18 @@ module RedriveExecution : sig
     'http_type Smaws_Lib.Context.t ->
     redrive_execution_input ->
     ( redrive_execution_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `ExecutionLimitExceeded of execution_limit_exceeded
+      | `ExecutionNotRedrivable of execution_not_redrivable
+      | `InvalidArn of invalid_arn
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    redrive_execution_input ->
+    ( redrive_execution_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionDoesNotExist of execution_does_not_exist
       | `ExecutionLimitExceeded of execution_limit_exceeded
@@ -1030,6 +1300,19 @@ module SendTaskFailure : sig
       | `TaskDoesNotExist of task_does_not_exist
       | `TaskTimedOut of task_timed_out ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_task_failure_input ->
+    ( send_task_failure_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidToken of invalid_token
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `TaskDoesNotExist of task_does_not_exist
+      | `TaskTimedOut of task_timed_out ] )
+    result
 end
 [@@ocaml.doc
   "Used by activity workers, Task states using the \
@@ -1057,6 +1340,16 @@ module SendTaskHeartbeat : sig
     'http_type Smaws_Lib.Context.t ->
     send_task_heartbeat_input ->
     ( send_task_heartbeat_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidToken of invalid_token
+      | `TaskDoesNotExist of task_does_not_exist
+      | `TaskTimedOut of task_timed_out ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_task_heartbeat_input ->
+    ( send_task_heartbeat_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidToken of invalid_token
       | `TaskDoesNotExist of task_does_not_exist
@@ -1109,6 +1402,20 @@ module SendTaskSuccess : sig
       | `TaskDoesNotExist of task_does_not_exist
       | `TaskTimedOut of task_timed_out ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_task_success_input ->
+    ( send_task_success_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidOutput of invalid_output
+      | `InvalidToken of invalid_token
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `TaskDoesNotExist of task_does_not_exist
+      | `TaskTimedOut of task_timed_out ] )
+    result
 end
 [@@ocaml.doc
   "Used by activity workers, Task states using the \
@@ -1137,6 +1444,24 @@ module StartExecution : sig
     'http_type Smaws_Lib.Context.t ->
     start_execution_input ->
     ( start_execution_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionAlreadyExists of execution_already_exists
+      | `ExecutionLimitExceeded of execution_limit_exceeded
+      | `InvalidArn of invalid_arn
+      | `InvalidExecutionInput of invalid_execution_input
+      | `InvalidName of invalid_name
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_execution_input ->
+    ( start_execution_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionAlreadyExists of execution_already_exists
       | `ExecutionLimitExceeded of execution_limit_exceeded
@@ -1240,6 +1565,22 @@ module StartSyncExecution : sig
       | `StateMachineDoesNotExist of state_machine_does_not_exist
       | `StateMachineTypeNotSupported of state_machine_type_not_supported ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_sync_execution_input ->
+    ( start_sync_execution_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidExecutionInput of invalid_execution_input
+      | `InvalidName of invalid_name
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `StateMachineTypeNotSupported of state_machine_type_not_supported ] )
+    result
 end
 [@@ocaml.doc
   "Starts a Synchronous Express state machine execution. [StartSyncExecution] is not available for \
@@ -1268,6 +1609,19 @@ module StopExecution : sig
     'http_type Smaws_Lib.Context.t ->
     stop_execution_input ->
     ( stop_execution_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ExecutionDoesNotExist of execution_does_not_exist
+      | `InvalidArn of invalid_arn
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsInvalidStateException of kms_invalid_state_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_execution_input ->
+    ( stop_execution_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionDoesNotExist of execution_does_not_exist
       | `InvalidArn of invalid_arn
@@ -1306,6 +1660,16 @@ module TagResource : sig
       | `ResourceNotFound of resource_not_found
       | `TooManyTags of too_many_tags ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( tag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `TooManyTags of too_many_tags ] )
+    result
 end
 [@@ocaml.doc
   "Add a tag to a Step Functions resource.\n\n\
@@ -1332,6 +1696,17 @@ module TestState : sig
     'http_type Smaws_Lib.Context.t ->
     test_state_input ->
     ( test_state_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `InvalidDefinition of invalid_definition
+      | `InvalidExecutionInput of invalid_execution_input
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_state_input ->
+    ( test_state_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `InvalidDefinition of invalid_definition
@@ -1425,6 +1800,15 @@ module UntagResource : sig
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( untag_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found ] )
+    result
 end
 [@@ocaml.doc "Remove a tag from a Step Functions resource\n"]
 
@@ -1440,6 +1824,16 @@ module UpdateMapRun : sig
     'http_type Smaws_Lib.Context.t ->
     update_map_run_input ->
     ( update_map_run_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_map_run_input ->
+    ( update_map_run_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
@@ -1472,6 +1866,26 @@ module UpdateStateMachine : sig
     'http_type Smaws_Lib.Context.t ->
     update_state_machine_input ->
     ( update_state_machine_output,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `InvalidDefinition of invalid_definition
+      | `InvalidEncryptionConfiguration of invalid_encryption_configuration
+      | `InvalidLoggingConfiguration of invalid_logging_configuration
+      | `InvalidTracingConfiguration of invalid_tracing_configuration
+      | `KmsAccessDeniedException of kms_access_denied_exception
+      | `KmsThrottlingException of kms_throttling_exception
+      | `MissingRequiredParameter of missing_required_parameter
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `StateMachineDeleting of state_machine_deleting
+      | `StateMachineDoesNotExist of state_machine_does_not_exist
+      | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_state_machine_input ->
+    ( update_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
@@ -1573,6 +1987,18 @@ module UpdateStateMachineAlias : sig
       | `StateMachineDeleting of state_machine_deleting
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_state_machine_alias_input ->
+    ( update_state_machine_alias_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidArn of invalid_arn
+      | `ResourceNotFound of resource_not_found
+      | `StateMachineDeleting of state_machine_deleting
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the configuration of an existing state machine \
@@ -1615,6 +2041,13 @@ module ValidateStateMachineDefinition : sig
     'http_type Smaws_Lib.Context.t ->
     validate_state_machine_definition_input ->
     ( validate_state_machine_definition_output,
+      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    validate_state_machine_definition_input ->
+    ( validate_state_machine_definition_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
     result
 end

--- a/sdks/sfn/operations.mli
+++ b/sdks/sfn/operations.mli
@@ -37,7 +37,8 @@ module CreateActivity : sig
       | `InvalidName of invalid_name
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsThrottlingException of kms_throttling_exception
-      | `TooManyTags of too_many_tags ] )
+      | `TooManyTags of too_many_tags ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -118,7 +119,8 @@ module CreateStateMachine : sig
       | `StateMachineLimitExceeded of state_machine_limit_exceeded
       | `StateMachineTypeNotSupported of state_machine_type_not_supported
       | `TooManyTags of too_many_tags
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -187,7 +189,8 @@ module CreateStateMachineAlias : sig
       | `ResourceNotFound of resource_not_found
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `StateMachineDeleting of state_machine_deleting
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -246,7 +249,8 @@ module DeleteActivity : sig
     'http_type Smaws_Lib.Context.t ->
     delete_activity_input ->
     ( delete_activity_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidArn of invalid_arn ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidArn of invalid_arn ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an activity.\n"]
@@ -273,7 +277,8 @@ module DeleteStateMachine : sig
     ( delete_state_machine_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -343,7 +348,8 @@ module DeleteStateMachineAlias : sig
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -396,7 +402,8 @@ module DeleteStateMachineVersion : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidArn of invalid_arn
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -445,7 +452,8 @@ module DescribeActivity : sig
     ( describe_activity_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ActivityDoesNotExist of activity_does_not_exist
-      | `InvalidArn of invalid_arn ] )
+      | `InvalidArn of invalid_arn ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -486,7 +494,8 @@ module DescribeExecution : sig
       | `InvalidArn of invalid_arn
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
-      | `KmsThrottlingException of kms_throttling_exception ] )
+      | `KmsThrottlingException of kms_throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -528,7 +537,8 @@ module DescribeMapRun : sig
     ( describe_map_run_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
-      | `ResourceNotFound of resource_not_found ] )
+      | `ResourceNotFound of resource_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -570,7 +580,8 @@ module DescribeStateMachine : sig
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception
-      | `StateMachineDoesNotExist of state_machine_does_not_exist ] )
+      | `StateMachineDoesNotExist of state_machine_does_not_exist ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -648,7 +659,8 @@ module DescribeStateMachineAlias : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -703,7 +715,8 @@ module DescribeStateMachineForExecution : sig
       | `InvalidArn of invalid_arn
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
-      | `KmsThrottlingException of kms_throttling_exception ] )
+      | `KmsThrottlingException of kms_throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -751,7 +764,8 @@ module GetActivityTask : sig
       | `InvalidArn of invalid_arn
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
-      | `KmsThrottlingException of kms_throttling_exception ] )
+      | `KmsThrottlingException of kms_throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -806,7 +820,8 @@ module GetExecutionHistory : sig
       | `InvalidToken of invalid_token
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
-      | `KmsThrottlingException of kms_throttling_exception ] )
+      | `KmsThrottlingException of kms_throttling_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -836,7 +851,8 @@ module ListActivities : sig
     'http_type Smaws_Lib.Context.t ->
     list_activities_input ->
     ( list_activities_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -885,7 +901,8 @@ module ListExecutions : sig
       | `ResourceNotFound of resource_not_found
       | `StateMachineDoesNotExist of state_machine_does_not_exist
       | `StateMachineTypeNotSupported of state_machine_type_not_supported
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -938,7 +955,8 @@ module ListMapRuns : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ExecutionDoesNotExist of execution_does_not_exist
       | `InvalidArn of invalid_arn
-      | `InvalidToken of invalid_token ] )
+      | `InvalidToken of invalid_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -976,7 +994,8 @@ module ListStateMachineAliases : sig
       | `InvalidToken of invalid_token
       | `ResourceNotFound of resource_not_found
       | `StateMachineDeleting of state_machine_deleting
-      | `StateMachineDoesNotExist of state_machine_does_not_exist ] )
+      | `StateMachineDoesNotExist of state_machine_does_not_exist ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1036,7 +1055,8 @@ module ListStateMachineVersions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `InvalidToken of invalid_token
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1077,7 +1097,8 @@ module ListStateMachines : sig
     'http_type Smaws_Lib.Context.t ->
     list_state_machines_input ->
     ( list_state_machines_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InvalidToken of invalid_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1114,7 +1135,8 @@ module ListTagsForResource : sig
     ( list_tags_for_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
-      | `ResourceNotFound of resource_not_found ] )
+      | `ResourceNotFound of resource_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1156,7 +1178,8 @@ module PublishStateMachineVersion : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `StateMachineDeleting of state_machine_deleting
       | `StateMachineDoesNotExist of state_machine_does_not_exist
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1218,7 +1241,8 @@ module RedriveExecution : sig
       | `ExecutionLimitExceeded of execution_limit_exceeded
       | `ExecutionNotRedrivable of execution_not_redrivable
       | `InvalidArn of invalid_arn
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1311,7 +1335,8 @@ module SendTaskFailure : sig
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception
       | `TaskDoesNotExist of task_does_not_exist
-      | `TaskTimedOut of task_timed_out ] )
+      | `TaskTimedOut of task_timed_out ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1353,7 +1378,8 @@ module SendTaskHeartbeat : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidToken of invalid_token
       | `TaskDoesNotExist of task_does_not_exist
-      | `TaskTimedOut of task_timed_out ] )
+      | `TaskTimedOut of task_timed_out ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1414,7 +1440,8 @@ module SendTaskSuccess : sig
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception
       | `TaskDoesNotExist of task_does_not_exist
-      | `TaskTimedOut of task_timed_out ] )
+      | `TaskTimedOut of task_timed_out ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1473,7 +1500,8 @@ module StartExecution : sig
       | `KmsThrottlingException of kms_throttling_exception
       | `StateMachineDeleting of state_machine_deleting
       | `StateMachineDoesNotExist of state_machine_does_not_exist
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1579,7 +1607,8 @@ module StartSyncExecution : sig
       | `KmsThrottlingException of kms_throttling_exception
       | `StateMachineDeleting of state_machine_deleting
       | `StateMachineDoesNotExist of state_machine_does_not_exist
-      | `StateMachineTypeNotSupported of state_machine_type_not_supported ] )
+      | `StateMachineTypeNotSupported of state_machine_type_not_supported ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1628,7 +1657,8 @@ module StopExecution : sig
       | `KmsAccessDeniedException of kms_access_denied_exception
       | `KmsInvalidStateException of kms_invalid_state_exception
       | `KmsThrottlingException of kms_throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1668,7 +1698,8 @@ module TagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
-      | `TooManyTags of too_many_tags ] )
+      | `TooManyTags of too_many_tags ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1711,7 +1742,8 @@ module TestState : sig
       | `InvalidArn of invalid_arn
       | `InvalidDefinition of invalid_definition
       | `InvalidExecutionInput of invalid_execution_input
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1807,7 +1839,8 @@ module UntagResource : sig
     ( untag_resource_output Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
-      | `ResourceNotFound of resource_not_found ] )
+      | `ResourceNotFound of resource_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Remove a tag from a Step Functions resource\n"]
@@ -1837,7 +1870,8 @@ module UpdateMapRun : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1899,7 +1933,8 @@ module UpdateStateMachine : sig
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `StateMachineDeleting of state_machine_deleting
       | `StateMachineDoesNotExist of state_machine_does_not_exist
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1997,7 +2032,8 @@ module UpdateStateMachineAlias : sig
       | `InvalidArn of invalid_arn
       | `ResourceNotFound of resource_not_found
       | `StateMachineDeleting of state_machine_deleting
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2048,7 +2084,8 @@ module ValidateStateMachineDefinition : sig
     'http_type Smaws_Lib.Context.t ->
     validate_state_machine_definition_input ->
     ( validate_state_machine_definition_output Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/shield/Smaws_Client_Shield.mli
+++ b/sdks/shield/Smaws_Client_Shield.mli
@@ -422,6 +422,21 @@ module AssociateDRTLogBucket : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_drt_log_bucket_request ->
+    ( associate_drt_log_bucket_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedForDependencyException of access_denied_for_dependency_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `NoAssociatedRoleException of no_associated_role_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Authorizes the Shield Response Team (SRT) to access the specified Amazon S3 bucket containing \
@@ -448,6 +463,19 @@ module AssociateDRTRole : sig
     'http_type Smaws_Lib.Context.t ->
     associate_drt_role_request ->
     ( associate_drt_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedForDependencyException of access_denied_for_dependency_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_drt_role_request ->
+    ( associate_drt_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedForDependencyException of access_denied_for_dependency_exception
       | `InternalErrorException of internal_error_exception
@@ -515,6 +543,19 @@ module AssociateHealthCheck : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_health_check_request ->
+    ( associate_health_check_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds health-based detection to the Shield Advanced protection for a resource. Shield Advanced \
@@ -540,6 +581,18 @@ module AssociateProactiveEngagementDetails : sig
     'http_type Smaws_Lib.Context.t ->
     associate_proactive_engagement_details_request ->
     ( associate_proactive_engagement_details_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_proactive_engagement_details_request ->
+    ( associate_proactive_engagement_details_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -591,6 +644,21 @@ module CreateProtection : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_protection_request ->
+    ( create_protection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables Shield Advanced for a specific Amazon Web Services resource. The resource can be an \
@@ -631,6 +699,19 @@ module CreateProtectionGroup : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_protection_group_request ->
+    ( create_protection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a grouping of protected resources so they can be handled as a collective. This resource \
@@ -647,6 +728,15 @@ module CreateSubscription : sig
     'http_type Smaws_Lib.Context.t ->
     create_subscription_request ->
     ( create_subscription_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_subscription_request ->
+    ( create_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
@@ -680,6 +770,16 @@ module DeleteProtection : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_protection_request ->
+    ( delete_protection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes an Shield Advanced [Protection].\n"]
 
@@ -695,6 +795,16 @@ module DeleteProtectionGroup : sig
     'http_type Smaws_Lib.Context.t ->
     delete_protection_group_request ->
     ( delete_protection_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_protection_group_request ->
+    ( delete_protection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `OptimisticLockException of optimistic_lock_exception
@@ -720,6 +830,16 @@ module DeleteSubscription : sig
       | `LockedSubscriptionException of locked_subscription_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_subscription_request ->
+    ( delete_subscription_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `LockedSubscriptionException of locked_subscription_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes Shield Advanced from an account. Shield Advanced requires a 1-year subscription \
@@ -740,6 +860,15 @@ module DescribeAttack : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalErrorException of internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_attack_request ->
+    ( describe_attack_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalErrorException of internal_error_exception ] )
+    result
 end
 [@@ocaml.doc "Describes the details of a DDoS attack. \n"]
 
@@ -752,6 +881,14 @@ module DescribeAttackStatistics : sig
     'http_type Smaws_Lib.Context.t ->
     describe_attack_statistics_request ->
     ( describe_attack_statistics_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_attack_statistics_request ->
+    ( describe_attack_statistics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
     )
     result
@@ -784,6 +921,15 @@ module DescribeDRTAccess : sig
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_drt_access_request ->
+    ( describe_drt_access_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the current role and list of Amazon S3 log buckets used by the Shield Response Team \
@@ -800,6 +946,15 @@ module DescribeEmergencyContactSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_emergency_contact_settings_request ->
     ( describe_emergency_contact_settings_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_emergency_contact_settings_request ->
+    ( describe_emergency_contact_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -827,6 +982,16 @@ module DescribeProtection : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_protection_request ->
+    ( describe_protection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the details of a [Protection] object.\n"]
 
@@ -845,6 +1010,15 @@ module DescribeProtectionGroup : sig
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_protection_group_request ->
+    ( describe_protection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the specification for the specified protection group.\n"]
 
@@ -859,6 +1033,15 @@ module DescribeSubscription : sig
     'http_type Smaws_Lib.Context.t ->
     describe_subscription_request ->
     ( describe_subscription_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_subscription_request ->
+    ( describe_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -887,6 +1070,18 @@ module DisableApplicationLayerAutomaticResponse : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_application_layer_automatic_response_request ->
+    ( disable_application_layer_automatic_response_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disable the Shield Advanced automatic application layer DDoS mitigation feature for the \
@@ -907,6 +1102,18 @@ module DisableProactiveEngagement : sig
     'http_type Smaws_Lib.Context.t ->
     disable_proactive_engagement_request ->
     ( disable_proactive_engagement_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_proactive_engagement_request ->
+    ( disable_proactive_engagement_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -942,6 +1149,19 @@ module DisassociateDRTLogBucket : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_drt_log_bucket_request ->
+    ( disassociate_drt_log_bucket_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedForDependencyException of access_denied_for_dependency_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `NoAssociatedRoleException of no_associated_role_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the Shield Response Team's (SRT) access to the specified Amazon S3 bucket containing \
@@ -966,6 +1186,17 @@ module DisassociateDRTRole : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_drt_role_request ->
+    ( disassociate_drt_role_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the Shield Response Team's (SRT) access to your Amazon Web Services account.\n"]
@@ -984,6 +1215,18 @@ module DisassociateHealthCheck : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_health_check_request ->
     ( disassociate_health_check_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_health_check_request ->
+    ( disassociate_health_check_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1017,6 +1260,19 @@ module EnableApplicationLayerAutomaticResponse : sig
     'http_type Smaws_Lib.Context.t ->
     enable_application_layer_automatic_response_request ->
     ( enable_application_layer_automatic_response_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_application_layer_automatic_response_request ->
+    ( enable_application_layer_automatic_response_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -1075,6 +1331,18 @@ module EnableProactiveEngagement : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_proactive_engagement_request ->
+    ( enable_proactive_engagement_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Authorizes the Shield Response Team (SRT) to use email and phone to notify contacts about \
@@ -1089,6 +1357,14 @@ module GetSubscriptionState : sig
     'http_type Smaws_Lib.Context.t ->
     get_subscription_state_request ->
     ( get_subscription_state_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_subscription_state_request ->
+    ( get_subscription_state_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
     )
     result
@@ -1112,6 +1388,16 @@ module ListAttacks : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_attacks_request ->
+    ( list_attacks_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns all ongoing DDoS attacks or all DDoS attacks during a specified time period.\n"]
@@ -1128,6 +1414,16 @@ module ListProtectionGroups : sig
     'http_type Smaws_Lib.Context.t ->
     list_protection_groups_request ->
     ( list_protection_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidPaginationTokenException of invalid_pagination_token_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_protection_groups_request ->
+    ( list_protection_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
@@ -1156,6 +1452,16 @@ module ListProtections : sig
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_protections_request ->
+    ( list_protections_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidPaginationTokenException of invalid_pagination_token_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves [Protection] objects for the account. You can retrieve all protections or you can \
@@ -1178,6 +1484,16 @@ module ListResourcesInProtectionGroup : sig
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resources_in_protection_group_request ->
+    ( list_resources_in_protection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidPaginationTokenException of invalid_pagination_token_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the resources that are included in the protection group. \n"]
 
@@ -1193,6 +1509,16 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidResourceException of invalid_resource_exception
@@ -1222,6 +1548,17 @@ module TagResource : sig
       | `InvalidResourceException of invalid_resource_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Adds or updates tags for a resource in Shield.\n"]
 
@@ -1238,6 +1575,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1261,6 +1609,18 @@ module UpdateApplicationLayerAutomaticResponse : sig
     'http_type Smaws_Lib.Context.t ->
     update_application_layer_automatic_response_request ->
     ( update_application_layer_automatic_response_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_application_layer_automatic_response_request ->
+    ( update_application_layer_automatic_response_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -1292,6 +1652,17 @@ module UpdateEmergencyContactSettings : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_emergency_contact_settings_request ->
+    ( update_emergency_contact_settings_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the details of the list of email addresses and phone numbers that the Shield Response \
@@ -1311,6 +1682,17 @@ module UpdateProtectionGroup : sig
     'http_type Smaws_Lib.Context.t ->
     update_protection_group_request ->
     ( update_protection_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_protection_group_request ->
+    ( update_protection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1338,6 +1720,18 @@ module UpdateSubscription : sig
     'http_type Smaws_Lib.Context.t ->
     update_subscription_request ->
     ( update_subscription_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LockedSubscriptionException of locked_subscription_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_subscription_request ->
+    ( update_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception

--- a/sdks/shield/Smaws_Client_Shield.mli
+++ b/sdks/shield/Smaws_Client_Shield.mli
@@ -435,7 +435,8 @@ module AssociateDRTLogBucket : sig
       | `LimitsExceededException of limits_exceeded_exception
       | `NoAssociatedRoleException of no_associated_role_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -482,7 +483,8 @@ module AssociateDRTRole : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -554,7 +556,8 @@ module AssociateHealthCheck : sig
       | `InvalidResourceException of invalid_resource_exception
       | `LimitsExceededException of limits_exceeded_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -598,7 +601,8 @@ module AssociateProactiveEngagementDetails : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -657,7 +661,8 @@ module CreateProtection : sig
       | `LimitsExceededException of limits_exceeded_exception
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -710,7 +715,8 @@ module CreateProtectionGroup : sig
       | `LimitsExceededException of limits_exceeded_exception
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -739,7 +745,8 @@ module CreateSubscription : sig
     ( create_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -778,7 +785,8 @@ module DeleteProtection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an Shield Advanced [Protection].\n"]
@@ -808,7 +816,8 @@ module DeleteProtectionGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the specified protection group.\n"]
@@ -838,7 +847,8 @@ module DeleteSubscription : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `LockedSubscriptionException of locked_subscription_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -867,7 +877,8 @@ module DescribeAttack : sig
     ( describe_attack_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
-      | `InternalErrorException of internal_error_exception ] )
+      | `InternalErrorException of internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes the details of a DDoS attack. \n"]
@@ -890,7 +901,7 @@ module DescribeAttackStatistics : sig
     describe_attack_statistics_request ->
     ( describe_attack_statistics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -928,7 +939,8 @@ module DescribeDRTAccess : sig
     ( describe_drt_access_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -957,7 +969,8 @@ module DescribeEmergencyContactSettings : sig
     ( describe_emergency_contact_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -990,7 +1003,8 @@ module DescribeProtection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the details of a [Protection] object.\n"]
@@ -1017,7 +1031,8 @@ module DescribeProtectionGroup : sig
     ( describe_protection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the specification for the specified protection group.\n"]
@@ -1044,7 +1059,8 @@ module DescribeSubscription : sig
     ( describe_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides details about the Shield Advanced subscription for an account.\n"]
@@ -1080,7 +1096,8 @@ module DisableApplicationLayerAutomaticResponse : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1119,7 +1136,8 @@ module DisableProactiveEngagement : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1160,7 +1178,8 @@ module DisassociateDRTLogBucket : sig
       | `InvalidOperationException of invalid_operation_exception
       | `NoAssociatedRoleException of no_associated_role_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1195,7 +1214,8 @@ module DisassociateDRTRole : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1232,7 +1252,8 @@ module DisassociateHealthCheck : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidResourceException of invalid_resource_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1279,7 +1300,8 @@ module EnableApplicationLayerAutomaticResponse : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitsExceededException of limits_exceeded_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1341,7 +1363,8 @@ module EnableProactiveEngagement : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1366,7 +1389,7 @@ module GetSubscriptionState : sig
     get_subscription_state_request ->
     ( get_subscription_state_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the [SubscriptionState], either [Active] or [Inactive].\n"]
@@ -1396,7 +1419,8 @@ module ListAttacks : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `InvalidParameterException of invalid_parameter_exception ] )
+      | `InvalidParameterException of invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1427,7 +1451,8 @@ module ListProtectionGroups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1460,7 +1485,8 @@ module ListProtections : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1492,7 +1518,8 @@ module ListResourcesInProtectionGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the resources that are included in the protection group. \n"]
@@ -1522,7 +1549,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1557,7 +1585,8 @@ module TagResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds or updates tags for a resource in Shield.\n"]
@@ -1590,7 +1619,8 @@ module UntagResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tags from a resource in Shield.\n"]
@@ -1626,7 +1656,8 @@ module UpdateApplicationLayerAutomaticResponse : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1661,7 +1692,8 @@ module UpdateEmergencyContactSettings : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1697,7 +1729,8 @@ module UpdateProtectionGroup : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1737,7 +1770,8 @@ module UpdateSubscription : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LockedSubscriptionException of locked_subscription_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/shield/operations.ml
+++ b/sdks/shield/operations.ml
@@ -50,6 +50,13 @@ module AssociateDRTLogBucket = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_drt_log_bucket_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_drt_log_bucket_request) =
+    let input = Json_serializers.associate_drt_log_bucket_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.AssociateDRTLogBucket" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_drt_log_bucket_response_of_yojson
+      ~error_deserializer
 end
 
 module AssociateDRTRole = struct
@@ -91,6 +98,13 @@ module AssociateDRTRole = struct
     let input = Json_serializers.associate_drt_role_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.AssociateDRTRole" ~service
       ~context ~input ~output_deserializer:Json_deserializers.associate_drt_role_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : associate_drt_role_request) =
+    let input = Json_serializers.associate_drt_role_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.AssociateDRTRole" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_drt_role_response_of_yojson
       ~error_deserializer
 end
 
@@ -134,6 +148,13 @@ module AssociateHealthCheck = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_health_check_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_health_check_request) =
+    let input = Json_serializers.associate_health_check_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.AssociateHealthCheck" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_health_check_response_of_yojson
+      ~error_deserializer
 end
 
 module AssociateProactiveEngagementDetails = struct
@@ -169,6 +190,14 @@ module AssociateProactiveEngagementDetails = struct
   let request context (request : associate_proactive_engagement_details_request) =
     let input = Json_serializers.associate_proactive_engagement_details_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSShield_20160616.AssociateProactiveEngagementDetails" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.associate_proactive_engagement_details_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : associate_proactive_engagement_details_request) =
+    let input = Json_serializers.associate_proactive_engagement_details_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSShield_20160616.AssociateProactiveEngagementDetails" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.associate_proactive_engagement_details_response_of_yojson
@@ -222,6 +251,13 @@ module CreateProtection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.CreateProtection" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_protection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_protection_request) =
+    let input = Json_serializers.create_protection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.CreateProtection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_protection_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateProtectionGroup = struct
@@ -264,6 +300,13 @@ module CreateProtectionGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_protection_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_protection_group_request) =
+    let input = Json_serializers.create_protection_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.CreateProtectionGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_protection_group_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateSubscription = struct
@@ -288,6 +331,13 @@ module CreateSubscription = struct
     let input = Json_serializers.create_subscription_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.CreateSubscription" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_subscription_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_subscription_request) =
+    let input = Json_serializers.create_subscription_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.CreateSubscription" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_subscription_response_of_yojson
       ~error_deserializer
 end
 
@@ -317,6 +367,13 @@ module DeleteProtection = struct
     let input = Json_serializers.delete_protection_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DeleteProtection" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_protection_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_protection_request) =
+    let input = Json_serializers.delete_protection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DeleteProtection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_protection_response_of_yojson
       ~error_deserializer
 end
 
@@ -348,6 +405,13 @@ module DeleteProtectionGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_protection_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_protection_group_request) =
+    let input = Json_serializers.delete_protection_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DeleteProtectionGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_protection_group_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteSubscription = struct
@@ -377,6 +441,13 @@ module DeleteSubscription = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DeleteSubscription" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_subscription_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_subscription_request) =
+    let input = Json_serializers.delete_subscription_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DeleteSubscription" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_subscription_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAttack = struct
@@ -401,6 +472,12 @@ module DescribeAttack = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DescribeAttack" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_attack_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_attack_request) =
+    let input = Json_serializers.describe_attack_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DescribeAttack" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_attack_response_of_yojson ~error_deserializer
 end
 
 module DescribeAttackStatistics = struct
@@ -421,6 +498,13 @@ module DescribeAttackStatistics = struct
     let input = Json_serializers.describe_attack_statistics_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DescribeAttackStatistics"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_attack_statistics_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_attack_statistics_request) =
+    let input = Json_serializers.describe_attack_statistics_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DescribeAttackStatistics" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_attack_statistics_response_of_yojson
       ~error_deserializer
 end
@@ -448,6 +532,13 @@ module DescribeDRTAccess = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DescribeDRTAccess" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_drt_access_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_drt_access_request) =
+    let input = Json_serializers.describe_drt_access_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DescribeDRTAccess" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_drt_access_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeEmergencyContactSettings = struct
@@ -471,6 +562,13 @@ module DescribeEmergencyContactSettings = struct
   let request context (request : describe_emergency_contact_settings_request) =
     let input = Json_serializers.describe_emergency_contact_settings_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSShield_20160616.DescribeEmergencyContactSettings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_emergency_contact_settings_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_emergency_contact_settings_request) =
+    let input = Json_serializers.describe_emergency_contact_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSShield_20160616.DescribeEmergencyContactSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_emergency_contact_settings_response_of_yojson
       ~error_deserializer
@@ -503,6 +601,13 @@ module DescribeProtection = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DescribeProtection" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_protection_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_protection_request) =
+    let input = Json_serializers.describe_protection_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DescribeProtection" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_protection_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeProtectionGroup = struct
@@ -529,6 +634,13 @@ module DescribeProtectionGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_protection_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_protection_group_request) =
+    let input = Json_serializers.describe_protection_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DescribeProtectionGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_protection_group_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeSubscription = struct
@@ -553,6 +665,13 @@ module DescribeSubscription = struct
     let input = Json_serializers.describe_subscription_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DescribeSubscription"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_subscription_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_subscription_request) =
+    let input = Json_serializers.describe_subscription_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DescribeSubscription" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_subscription_response_of_yojson
       ~error_deserializer
 end
@@ -597,6 +716,18 @@ module DisableApplicationLayerAutomaticResponse = struct
       ~output_deserializer:
         Json_deserializers.disable_application_layer_automatic_response_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disable_application_layer_automatic_response_request)
+      =
+    let input =
+      Json_serializers.disable_application_layer_automatic_response_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DisableApplicationLayerAutomaticResponse" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.disable_application_layer_automatic_response_response_of_yojson
+      ~error_deserializer
 end
 
 module DisableProactiveEngagement = struct
@@ -633,6 +764,13 @@ module DisableProactiveEngagement = struct
     let input = Json_serializers.disable_proactive_engagement_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DisableProactiveEngagement"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disable_proactive_engagement_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disable_proactive_engagement_request) =
+    let input = Json_serializers.disable_proactive_engagement_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DisableProactiveEngagement" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disable_proactive_engagement_response_of_yojson
       ~error_deserializer
 end
@@ -678,6 +816,13 @@ module DisassociateDRTLogBucket = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_drt_log_bucket_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_drt_log_bucket_request) =
+    let input = Json_serializers.disassociate_drt_log_bucket_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DisassociateDRTLogBucket" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_drt_log_bucket_response_of_yojson
+      ~error_deserializer
 end
 
 module DisassociateDRTRole = struct
@@ -710,6 +855,13 @@ module DisassociateDRTRole = struct
     let input = Json_serializers.disassociate_drt_role_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DisassociateDRTRole"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_drt_role_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_drt_role_request) =
+    let input = Json_serializers.disassociate_drt_role_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DisassociateDRTRole" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_drt_role_response_of_yojson
       ~error_deserializer
 end
@@ -748,6 +900,13 @@ module DisassociateHealthCheck = struct
     let input = Json_serializers.disassociate_health_check_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.DisassociateHealthCheck"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_health_check_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_health_check_request) =
+    let input = Json_serializers.disassociate_health_check_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.DisassociateHealthCheck" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_health_check_response_of_yojson
       ~error_deserializer
 end
@@ -796,6 +955,18 @@ module EnableApplicationLayerAutomaticResponse = struct
       ~output_deserializer:
         Json_deserializers.enable_application_layer_automatic_response_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : enable_application_layer_automatic_response_request)
+      =
+    let input =
+      Json_serializers.enable_application_layer_automatic_response_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.EnableApplicationLayerAutomaticResponse" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.enable_application_layer_automatic_response_response_of_yojson
+      ~error_deserializer
 end
 
 module EnableProactiveEngagement = struct
@@ -834,6 +1005,13 @@ module EnableProactiveEngagement = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.enable_proactive_engagement_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : enable_proactive_engagement_request) =
+    let input = Json_serializers.enable_proactive_engagement_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.EnableProactiveEngagement" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.enable_proactive_engagement_response_of_yojson
+      ~error_deserializer
 end
 
 module GetSubscriptionState = struct
@@ -854,6 +1032,13 @@ module GetSubscriptionState = struct
     let input = Json_serializers.get_subscription_state_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.GetSubscriptionState"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_subscription_state_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_subscription_state_request) =
+    let input = Json_serializers.get_subscription_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.GetSubscriptionState" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_subscription_state_response_of_yojson
       ~error_deserializer
 end
@@ -885,6 +1070,12 @@ module ListAttacks = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.ListAttacks" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_attacks_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_attacks_request) =
+    let input = Json_serializers.list_attacks_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSShield_20160616.ListAttacks"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_attacks_response_of_yojson ~error_deserializer
 end
 
 module ListProtectionGroups = struct
@@ -913,6 +1104,13 @@ module ListProtectionGroups = struct
     let input = Json_serializers.list_protection_groups_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.ListProtectionGroups"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_protection_groups_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_protection_groups_request) =
+    let input = Json_serializers.list_protection_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.ListProtectionGroups" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_protection_groups_response_of_yojson
       ~error_deserializer
 end
@@ -944,6 +1142,13 @@ module ListProtections = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.ListProtections" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_protections_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_protections_request) =
+    let input = Json_serializers.list_protections_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.ListProtections" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_protections_response_of_yojson
+      ~error_deserializer
 end
 
 module ListResourcesInProtectionGroup = struct
@@ -971,6 +1176,13 @@ module ListResourcesInProtectionGroup = struct
   let request context (request : list_resources_in_protection_group_request) =
     let input = Json_serializers.list_resources_in_protection_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSShield_20160616.ListResourcesInProtectionGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resources_in_protection_group_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_resources_in_protection_group_request) =
+    let input = Json_serializers.list_resources_in_protection_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSShield_20160616.ListResourcesInProtectionGroup" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_resources_in_protection_group_response_of_yojson
       ~error_deserializer
@@ -1002,6 +1214,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.ListTagsForResource"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
 end
@@ -1037,6 +1256,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.TagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSShield_20160616.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1070,6 +1295,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSShield_20160616.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
 module UpdateApplicationLayerAutomaticResponse = struct
@@ -1112,6 +1343,18 @@ module UpdateApplicationLayerAutomaticResponse = struct
       ~output_deserializer:
         Json_deserializers.update_application_layer_automatic_response_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_application_layer_automatic_response_request)
+      =
+    let input =
+      Json_serializers.update_application_layer_automatic_response_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.UpdateApplicationLayerAutomaticResponse" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.update_application_layer_automatic_response_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateEmergencyContactSettings = struct
@@ -1143,6 +1386,13 @@ module UpdateEmergencyContactSettings = struct
   let request context (request : update_emergency_contact_settings_request) =
     let input = Json_serializers.update_emergency_contact_settings_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSShield_20160616.UpdateEmergencyContactSettings" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_emergency_contact_settings_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_emergency_contact_settings_request) =
+    let input = Json_serializers.update_emergency_contact_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSShield_20160616.UpdateEmergencyContactSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_emergency_contact_settings_response_of_yojson
       ~error_deserializer
@@ -1178,6 +1428,13 @@ module UpdateProtectionGroup = struct
     let input = Json_serializers.update_protection_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.UpdateProtectionGroup"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_protection_group_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_protection_group_request) =
+    let input = Json_serializers.update_protection_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.UpdateProtectionGroup" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_protection_group_response_of_yojson
       ~error_deserializer
 end
@@ -1216,5 +1473,12 @@ module UpdateSubscription = struct
     let input = Json_serializers.update_subscription_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSShield_20160616.UpdateSubscription" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_subscription_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_subscription_request) =
+    let input = Json_serializers.update_subscription_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSShield_20160616.UpdateSubscription" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_subscription_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/shield/operations.mli
+++ b/sdks/shield/operations.mli
@@ -40,7 +40,8 @@ module AssociateDRTLogBucket : sig
       | `LimitsExceededException of limits_exceeded_exception
       | `NoAssociatedRoleException of no_associated_role_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -87,7 +88,8 @@ module AssociateDRTRole : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -159,7 +161,8 @@ module AssociateHealthCheck : sig
       | `InvalidResourceException of invalid_resource_exception
       | `LimitsExceededException of limits_exceeded_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -203,7 +206,8 @@ module AssociateProactiveEngagementDetails : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -262,7 +266,8 @@ module CreateProtection : sig
       | `LimitsExceededException of limits_exceeded_exception
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -315,7 +320,8 @@ module CreateProtectionGroup : sig
       | `LimitsExceededException of limits_exceeded_exception
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -344,7 +350,8 @@ module CreateSubscription : sig
     ( create_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -383,7 +390,8 @@ module DeleteProtection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an Shield Advanced [Protection].\n"]
@@ -413,7 +421,8 @@ module DeleteProtectionGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes the specified protection group.\n"]
@@ -443,7 +452,8 @@ module DeleteSubscription : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `LockedSubscriptionException of locked_subscription_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -472,7 +482,8 @@ module DescribeAttack : sig
     ( describe_attack_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedException of access_denied_exception
-      | `InternalErrorException of internal_error_exception ] )
+      | `InternalErrorException of internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes the details of a DDoS attack. \n"]
@@ -495,7 +506,7 @@ module DescribeAttackStatistics : sig
     describe_attack_statistics_request ->
     ( describe_attack_statistics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -533,7 +544,8 @@ module DescribeDRTAccess : sig
     ( describe_drt_access_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -562,7 +574,8 @@ module DescribeEmergencyContactSettings : sig
     ( describe_emergency_contact_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -595,7 +608,8 @@ module DescribeProtection : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the details of a [Protection] object.\n"]
@@ -622,7 +636,8 @@ module DescribeProtectionGroup : sig
     ( describe_protection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the specification for the specified protection group.\n"]
@@ -649,7 +664,8 @@ module DescribeSubscription : sig
     ( describe_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides details about the Shield Advanced subscription for an account.\n"]
@@ -685,7 +701,8 @@ module DisableApplicationLayerAutomaticResponse : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -724,7 +741,8 @@ module DisableProactiveEngagement : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -765,7 +783,8 @@ module DisassociateDRTLogBucket : sig
       | `InvalidOperationException of invalid_operation_exception
       | `NoAssociatedRoleException of no_associated_role_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -800,7 +819,8 @@ module DisassociateDRTRole : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -837,7 +857,8 @@ module DisassociateHealthCheck : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidResourceException of invalid_resource_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -884,7 +905,8 @@ module EnableApplicationLayerAutomaticResponse : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitsExceededException of limits_exceeded_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -946,7 +968,8 @@ module EnableProactiveEngagement : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -971,7 +994,7 @@ module GetSubscriptionState : sig
     get_subscription_state_request ->
     ( get_subscription_state_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the [SubscriptionState], either [Active] or [Inactive].\n"]
@@ -1001,7 +1024,8 @@ module ListAttacks : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
-      | `InvalidParameterException of invalid_parameter_exception ] )
+      | `InvalidParameterException of invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1032,7 +1056,8 @@ module ListProtectionGroups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1065,7 +1090,8 @@ module ListProtections : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1097,7 +1123,8 @@ module ListResourcesInProtectionGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the resources that are included in the protection group. \n"]
@@ -1127,7 +1154,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1162,7 +1190,8 @@ module TagResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds or updates tags for a resource in Shield.\n"]
@@ -1195,7 +1224,8 @@ module UntagResource : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tags from a resource in Shield.\n"]
@@ -1231,7 +1261,8 @@ module UpdateApplicationLayerAutomaticResponse : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1266,7 +1297,8 @@ module UpdateEmergencyContactSettings : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1302,7 +1334,8 @@ module UpdateProtectionGroup : sig
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1341,7 +1374,8 @@ module UpdateSubscription : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LockedSubscriptionException of locked_subscription_exception
       | `OptimisticLockException of optimistic_lock_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/shield/operations.mli
+++ b/sdks/shield/operations.mli
@@ -27,6 +27,21 @@ module AssociateDRTLogBucket : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_drt_log_bucket_request ->
+    ( associate_drt_log_bucket_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedForDependencyException of access_denied_for_dependency_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `NoAssociatedRoleException of no_associated_role_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Authorizes the Shield Response Team (SRT) to access the specified Amazon S3 bucket containing \
@@ -53,6 +68,19 @@ module AssociateDRTRole : sig
     'http_type Smaws_Lib.Context.t ->
     associate_drt_role_request ->
     ( associate_drt_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedForDependencyException of access_denied_for_dependency_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_drt_role_request ->
+    ( associate_drt_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AccessDeniedForDependencyException of access_denied_for_dependency_exception
       | `InternalErrorException of internal_error_exception
@@ -120,6 +148,19 @@ module AssociateHealthCheck : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_health_check_request ->
+    ( associate_health_check_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds health-based detection to the Shield Advanced protection for a resource. Shield Advanced \
@@ -145,6 +186,18 @@ module AssociateProactiveEngagementDetails : sig
     'http_type Smaws_Lib.Context.t ->
     associate_proactive_engagement_details_request ->
     ( associate_proactive_engagement_details_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_proactive_engagement_details_request ->
+    ( associate_proactive_engagement_details_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -196,6 +249,21 @@ module CreateProtection : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_protection_request ->
+    ( create_protection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Enables Shield Advanced for a specific Amazon Web Services resource. The resource can be an \
@@ -236,6 +304,19 @@ module CreateProtectionGroup : sig
       | `ResourceAlreadyExistsException of resource_already_exists_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_protection_group_request ->
+    ( create_protection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a grouping of protected resources so they can be handled as a collective. This resource \
@@ -252,6 +333,15 @@ module CreateSubscription : sig
     'http_type Smaws_Lib.Context.t ->
     create_subscription_request ->
     ( create_subscription_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_subscription_request ->
+    ( create_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceAlreadyExistsException of resource_already_exists_exception ] )
@@ -285,6 +375,16 @@ module DeleteProtection : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_protection_request ->
+    ( delete_protection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes an Shield Advanced [Protection].\n"]
 
@@ -300,6 +400,16 @@ module DeleteProtectionGroup : sig
     'http_type Smaws_Lib.Context.t ->
     delete_protection_group_request ->
     ( delete_protection_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_protection_group_request ->
+    ( delete_protection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `OptimisticLockException of optimistic_lock_exception
@@ -325,6 +435,16 @@ module DeleteSubscription : sig
       | `LockedSubscriptionException of locked_subscription_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_subscription_request ->
+    ( delete_subscription_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `LockedSubscriptionException of locked_subscription_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes Shield Advanced from an account. Shield Advanced requires a 1-year subscription \
@@ -345,6 +465,15 @@ module DescribeAttack : sig
       | `AccessDeniedException of access_denied_exception
       | `InternalErrorException of internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_attack_request ->
+    ( describe_attack_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalErrorException of internal_error_exception ] )
+    result
 end
 [@@ocaml.doc "Describes the details of a DDoS attack. \n"]
 
@@ -357,6 +486,14 @@ module DescribeAttackStatistics : sig
     'http_type Smaws_Lib.Context.t ->
     describe_attack_statistics_request ->
     ( describe_attack_statistics_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_attack_statistics_request ->
+    ( describe_attack_statistics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
     )
     result
@@ -389,6 +526,15 @@ module DescribeDRTAccess : sig
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_drt_access_request ->
+    ( describe_drt_access_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the current role and list of Amazon S3 log buckets used by the Shield Response Team \
@@ -405,6 +551,15 @@ module DescribeEmergencyContactSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_emergency_contact_settings_request ->
     ( describe_emergency_contact_settings_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_emergency_contact_settings_request ->
+    ( describe_emergency_contact_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -432,6 +587,16 @@ module DescribeProtection : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_protection_request ->
+    ( describe_protection_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the details of a [Protection] object.\n"]
 
@@ -450,6 +615,15 @@ module DescribeProtectionGroup : sig
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_protection_group_request ->
+    ( describe_protection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the specification for the specified protection group.\n"]
 
@@ -464,6 +638,15 @@ module DescribeSubscription : sig
     'http_type Smaws_Lib.Context.t ->
     describe_subscription_request ->
     ( describe_subscription_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_subscription_request ->
+    ( describe_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -492,6 +675,18 @@ module DisableApplicationLayerAutomaticResponse : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_application_layer_automatic_response_request ->
+    ( disable_application_layer_automatic_response_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disable the Shield Advanced automatic application layer DDoS mitigation feature for the \
@@ -512,6 +707,18 @@ module DisableProactiveEngagement : sig
     'http_type Smaws_Lib.Context.t ->
     disable_proactive_engagement_request ->
     ( disable_proactive_engagement_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disable_proactive_engagement_request ->
+    ( disable_proactive_engagement_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -547,6 +754,19 @@ module DisassociateDRTLogBucket : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_drt_log_bucket_request ->
+    ( disassociate_drt_log_bucket_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedForDependencyException of access_denied_for_dependency_exception
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `NoAssociatedRoleException of no_associated_role_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the Shield Response Team's (SRT) access to the specified Amazon S3 bucket containing \
@@ -571,6 +791,17 @@ module DisassociateDRTRole : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_drt_role_request ->
+    ( disassociate_drt_role_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the Shield Response Team's (SRT) access to your Amazon Web Services account.\n"]
@@ -589,6 +820,18 @@ module DisassociateHealthCheck : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_health_check_request ->
     ( disassociate_health_check_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_health_check_request ->
+    ( disassociate_health_check_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -622,6 +865,19 @@ module EnableApplicationLayerAutomaticResponse : sig
     'http_type Smaws_Lib.Context.t ->
     enable_application_layer_automatic_response_request ->
     ( enable_application_layer_automatic_response_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitsExceededException of limits_exceeded_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_application_layer_automatic_response_request ->
+    ( enable_application_layer_automatic_response_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -680,6 +936,18 @@ module EnableProactiveEngagement : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    enable_proactive_engagement_request ->
+    ( enable_proactive_engagement_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Authorizes the Shield Response Team (SRT) to use email and phone to notify contacts about \
@@ -694,6 +962,14 @@ module GetSubscriptionState : sig
     'http_type Smaws_Lib.Context.t ->
     get_subscription_state_request ->
     ( get_subscription_state_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_subscription_state_request ->
+    ( get_subscription_state_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalErrorException of internal_error_exception ]
     )
     result
@@ -717,6 +993,16 @@ module ListAttacks : sig
       | `InvalidOperationException of invalid_operation_exception
       | `InvalidParameterException of invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_attacks_request ->
+    ( list_attacks_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns all ongoing DDoS attacks or all DDoS attacks during a specified time period.\n"]
@@ -733,6 +1019,16 @@ module ListProtectionGroups : sig
     'http_type Smaws_Lib.Context.t ->
     list_protection_groups_request ->
     ( list_protection_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidPaginationTokenException of invalid_pagination_token_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_protection_groups_request ->
+    ( list_protection_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
@@ -761,6 +1057,16 @@ module ListProtections : sig
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_protections_request ->
+    ( list_protections_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidPaginationTokenException of invalid_pagination_token_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves [Protection] objects for the account. You can retrieve all protections or you can \
@@ -783,6 +1089,16 @@ module ListResourcesInProtectionGroup : sig
       | `InvalidPaginationTokenException of invalid_pagination_token_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resources_in_protection_group_request ->
+    ( list_resources_in_protection_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidPaginationTokenException of invalid_pagination_token_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the resources that are included in the protection group. \n"]
 
@@ -798,6 +1114,16 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidResourceException of invalid_resource_exception
@@ -827,6 +1153,17 @@ module TagResource : sig
       | `InvalidResourceException of invalid_resource_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Adds or updates tags for a resource in Shield.\n"]
 
@@ -843,6 +1180,17 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_request ->
     ( untag_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -866,6 +1214,18 @@ module UpdateApplicationLayerAutomaticResponse : sig
     'http_type Smaws_Lib.Context.t ->
     update_application_layer_automatic_response_request ->
     ( update_application_layer_automatic_response_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidOperationException of invalid_operation_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_application_layer_automatic_response_request ->
+    ( update_application_layer_automatic_response_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidOperationException of invalid_operation_exception
@@ -897,6 +1257,17 @@ module UpdateEmergencyContactSettings : sig
       | `OptimisticLockException of optimistic_lock_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_emergency_contact_settings_request ->
+    ( update_emergency_contact_settings_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the details of the list of email addresses and phone numbers that the Shield Response \
@@ -916,6 +1287,17 @@ module UpdateProtectionGroup : sig
     'http_type Smaws_Lib.Context.t ->
     update_protection_group_request ->
     ( update_protection_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_protection_group_request ->
+    ( update_protection_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -942,6 +1324,18 @@ module UpdateSubscription : sig
     'http_type Smaws_Lib.Context.t ->
     update_subscription_request ->
     ( update_subscription_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalErrorException of internal_error_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LockedSubscriptionException of locked_subscription_exception
+      | `OptimisticLockException of optimistic_lock_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_subscription_request ->
+    ( update_subscription_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalErrorException of internal_error_exception
       | `InvalidParameterException of invalid_parameter_exception

--- a/sdks/snowball/Smaws_Client_Snowball.mli
+++ b/sdks/snowball/Smaws_Client_Snowball.mli
@@ -406,7 +406,8 @@ module CancelCluster : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -438,7 +439,8 @@ module CancelJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -468,7 +470,8 @@ module CreateAddress : sig
     ( create_address_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddressException of invalid_address_exception
-      | `UnsupportedAddressException of unsupported_address_exception ] )
+      | `UnsupportedAddressException of unsupported_address_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -506,7 +509,8 @@ module CreateCluster : sig
       | `Ec2RequestFailedException of ec2_request_failed_exception
       | `InvalidInputCombinationException of invalid_input_combination_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -545,7 +549,8 @@ module CreateJob : sig
       | `Ec2RequestFailedException of ec2_request_failed_exception
       | `InvalidInputCombinationException of invalid_input_combination_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -732,7 +737,8 @@ module CreateLongTermPricing : sig
     create_long_term_pricing_request ->
     ( create_long_term_pricing_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -774,7 +780,8 @@ module CreateReturnShippingLabel : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
       | `ReturnShippingLabelAlreadyExistsException of return_shipping_label_already_exists_exception
-      ] )
+      ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -798,7 +805,8 @@ module DescribeAddress : sig
     describe_address_request ->
     ( describe_address_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -827,7 +835,8 @@ module DescribeAddresses : sig
     ( describe_addresses_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -852,7 +861,8 @@ module DescribeCluster : sig
     describe_cluster_request ->
     ( describe_cluster_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -877,7 +887,8 @@ module DescribeJob : sig
     describe_job_request ->
     ( describe_job_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -909,7 +920,8 @@ module DescribeReturnShippingLabel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -937,7 +949,8 @@ module GetJobManifest : sig
     ( get_job_manifest_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -982,7 +995,8 @@ module GetJobUnlockCode : sig
     ( get_job_unlock_code_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1010,7 +1024,9 @@ module GetSnowballUsage : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     get_snowball_usage_request ->
-    (get_snowball_usage_result Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( get_snowball_usage_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "Returns information about the Snow Family service limit for your account, and also the number \
@@ -1041,7 +1057,8 @@ module GetSoftwareUpdates : sig
     ( get_software_updates_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1069,7 +1086,8 @@ module ListClusterJobs : sig
     ( list_cluster_jobs_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1096,7 +1114,8 @@ module ListClusters : sig
     list_clusters_request ->
     ( list_clusters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidNextTokenException of invalid_next_token_exception ] )
+      | `InvalidNextTokenException of invalid_next_token_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1125,7 +1144,8 @@ module ListCompatibleImages : sig
     ( list_compatible_images_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `Ec2RequestFailedException of ec2_request_failed_exception
-      | `InvalidNextTokenException of invalid_next_token_exception ] )
+      | `InvalidNextTokenException of invalid_next_token_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1155,7 +1175,8 @@ module ListJobs : sig
     list_jobs_request ->
     ( list_jobs_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidNextTokenException of invalid_next_token_exception ] )
+      | `InvalidNextTokenException of invalid_next_token_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1186,7 +1207,8 @@ module ListLongTermPricing : sig
     ( list_long_term_pricing_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all long-term pricing types.\n"]
@@ -1209,7 +1231,8 @@ module ListPickupLocations : sig
     list_pickup_locations_request ->
     ( list_pickup_locations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "A list of locations from which the customer can choose to pickup a device.\n"]
@@ -1236,7 +1259,8 @@ module ListServiceVersions : sig
     ( list_service_versions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1274,7 +1298,8 @@ module UpdateCluster : sig
       | `InvalidInputCombinationException of invalid_input_combination_exception
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1316,7 +1341,8 @@ module UpdateJob : sig
       | `InvalidInputCombinationException of invalid_input_combination_exception
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1346,7 +1372,8 @@ module UpdateJobShipmentState : sig
     ( update_job_shipment_state_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the state when a shipment state changes to a different state.\n"]
@@ -1370,7 +1397,8 @@ module UpdateLongTermPricing : sig
     update_long_term_pricing_request ->
     ( update_long_term_pricing_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the long-term pricing type.\n"]

--- a/sdks/snowball/Smaws_Client_Snowball.mli
+++ b/sdks/snowball/Smaws_Client_Snowball.mli
@@ -398,6 +398,16 @@ module CancelCluster : sig
       | `InvalidResourceException of invalid_resource_exception
       | `KMSRequestFailedException of kms_request_failed_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_cluster_request ->
+    ( cancel_cluster_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
 end
 [@@ocaml.doc
   "Cancels a cluster job. You can only cancel a cluster job while it's in the [AwaitingQuorum] \
@@ -420,6 +430,16 @@ module CancelJob : sig
       | `InvalidResourceException of invalid_resource_exception
       | `KMSRequestFailedException of kms_request_failed_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_job_request ->
+    ( cancel_job_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
 end
 [@@ocaml.doc
   "Cancels the specified job. You can only cancel a job before its [JobState] value changes to \
@@ -437,6 +457,15 @@ module CreateAddress : sig
     'http_type Smaws_Lib.Context.t ->
     create_address_request ->
     ( create_address_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddressException of invalid_address_exception
+      | `UnsupportedAddressException of unsupported_address_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_address_request ->
+    ( create_address_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddressException of invalid_address_exception
       | `UnsupportedAddressException of unsupported_address_exception ] )
@@ -468,6 +497,17 @@ module CreateCluster : sig
       | `InvalidResourceException of invalid_resource_exception
       | `KMSRequestFailedException of kms_request_failed_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_cluster_request ->
+    ( create_cluster_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an empty cluster. Each cluster supports five nodes. You use the [CreateJob] action \
@@ -488,6 +528,18 @@ module CreateJob : sig
     'http_type Smaws_Lib.Context.t ->
     create_job_request ->
     ( create_job_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterLimitExceededException of cluster_limit_exceeded_exception
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_job_request ->
+    ( create_job_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterLimitExceededException of cluster_limit_exceeded_exception
       | `Ec2RequestFailedException of ec2_request_failed_exception
@@ -674,6 +726,14 @@ module CreateLongTermPricing : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_long_term_pricing_request ->
+    ( create_long_term_pricing_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a job with the long-term usage option for a device. The long-term usage is a 1-year or \
@@ -703,6 +763,19 @@ module CreateReturnShippingLabel : sig
       | `ReturnShippingLabelAlreadyExistsException of return_shipping_label_already_exists_exception
       ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_return_shipping_label_request ->
+    ( create_return_shipping_label_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `ReturnShippingLabelAlreadyExistsException of return_shipping_label_already_exists_exception
+      ] )
+    result
 end
 [@@ocaml.doc
   "Creates a shipping label that will be used to return the Snow device to Amazon Web Services.\n"]
@@ -716,6 +789,14 @@ module DescribeAddress : sig
     'http_type Smaws_Lib.Context.t ->
     describe_address_request ->
     ( describe_address_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_address_request ->
+    ( describe_address_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
@@ -739,6 +820,15 @@ module DescribeAddresses : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_addresses_request ->
+    ( describe_addresses_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a specified number of [ADDRESS] objects. Calling this API in one of the US regions will \
@@ -756,6 +846,14 @@ module DescribeCluster : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_cluster_request ->
+    ( describe_cluster_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a specific cluster including shipping information, cluster status, \
@@ -770,6 +868,14 @@ module DescribeJob : sig
     'http_type Smaws_Lib.Context.t ->
     describe_job_request ->
     ( describe_job_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_job_request ->
+    ( describe_job_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
@@ -795,6 +901,16 @@ module DescribeReturnShippingLabel : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_return_shipping_label_request ->
+    ( describe_return_shipping_label_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Information on the shipping label of a Snow device that is being returned to Amazon Web Services.\n"]
@@ -810,6 +926,15 @@ module GetJobManifest : sig
     'http_type Smaws_Lib.Context.t ->
     get_job_manifest_request ->
     ( get_job_manifest_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_job_manifest_request ->
+    ( get_job_manifest_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
@@ -850,6 +975,15 @@ module GetJobUnlockCode : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_job_unlock_code_request ->
+    ( get_job_unlock_code_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the [UnlockCode] code value for the specified job. A particular [UnlockCode] value can \
@@ -872,6 +1006,11 @@ module GetSnowballUsage : sig
     'http_type Smaws_Lib.Context.t ->
     get_snowball_usage_request ->
     (get_snowball_usage_result, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_snowball_usage_request ->
+    (get_snowball_usage_result Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc
   "Returns information about the Snow Family service limit for your account, and also the number \
@@ -895,6 +1034,15 @@ module GetSoftwareUpdates : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_software_updates_request ->
+    ( get_software_updates_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an Amazon S3 presigned URL for an update file associated with a specified [JobId].\n"]
@@ -910,6 +1058,15 @@ module ListClusterJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_cluster_jobs_request ->
     ( list_cluster_jobs_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_cluster_jobs_request ->
+    ( list_cluster_jobs_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidResourceException of invalid_resource_exception ] )
@@ -933,6 +1090,14 @@ module ListClusters : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_clusters_request ->
+    ( list_clusters_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an array of [ClusterListEntry] objects of the specified length. Each [ClusterListEntry] \
@@ -949,6 +1114,15 @@ module ListCompatibleImages : sig
     'http_type Smaws_Lib.Context.t ->
     list_compatible_images_request ->
     ( list_compatible_images_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidNextTokenException of invalid_next_token_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_compatible_images_request ->
+    ( list_compatible_images_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `Ec2RequestFailedException of ec2_request_failed_exception
       | `InvalidNextTokenException of invalid_next_token_exception ] )
@@ -975,6 +1149,14 @@ module ListJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_jobs_request ->
+    ( list_jobs_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an array of [JobListEntry] objects of the specified length. Each [JobListEntry] object \
@@ -997,6 +1179,15 @@ module ListLongTermPricing : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_long_term_pricing_request ->
+    ( list_long_term_pricing_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc "Lists all long-term pricing types.\n"]
 
@@ -1009,6 +1200,14 @@ module ListPickupLocations : sig
     'http_type Smaws_Lib.Context.t ->
     list_pickup_locations_request ->
     ( list_pickup_locations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_pickup_locations_request ->
+    ( list_pickup_locations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
@@ -1026,6 +1225,15 @@ module ListServiceVersions : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_versions_request ->
     ( list_service_versions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_versions_request ->
+    ( list_service_versions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidResourceException of invalid_resource_exception ] )
@@ -1049,6 +1257,18 @@ module UpdateCluster : sig
     'http_type Smaws_Lib.Context.t ->
     update_cluster_request ->
     ( update_cluster_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_cluster_request ->
+    ( update_cluster_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `Ec2RequestFailedException of ec2_request_failed_exception
       | `InvalidInputCombinationException of invalid_input_combination_exception
@@ -1085,6 +1305,19 @@ module UpdateJob : sig
       | `InvalidResourceException of invalid_resource_exception
       | `KMSRequestFailedException of kms_request_failed_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_job_request ->
+    ( update_job_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterLimitExceededException of cluster_limit_exceeded_exception
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
 end
 [@@ocaml.doc
   "While a job's [JobState] value is [New], you can update some of the information associated with \
@@ -1106,6 +1339,15 @@ module UpdateJobShipmentState : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_job_shipment_state_request ->
+    ( update_job_shipment_state_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc "Updates the state when a shipment state changes to a different state.\n"]
 
@@ -1119,6 +1361,14 @@ module UpdateLongTermPricing : sig
     'http_type Smaws_Lib.Context.t ->
     update_long_term_pricing_request ->
     ( update_long_term_pricing_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_long_term_pricing_request ->
+    ( update_long_term_pricing_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result

--- a/sdks/snowball/operations.ml
+++ b/sdks/snowball/operations.ml
@@ -29,6 +29,12 @@ module CancelCluster = struct
     Smaws_Lib.Protocols.AwsJson.request
       ~shape_name:"AWSIESnowballJobManagementService.CancelCluster" ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_cluster_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : cancel_cluster_request) =
+    let input = Json_serializers.cancel_cluster_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.CancelCluster" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_cluster_result_of_yojson ~error_deserializer
 end
 
 module CancelJob = struct
@@ -59,6 +65,12 @@ module CancelJob = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSIESnowballJobManagementService.CancelJob"
       ~service ~context ~input ~output_deserializer:Json_deserializers.cancel_job_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : cancel_job_request) =
+    let input = Json_serializers.cancel_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.CancelJob" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_job_result_of_yojson ~error_deserializer
 end
 
 module CreateAddress = struct
@@ -83,6 +95,12 @@ module CreateAddress = struct
   let request context (request : create_address_request) =
     let input = Json_serializers.create_address_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.CreateAddress" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_address_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_address_request) =
+    let input = Json_serializers.create_address_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.CreateAddress" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_address_result_of_yojson ~error_deserializer
 end
@@ -118,6 +136,12 @@ module CreateCluster = struct
   let request context (request : create_cluster_request) =
     let input = Json_serializers.create_cluster_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.CreateCluster" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_cluster_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_cluster_request) =
+    let input = Json_serializers.create_cluster_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.CreateCluster" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_cluster_result_of_yojson ~error_deserializer
 end
@@ -159,6 +183,12 @@ module CreateJob = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSIESnowballJobManagementService.CreateJob"
       ~service ~context ~input ~output_deserializer:Json_deserializers.create_job_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_job_request) =
+    let input = Json_serializers.create_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.CreateJob" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_job_result_of_yojson ~error_deserializer
 end
 
 module CreateLongTermPricing = struct
@@ -179,6 +209,13 @@ module CreateLongTermPricing = struct
   let request context (request : create_long_term_pricing_request) =
     let input = Json_serializers.create_long_term_pricing_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.CreateLongTermPricing" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_long_term_pricing_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_long_term_pricing_request) =
+    let input = Json_serializers.create_long_term_pricing_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.CreateLongTermPricing" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_long_term_pricing_result_of_yojson
       ~error_deserializer
@@ -222,6 +259,13 @@ module CreateReturnShippingLabel = struct
       ~shape_name:"AWSIESnowballJobManagementService.CreateReturnShippingLabel" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_return_shipping_label_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_return_shipping_label_request) =
+    let input = Json_serializers.create_return_shipping_label_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.CreateReturnShippingLabel" ~service ~context
+      ~input ~output_deserializer:Json_deserializers.create_return_shipping_label_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAddress = struct
@@ -242,6 +286,12 @@ module DescribeAddress = struct
   let request context (request : describe_address_request) =
     let input = Json_serializers.describe_address_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.DescribeAddress" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_address_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_address_request) =
+    let input = Json_serializers.describe_address_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.DescribeAddress" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_address_result_of_yojson ~error_deserializer
 end
@@ -271,6 +321,13 @@ module DescribeAddresses = struct
       ~shape_name:"AWSIESnowballJobManagementService.DescribeAddresses" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_addresses_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_addresses_request) =
+    let input = Json_serializers.describe_addresses_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.DescribeAddresses" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_addresses_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeCluster = struct
@@ -291,6 +348,12 @@ module DescribeCluster = struct
   let request context (request : describe_cluster_request) =
     let input = Json_serializers.describe_cluster_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.DescribeCluster" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_cluster_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_cluster_request) =
+    let input = Json_serializers.describe_cluster_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.DescribeCluster" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_cluster_result_of_yojson ~error_deserializer
 end
@@ -315,6 +378,12 @@ module DescribeJob = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSIESnowballJobManagementService.DescribeJob"
       ~service ~context ~input ~output_deserializer:Json_deserializers.describe_job_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_job_request) =
+    let input = Json_serializers.describe_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.DescribeJob" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_job_result_of_yojson ~error_deserializer
 end
 
 module DescribeReturnShippingLabel = struct
@@ -345,6 +414,13 @@ module DescribeReturnShippingLabel = struct
       ~shape_name:"AWSIESnowballJobManagementService.DescribeReturnShippingLabel" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_return_shipping_label_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_return_shipping_label_request) =
+    let input = Json_serializers.describe_return_shipping_label_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.DescribeReturnShippingLabel" ~service ~context
+      ~input ~output_deserializer:Json_deserializers.describe_return_shipping_label_result_of_yojson
+      ~error_deserializer
 end
 
 module GetJobManifest = struct
@@ -369,6 +445,12 @@ module GetJobManifest = struct
   let request context (request : get_job_manifest_request) =
     let input = Json_serializers.get_job_manifest_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.GetJobManifest" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_job_manifest_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_job_manifest_request) =
+    let input = Json_serializers.get_job_manifest_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.GetJobManifest" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_job_manifest_result_of_yojson ~error_deserializer
 end
@@ -398,6 +480,13 @@ module GetJobUnlockCode = struct
       ~shape_name:"AWSIESnowballJobManagementService.GetJobUnlockCode" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_job_unlock_code_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_job_unlock_code_request) =
+    let input = Json_serializers.get_job_unlock_code_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.GetJobUnlockCode" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_job_unlock_code_result_of_yojson
+      ~error_deserializer
 end
 
 module GetSnowballUsage = struct
@@ -411,6 +500,13 @@ module GetSnowballUsage = struct
   let request context (request : get_snowball_usage_request) =
     let input = Json_serializers.get_snowball_usage_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.GetSnowballUsage" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_snowball_usage_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_snowball_usage_request) =
+    let input = Json_serializers.get_snowball_usage_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.GetSnowballUsage" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_snowball_usage_result_of_yojson
       ~error_deserializer
@@ -441,6 +537,13 @@ module GetSoftwareUpdates = struct
       ~shape_name:"AWSIESnowballJobManagementService.GetSoftwareUpdates" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_software_updates_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_software_updates_request) =
+    let input = Json_serializers.get_software_updates_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.GetSoftwareUpdates" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_software_updates_result_of_yojson
+      ~error_deserializer
 end
 
 module ListClusterJobs = struct
@@ -467,6 +570,12 @@ module ListClusterJobs = struct
     Smaws_Lib.Protocols.AwsJson.request
       ~shape_name:"AWSIESnowballJobManagementService.ListClusterJobs" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_cluster_jobs_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_cluster_jobs_request) =
+    let input = Json_serializers.list_cluster_jobs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.ListClusterJobs" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_cluster_jobs_result_of_yojson ~error_deserializer
 end
 
 module ListClusters = struct
@@ -488,6 +597,12 @@ module ListClusters = struct
     let input = Json_serializers.list_clusters_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSIESnowballJobManagementService.ListClusters"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_clusters_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_clusters_request) =
+    let input = Json_serializers.list_clusters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.ListClusters" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_clusters_result_of_yojson ~error_deserializer
 end
 
@@ -516,6 +631,13 @@ module ListCompatibleImages = struct
       ~shape_name:"AWSIESnowballJobManagementService.ListCompatibleImages" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_compatible_images_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_compatible_images_request) =
+    let input = Json_serializers.list_compatible_images_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.ListCompatibleImages" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_compatible_images_result_of_yojson
+      ~error_deserializer
 end
 
 module ListJobs = struct
@@ -538,6 +660,12 @@ module ListJobs = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSIESnowballJobManagementService.ListJobs"
       ~service ~context ~input ~output_deserializer:Json_deserializers.list_jobs_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_jobs_request) =
+    let input = Json_serializers.list_jobs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.ListJobs" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_jobs_result_of_yojson ~error_deserializer
 end
 
 module ListLongTermPricing = struct
@@ -565,6 +693,13 @@ module ListLongTermPricing = struct
       ~shape_name:"AWSIESnowballJobManagementService.ListLongTermPricing" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_long_term_pricing_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_long_term_pricing_request) =
+    let input = Json_serializers.list_long_term_pricing_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.ListLongTermPricing" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_long_term_pricing_result_of_yojson
+      ~error_deserializer
 end
 
 module ListPickupLocations = struct
@@ -585,6 +720,13 @@ module ListPickupLocations = struct
   let request context (request : list_pickup_locations_request) =
     let input = Json_serializers.list_pickup_locations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.ListPickupLocations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_pickup_locations_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_pickup_locations_request) =
+    let input = Json_serializers.list_pickup_locations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.ListPickupLocations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_pickup_locations_result_of_yojson
       ~error_deserializer
@@ -612,6 +754,13 @@ module ListServiceVersions = struct
   let request context (request : list_service_versions_request) =
     let input = Json_serializers.list_service_versions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.ListServiceVersions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_service_versions_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_service_versions_request) =
+    let input = Json_serializers.list_service_versions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.ListServiceVersions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_service_versions_result_of_yojson
       ~error_deserializer
@@ -652,6 +801,12 @@ module UpdateCluster = struct
   let request context (request : update_cluster_request) =
     let input = Json_serializers.update_cluster_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.UpdateCluster" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_cluster_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : update_cluster_request) =
+    let input = Json_serializers.update_cluster_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.UpdateCluster" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_cluster_result_of_yojson ~error_deserializer
 end
@@ -697,6 +852,12 @@ module UpdateJob = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSIESnowballJobManagementService.UpdateJob"
       ~service ~context ~input ~output_deserializer:Json_deserializers.update_job_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_job_request) =
+    let input = Json_serializers.update_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.UpdateJob" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_job_result_of_yojson ~error_deserializer
 end
 
 module UpdateJobShipmentState = struct
@@ -724,6 +885,13 @@ module UpdateJobShipmentState = struct
       ~shape_name:"AWSIESnowballJobManagementService.UpdateJobShipmentState" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_job_shipment_state_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_job_shipment_state_request) =
+    let input = Json_serializers.update_job_shipment_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSIESnowballJobManagementService.UpdateJobShipmentState" ~service ~context
+      ~input ~output_deserializer:Json_deserializers.update_job_shipment_state_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateLongTermPricing = struct
@@ -744,6 +912,13 @@ module UpdateLongTermPricing = struct
   let request context (request : update_long_term_pricing_request) =
     let input = Json_serializers.update_long_term_pricing_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSIESnowballJobManagementService.UpdateLongTermPricing" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_long_term_pricing_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_long_term_pricing_request) =
+    let input = Json_serializers.update_long_term_pricing_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSIESnowballJobManagementService.UpdateLongTermPricing" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_long_term_pricing_result_of_yojson
       ~error_deserializer

--- a/sdks/snowball/operations.mli
+++ b/sdks/snowball/operations.mli
@@ -17,6 +17,16 @@ module CancelCluster : sig
       | `InvalidResourceException of invalid_resource_exception
       | `KMSRequestFailedException of kms_request_failed_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_cluster_request ->
+    ( cancel_cluster_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
 end
 [@@ocaml.doc
   "Cancels a cluster job. You can only cancel a cluster job while it's in the [AwaitingQuorum] \
@@ -39,6 +49,16 @@ module CancelJob : sig
       | `InvalidResourceException of invalid_resource_exception
       | `KMSRequestFailedException of kms_request_failed_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_job_request ->
+    ( cancel_job_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
 end
 [@@ocaml.doc
   "Cancels the specified job. You can only cancel a job before its [JobState] value changes to \
@@ -56,6 +76,15 @@ module CreateAddress : sig
     'http_type Smaws_Lib.Context.t ->
     create_address_request ->
     ( create_address_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddressException of invalid_address_exception
+      | `UnsupportedAddressException of unsupported_address_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_address_request ->
+    ( create_address_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddressException of invalid_address_exception
       | `UnsupportedAddressException of unsupported_address_exception ] )
@@ -87,6 +116,17 @@ module CreateCluster : sig
       | `InvalidResourceException of invalid_resource_exception
       | `KMSRequestFailedException of kms_request_failed_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_cluster_request ->
+    ( create_cluster_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an empty cluster. Each cluster supports five nodes. You use the [CreateJob] action \
@@ -107,6 +147,18 @@ module CreateJob : sig
     'http_type Smaws_Lib.Context.t ->
     create_job_request ->
     ( create_job_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterLimitExceededException of cluster_limit_exceeded_exception
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_job_request ->
+    ( create_job_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ClusterLimitExceededException of cluster_limit_exceeded_exception
       | `Ec2RequestFailedException of ec2_request_failed_exception
@@ -293,6 +345,14 @@ module CreateLongTermPricing : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_long_term_pricing_request ->
+    ( create_long_term_pricing_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a job with the long-term usage option for a device. The long-term usage is a 1-year or \
@@ -322,6 +382,19 @@ module CreateReturnShippingLabel : sig
       | `ReturnShippingLabelAlreadyExistsException of return_shipping_label_already_exists_exception
       ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_return_shipping_label_request ->
+    ( create_return_shipping_label_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `ReturnShippingLabelAlreadyExistsException of return_shipping_label_already_exists_exception
+      ] )
+    result
 end
 [@@ocaml.doc
   "Creates a shipping label that will be used to return the Snow device to Amazon Web Services.\n"]
@@ -335,6 +408,14 @@ module DescribeAddress : sig
     'http_type Smaws_Lib.Context.t ->
     describe_address_request ->
     ( describe_address_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_address_request ->
+    ( describe_address_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
@@ -358,6 +439,15 @@ module DescribeAddresses : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_addresses_request ->
+    ( describe_addresses_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a specified number of [ADDRESS] objects. Calling this API in one of the US regions will \
@@ -375,6 +465,14 @@ module DescribeCluster : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_cluster_request ->
+    ( describe_cluster_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about a specific cluster including shipping information, cluster status, \
@@ -389,6 +487,14 @@ module DescribeJob : sig
     'http_type Smaws_Lib.Context.t ->
     describe_job_request ->
     ( describe_job_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_job_request ->
+    ( describe_job_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
@@ -414,6 +520,16 @@ module DescribeReturnShippingLabel : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_return_shipping_label_request ->
+    ( describe_return_shipping_label_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ConflictException of conflict_exception
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Information on the shipping label of a Snow device that is being returned to Amazon Web Services.\n"]
@@ -429,6 +545,15 @@ module GetJobManifest : sig
     'http_type Smaws_Lib.Context.t ->
     get_job_manifest_request ->
     ( get_job_manifest_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_job_manifest_request ->
+    ( get_job_manifest_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
@@ -469,6 +594,15 @@ module GetJobUnlockCode : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_job_unlock_code_request ->
+    ( get_job_unlock_code_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the [UnlockCode] code value for the specified job. A particular [UnlockCode] value can \
@@ -491,6 +625,11 @@ module GetSnowballUsage : sig
     'http_type Smaws_Lib.Context.t ->
     get_snowball_usage_request ->
     (get_snowball_usage_result, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_snowball_usage_request ->
+    (get_snowball_usage_result Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
 end
 [@@ocaml.doc
   "Returns information about the Snow Family service limit for your account, and also the number \
@@ -514,6 +653,15 @@ module GetSoftwareUpdates : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_software_updates_request ->
+    ( get_software_updates_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an Amazon S3 presigned URL for an update file associated with a specified [JobId].\n"]
@@ -529,6 +677,15 @@ module ListClusterJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_cluster_jobs_request ->
     ( list_cluster_jobs_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_cluster_jobs_request ->
+    ( list_cluster_jobs_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidResourceException of invalid_resource_exception ] )
@@ -552,6 +709,14 @@ module ListClusters : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_clusters_request ->
+    ( list_clusters_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an array of [ClusterListEntry] objects of the specified length. Each [ClusterListEntry] \
@@ -568,6 +733,15 @@ module ListCompatibleImages : sig
     'http_type Smaws_Lib.Context.t ->
     list_compatible_images_request ->
     ( list_compatible_images_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidNextTokenException of invalid_next_token_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_compatible_images_request ->
+    ( list_compatible_images_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `Ec2RequestFailedException of ec2_request_failed_exception
       | `InvalidNextTokenException of invalid_next_token_exception ] )
@@ -594,6 +768,14 @@ module ListJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_jobs_request ->
+    ( list_jobs_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns an array of [JobListEntry] objects of the specified length. Each [JobListEntry] object \
@@ -616,6 +798,15 @@ module ListLongTermPricing : sig
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_long_term_pricing_request ->
+    ( list_long_term_pricing_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc "Lists all long-term pricing types.\n"]
 
@@ -628,6 +819,14 @@ module ListPickupLocations : sig
     'http_type Smaws_Lib.Context.t ->
     list_pickup_locations_request ->
     ( list_pickup_locations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_pickup_locations_request ->
+    ( list_pickup_locations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result
@@ -645,6 +844,15 @@ module ListServiceVersions : sig
     'http_type Smaws_Lib.Context.t ->
     list_service_versions_request ->
     ( list_service_versions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidNextTokenException of invalid_next_token_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_service_versions_request ->
+    ( list_service_versions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
       | `InvalidResourceException of invalid_resource_exception ] )
@@ -668,6 +876,18 @@ module UpdateCluster : sig
     'http_type Smaws_Lib.Context.t ->
     update_cluster_request ->
     ( update_cluster_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_cluster_request ->
+    ( update_cluster_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `Ec2RequestFailedException of ec2_request_failed_exception
       | `InvalidInputCombinationException of invalid_input_combination_exception
@@ -704,6 +924,19 @@ module UpdateJob : sig
       | `InvalidResourceException of invalid_resource_exception
       | `KMSRequestFailedException of kms_request_failed_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_job_request ->
+    ( update_job_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ClusterLimitExceededException of cluster_limit_exceeded_exception
+      | `Ec2RequestFailedException of ec2_request_failed_exception
+      | `InvalidInputCombinationException of invalid_input_combination_exception
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception
+      | `KMSRequestFailedException of kms_request_failed_exception ] )
+    result
 end
 [@@ocaml.doc
   "While a job's [JobState] value is [New], you can update some of the information associated with \
@@ -725,6 +958,15 @@ module UpdateJobShipmentState : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_job_shipment_state_request ->
+    ( update_job_shipment_state_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidJobStateException of invalid_job_state_exception
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc "Updates the state when a shipment state changes to a different state.\n"]
 
@@ -737,6 +979,14 @@ module UpdateLongTermPricing : sig
     'http_type Smaws_Lib.Context.t ->
     update_long_term_pricing_request ->
     ( update_long_term_pricing_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidResourceException of invalid_resource_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_long_term_pricing_request ->
+    ( update_long_term_pricing_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidResourceException of invalid_resource_exception ] )
     result

--- a/sdks/snowball/operations.mli
+++ b/sdks/snowball/operations.mli
@@ -25,7 +25,8 @@ module CancelCluster : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -57,7 +58,8 @@ module CancelJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -87,7 +89,8 @@ module CreateAddress : sig
     ( create_address_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddressException of invalid_address_exception
-      | `UnsupportedAddressException of unsupported_address_exception ] )
+      | `UnsupportedAddressException of unsupported_address_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -125,7 +128,8 @@ module CreateCluster : sig
       | `Ec2RequestFailedException of ec2_request_failed_exception
       | `InvalidInputCombinationException of invalid_input_combination_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -164,7 +168,8 @@ module CreateJob : sig
       | `Ec2RequestFailedException of ec2_request_failed_exception
       | `InvalidInputCombinationException of invalid_input_combination_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -351,7 +356,8 @@ module CreateLongTermPricing : sig
     create_long_term_pricing_request ->
     ( create_long_term_pricing_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -393,7 +399,8 @@ module CreateReturnShippingLabel : sig
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
       | `ReturnShippingLabelAlreadyExistsException of return_shipping_label_already_exists_exception
-      ] )
+      ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -417,7 +424,8 @@ module DescribeAddress : sig
     describe_address_request ->
     ( describe_address_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -446,7 +454,8 @@ module DescribeAddresses : sig
     ( describe_addresses_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -471,7 +480,8 @@ module DescribeCluster : sig
     describe_cluster_request ->
     ( describe_cluster_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -496,7 +506,8 @@ module DescribeJob : sig
     describe_job_request ->
     ( describe_job_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -528,7 +539,8 @@ module DescribeReturnShippingLabel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ConflictException of conflict_exception
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -556,7 +568,8 @@ module GetJobManifest : sig
     ( get_job_manifest_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -601,7 +614,8 @@ module GetJobUnlockCode : sig
     ( get_job_unlock_code_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -629,7 +643,9 @@ module GetSnowballUsage : sig
   val request_with_metadata :
     'http_type Smaws_Lib.Context.t ->
     get_snowball_usage_request ->
-    (get_snowball_usage_result Smaws_Lib.Response.t, [> Smaws_Lib.Protocols.AwsJson.error ]) result
+    ( get_snowball_usage_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error ] * Smaws_Lib.Response.metadata )
+    result
 end
 [@@ocaml.doc
   "Returns information about the Snow Family service limit for your account, and also the number \
@@ -660,7 +676,8 @@ module GetSoftwareUpdates : sig
     ( get_software_updates_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -688,7 +705,8 @@ module ListClusterJobs : sig
     ( list_cluster_jobs_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -715,7 +733,8 @@ module ListClusters : sig
     list_clusters_request ->
     ( list_clusters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidNextTokenException of invalid_next_token_exception ] )
+      | `InvalidNextTokenException of invalid_next_token_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -744,7 +763,8 @@ module ListCompatibleImages : sig
     ( list_compatible_images_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `Ec2RequestFailedException of ec2_request_failed_exception
-      | `InvalidNextTokenException of invalid_next_token_exception ] )
+      | `InvalidNextTokenException of invalid_next_token_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -774,7 +794,8 @@ module ListJobs : sig
     list_jobs_request ->
     ( list_jobs_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidNextTokenException of invalid_next_token_exception ] )
+      | `InvalidNextTokenException of invalid_next_token_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -805,7 +826,8 @@ module ListLongTermPricing : sig
     ( list_long_term_pricing_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all long-term pricing types.\n"]
@@ -828,7 +850,8 @@ module ListPickupLocations : sig
     list_pickup_locations_request ->
     ( list_pickup_locations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "A list of locations from which the customer can choose to pickup a device.\n"]
@@ -855,7 +878,8 @@ module ListServiceVersions : sig
     ( list_service_versions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidNextTokenException of invalid_next_token_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -893,7 +917,8 @@ module UpdateCluster : sig
       | `InvalidInputCombinationException of invalid_input_combination_exception
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -935,7 +960,8 @@ module UpdateJob : sig
       | `InvalidInputCombinationException of invalid_input_combination_exception
       | `InvalidJobStateException of invalid_job_state_exception
       | `InvalidResourceException of invalid_resource_exception
-      | `KMSRequestFailedException of kms_request_failed_exception ] )
+      | `KMSRequestFailedException of kms_request_failed_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -965,7 +991,8 @@ module UpdateJobShipmentState : sig
     ( update_job_shipment_state_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidJobStateException of invalid_job_state_exception
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the state when a shipment state changes to a different state.\n"]
@@ -988,7 +1015,8 @@ module UpdateLongTermPricing : sig
     update_long_term_pricing_request ->
     ( update_long_term_pricing_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidResourceException of invalid_resource_exception ] )
+      | `InvalidResourceException of invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates the long-term pricing type.\n"]

--- a/sdks/sqs/Smaws_Client_SQS.mli
+++ b/sdks/sqs/Smaws_Client_SQS.mli
@@ -245,7 +245,8 @@ module AddPermission : sig
       | `OverLimit of over_limit
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -317,7 +318,8 @@ module CancelMessageMoveTask : sig
       | `InvalidSecurity of invalid_security
       | `RequestThrottled of request_throttled
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -375,7 +377,8 @@ module ChangeMessageVisibility : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `ReceiptHandleIsInvalid of receipt_handle_is_invalid
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -481,7 +484,8 @@ module ChangeMessageVisibilityBatch : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -540,7 +544,8 @@ module CreateQueue : sig
       | `QueueDeletedRecently of queue_deleted_recently
       | `QueueNameExists of queue_name_exists
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -637,7 +642,8 @@ module DeleteMessage : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `ReceiptHandleIsInvalid of receipt_handle_is_invalid
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -704,7 +710,8 @@ module DeleteMessageBatch : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -749,7 +756,8 @@ module DeleteQueue : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -810,7 +818,8 @@ module GetQueueAttributes : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -852,7 +861,8 @@ module GetQueueUrl : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -901,7 +911,8 @@ module ListDeadLetterSourceQueues : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -950,7 +961,8 @@ module ListMessageMoveTasks : sig
       | `InvalidSecurity of invalid_security
       | `RequestThrottled of request_throttled
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1000,7 +1012,8 @@ module ListQueueTags : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1041,7 +1054,8 @@ module ListQueues : sig
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1095,7 +1109,8 @@ module PurgeQueue : sig
       | `PurgeQueueInProgress of purge_queue_in_progress
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1168,7 +1183,8 @@ module ReceiveMessage : sig
       | `OverLimit of over_limit
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1252,7 +1268,8 @@ module RemovePermission : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1328,7 +1345,8 @@ module SendMessage : sig
       | `KmsThrottled of kms_throttled
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1412,7 +1430,8 @@ module SendMessageBatch : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1486,7 +1505,8 @@ module SetQueueAttributes : sig
       | `OverLimit of over_limit
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1545,7 +1565,8 @@ module StartMessageMoveTask : sig
       | `InvalidSecurity of invalid_security
       | `RequestThrottled of request_throttled
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1601,7 +1622,8 @@ module TagQueue : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1668,7 +1690,8 @@ module UntagQueue : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/sqs/Smaws_Client_SQS.mli
+++ b/sdks/sqs/Smaws_Client_SQS.mli
@@ -234,6 +234,19 @@ module AddPermission : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_permission_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `OverLimit of over_limit
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Adds a permission to a queue for a specific \
@@ -294,6 +307,18 @@ module CancelMessageMoveTask : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_message_move_task_request ->
+    ( cancel_message_move_task_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `RequestThrottled of request_throttled
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Cancels a specified message movement task. A message movement can only be cancelled when the \
@@ -329,6 +354,20 @@ module ChangeMessageVisibility : sig
     'http_type Smaws_Lib.Context.t ->
     change_message_visibility_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `MessageNotInflight of message_not_inflight
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `ReceiptHandleIsInvalid of receipt_handle_is_invalid
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    change_message_visibility_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -428,6 +467,22 @@ module ChangeMessageVisibilityBatch : sig
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    change_message_visibility_batch_request ->
+    ( change_message_visibility_batch_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BatchEntryIdsNotDistinct of batch_entry_ids_not_distinct
+      | `EmptyBatchRequest of empty_batch_request
+      | `InvalidAddress of invalid_address
+      | `InvalidBatchEntryId of invalid_batch_entry_id
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Changes the visibility timeout of multiple messages. This is a batch version of \n\
@@ -462,6 +517,21 @@ module CreateQueue : sig
     'http_type Smaws_Lib.Context.t ->
     create_queue_request ->
     ( create_queue_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidAttributeName of invalid_attribute_name
+      | `InvalidAttributeValue of invalid_attribute_value
+      | `InvalidSecurity of invalid_security
+      | `QueueDeletedRecently of queue_deleted_recently
+      | `QueueNameExists of queue_name_exists
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_queue_request ->
+    ( create_queue_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidAttributeName of invalid_attribute_name
@@ -555,6 +625,20 @@ module DeleteMessage : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_message_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidIdFormat of invalid_id_format
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `ReceiptHandleIsInvalid of receipt_handle_is_invalid
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified message from the specified queue. To select the message to delete, use \
@@ -606,6 +690,22 @@ module DeleteMessageBatch : sig
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_message_batch_request ->
+    ( delete_message_batch_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BatchEntryIdsNotDistinct of batch_entry_ids_not_distinct
+      | `EmptyBatchRequest of empty_batch_request
+      | `InvalidAddress of invalid_address
+      | `InvalidBatchEntryId of invalid_batch_entry_id
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Deletes up to ten messages from the specified queue. This is a batch version of \n\
@@ -632,6 +732,18 @@ module DeleteQueue : sig
     'http_type Smaws_Lib.Context.t ->
     delete_queue_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_queue_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -687,6 +799,19 @@ module GetQueueAttributes : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_queue_attributes_request ->
+    ( get_queue_attributes_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidAttributeName of invalid_attribute_name
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Gets attributes for the specified queue.\n\n\
@@ -710,6 +835,18 @@ module GetQueueUrl : sig
     'http_type Smaws_Lib.Context.t ->
     get_queue_url_request ->
     ( get_queue_url_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_queue_url_request ->
+    ( get_queue_url_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -754,6 +891,18 @@ module ListDeadLetterSourceQueues : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_dead_letter_source_queues_request ->
+    ( list_dead_letter_source_queues_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of your queues that have the [RedrivePolicy] queue attribute configured with a \
@@ -784,6 +933,18 @@ module ListMessageMoveTasks : sig
     'http_type Smaws_Lib.Context.t ->
     list_message_move_tasks_request ->
     ( list_message_move_tasks_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `RequestThrottled of request_throttled
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_message_move_tasks_request ->
+    ( list_message_move_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -829,6 +990,18 @@ module ListQueueTags : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_queue_tags_request ->
+    ( list_queue_tags_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "List all cost allocation tags added to the specified Amazon SQS queue. For an overview, see \
@@ -853,6 +1026,17 @@ module ListQueues : sig
     'http_type Smaws_Lib.Context.t ->
     list_queues_request ->
     ( list_queues_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_queues_request ->
+    ( list_queues_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -900,6 +1084,19 @@ module PurgeQueue : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    purge_queue_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `PurgeQueueInProgress of purge_queue_in_progress
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Deletes available messages in a queue (including in-flight messages) specified by the \
@@ -938,6 +1135,26 @@ module ReceiveMessage : sig
     'http_type Smaws_Lib.Context.t ->
     receive_message_request ->
     ( receive_message_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `KmsAccessDenied of kms_access_denied
+      | `KmsDisabled of kms_disabled
+      | `KmsInvalidKeyUsage of kms_invalid_key_usage
+      | `KmsInvalidState of kms_invalid_state
+      | `KmsNotFound of kms_not_found
+      | `KmsOptInRequired of kms_opt_in_required
+      | `KmsThrottled of kms_throttled
+      | `OverLimit of over_limit
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    receive_message_request ->
+    ( receive_message_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -1025,6 +1242,18 @@ module RemovePermission : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_permission_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Revokes any permissions in the queue policy that matches the specified [Label] parameter.\n\n\
@@ -1081,6 +1310,26 @@ module SendMessage : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_message_request ->
+    ( send_message_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidMessageContents of invalid_message_contents
+      | `InvalidSecurity of invalid_security
+      | `KmsAccessDenied of kms_access_denied
+      | `KmsDisabled of kms_disabled
+      | `KmsInvalidKeyUsage of kms_invalid_key_usage
+      | `KmsInvalidState of kms_invalid_state
+      | `KmsNotFound of kms_not_found
+      | `KmsOptInRequired of kms_opt_in_required
+      | `KmsThrottled of kms_throttled
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Delivers a message to the specified queue.\n\n\
@@ -1122,6 +1371,30 @@ module SendMessageBatch : sig
     'http_type Smaws_Lib.Context.t ->
     send_message_batch_request ->
     ( send_message_batch_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BatchEntryIdsNotDistinct of batch_entry_ids_not_distinct
+      | `BatchRequestTooLong of batch_request_too_long
+      | `EmptyBatchRequest of empty_batch_request
+      | `InvalidAddress of invalid_address
+      | `InvalidBatchEntryId of invalid_batch_entry_id
+      | `InvalidSecurity of invalid_security
+      | `KmsAccessDenied of kms_access_denied
+      | `KmsDisabled of kms_disabled
+      | `KmsInvalidKeyUsage of kms_invalid_key_usage
+      | `KmsInvalidState of kms_invalid_state
+      | `KmsNotFound of kms_not_found
+      | `KmsOptInRequired of kms_opt_in_required
+      | `KmsThrottled of kms_throttled
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_message_batch_request ->
+    ( send_message_batch_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BatchEntryIdsNotDistinct of batch_entry_ids_not_distinct
       | `BatchRequestTooLong of batch_request_too_long
@@ -1200,6 +1473,21 @@ module SetQueueAttributes : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_queue_attributes_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidAttributeName of invalid_attribute_name
+      | `InvalidAttributeValue of invalid_attribute_value
+      | `InvalidSecurity of invalid_security
+      | `OverLimit of over_limit
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Sets the value of one or more queue attributes, like a policy. When you change a queue's \
@@ -1247,6 +1535,18 @@ module StartMessageMoveTask : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_message_move_task_request ->
+    ( start_message_move_task_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `RequestThrottled of request_throttled
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Starts an asynchronous task to move messages from a specified source queue to a specified \
@@ -1284,6 +1584,18 @@ module TagQueue : sig
     'http_type Smaws_Lib.Context.t ->
     tag_queue_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_queue_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -1339,6 +1651,18 @@ module UntagQueue : sig
     'http_type Smaws_Lib.Context.t ->
     untag_queue_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_queue_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security

--- a/sdks/sqs/operations.ml
+++ b/sdks/sqs/operations.ml
@@ -34,6 +34,12 @@ module AddPermission = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.AddPermission" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_permission_request) =
+    let input = Json_serializers.add_permission_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.AddPermission" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module CancelMessageMoveTask = struct
@@ -67,6 +73,13 @@ module CancelMessageMoveTask = struct
     let input = Json_serializers.cancel_message_move_task_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.CancelMessageMoveTask" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_message_move_task_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : cancel_message_move_task_request) =
+    let input = Json_serializers.cancel_message_move_task_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.CancelMessageMoveTask"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_message_move_task_result_of_yojson
       ~error_deserializer
 end
@@ -107,6 +120,13 @@ module ChangeMessageVisibility = struct
     let input = Json_serializers.change_message_visibility_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.ChangeMessageVisibility" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : change_message_visibility_request) =
+    let input = Json_serializers.change_message_visibility_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSQS.ChangeMessageVisibility" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -156,6 +176,13 @@ module ChangeMessageVisibilityBatch = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.change_message_visibility_batch_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : change_message_visibility_batch_request) =
+    let input = Json_serializers.change_message_visibility_batch_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSQS.ChangeMessageVisibilityBatch" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.change_message_visibility_batch_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateQueue = struct
@@ -197,6 +224,12 @@ module CreateQueue = struct
     let input = Json_serializers.create_queue_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.CreateQueue" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_queue_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : create_queue_request) =
+    let input = Json_serializers.create_queue_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.CreateQueue" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.create_queue_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteMessage = struct
@@ -235,6 +268,12 @@ module DeleteMessage = struct
     let input = Json_serializers.delete_message_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.DeleteMessage" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_message_request) =
+    let input = Json_serializers.delete_message_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.DeleteMessage" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -283,6 +322,13 @@ module DeleteMessageBatch = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.DeleteMessageBatch" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_message_batch_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_message_batch_request) =
+    let input = Json_serializers.delete_message_batch_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.DeleteMessageBatch"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_message_batch_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteQueue = struct
@@ -315,6 +361,12 @@ module DeleteQueue = struct
     let input = Json_serializers.delete_queue_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.DeleteQueue" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_queue_request) =
+    let input = Json_serializers.delete_queue_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.DeleteQueue" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -352,6 +404,13 @@ module GetQueueAttributes = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.GetQueueAttributes" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_queue_attributes_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_queue_attributes_request) =
+    let input = Json_serializers.get_queue_attributes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.GetQueueAttributes"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_queue_attributes_result_of_yojson
+      ~error_deserializer
 end
 
 module GetQueueUrl = struct
@@ -384,6 +443,12 @@ module GetQueueUrl = struct
     let input = Json_serializers.get_queue_url_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.GetQueueUrl" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_queue_url_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_queue_url_request) =
+    let input = Json_serializers.get_queue_url_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.GetQueueUrl" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.get_queue_url_result_of_yojson
+      ~error_deserializer
 end
 
 module ListDeadLetterSourceQueues = struct
@@ -416,6 +481,13 @@ module ListDeadLetterSourceQueues = struct
     let input = Json_serializers.list_dead_letter_source_queues_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.ListDeadLetterSourceQueues" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_dead_letter_source_queues_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_dead_letter_source_queues_request) =
+    let input = Json_serializers.list_dead_letter_source_queues_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSQS.ListDeadLetterSourceQueues" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_dead_letter_source_queues_result_of_yojson
       ~error_deserializer
 end
@@ -453,6 +525,13 @@ module ListMessageMoveTasks = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_message_move_tasks_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_message_move_tasks_request) =
+    let input = Json_serializers.list_message_move_tasks_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.ListMessageMoveTasks"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_message_move_tasks_result_of_yojson
+      ~error_deserializer
 end
 
 module ListQueueTags = struct
@@ -486,6 +565,12 @@ module ListQueueTags = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.ListQueueTags" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_queue_tags_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_queue_tags_request) =
+    let input = Json_serializers.list_queue_tags_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.ListQueueTags" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_queue_tags_result_of_yojson
+      ~error_deserializer
 end
 
 module ListQueues = struct
@@ -515,6 +600,12 @@ module ListQueues = struct
     let input = Json_serializers.list_queues_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.ListQueues" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_queues_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_queues_request) =
+    let input = Json_serializers.list_queues_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.ListQueues" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_queues_result_of_yojson
+      ~error_deserializer
 end
 
 module PurgeQueue = struct
@@ -550,6 +641,12 @@ module PurgeQueue = struct
     let input = Json_serializers.purge_queue_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.PurgeQueue" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : purge_queue_request) =
+    let input = Json_serializers.purge_queue_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.PurgeQueue" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -604,6 +701,12 @@ module ReceiveMessage = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.ReceiveMessage" ~service ~context
       ~input ~output_deserializer:Json_deserializers.receive_message_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : receive_message_request) =
+    let input = Json_serializers.receive_message_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.ReceiveMessage"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.receive_message_result_of_yojson ~error_deserializer
 end
 
 module RemovePermission = struct
@@ -636,6 +739,13 @@ module RemovePermission = struct
     let input = Json_serializers.remove_permission_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.RemovePermission" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : remove_permission_request) =
+    let input = Json_serializers.remove_permission_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.RemovePermission"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -690,6 +800,12 @@ module SendMessage = struct
     let input = Json_serializers.send_message_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.SendMessage" ~service ~context ~input
       ~output_deserializer:Json_deserializers.send_message_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : send_message_request) =
+    let input = Json_serializers.send_message_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.SendMessage" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.send_message_result_of_yojson
+      ~error_deserializer
 end
 
 module SendMessageBatch = struct
@@ -758,6 +874,13 @@ module SendMessageBatch = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.SendMessageBatch" ~service ~context
       ~input ~output_deserializer:Json_deserializers.send_message_batch_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : send_message_batch_request) =
+    let input = Json_serializers.send_message_batch_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.SendMessageBatch"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.send_message_batch_result_of_yojson
+      ~error_deserializer
 end
 
 module SetQueueAttributes = struct
@@ -799,6 +922,13 @@ module SetQueueAttributes = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.SetQueueAttributes" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : set_queue_attributes_request) =
+    let input = Json_serializers.set_queue_attributes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.SetQueueAttributes"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module StartMessageMoveTask = struct
@@ -834,6 +964,13 @@ module StartMessageMoveTask = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.start_message_move_task_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_message_move_task_request) =
+    let input = Json_serializers.start_message_move_task_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.StartMessageMoveTask"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_message_move_task_result_of_yojson
+      ~error_deserializer
 end
 
 module TagQueue = struct
@@ -867,6 +1004,12 @@ module TagQueue = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.TagQueue" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_queue_request) =
+    let input = Json_serializers.tag_queue_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.TagQueue" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UntagQueue = struct
@@ -899,5 +1042,11 @@ module UntagQueue = struct
     let input = Json_serializers.untag_queue_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSQS.UntagQueue" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : untag_queue_request) =
+    let input = Json_serializers.untag_queue_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSQS.UntagQueue" ~service
+      ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end

--- a/sdks/sqs/operations.mli
+++ b/sdks/sqs/operations.mli
@@ -23,6 +23,19 @@ module AddPermission : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_permission_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `OverLimit of over_limit
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Adds a permission to a queue for a specific \
@@ -83,6 +96,18 @@ module CancelMessageMoveTask : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_message_move_task_request ->
+    ( cancel_message_move_task_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `RequestThrottled of request_throttled
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Cancels a specified message movement task. A message movement can only be cancelled when the \
@@ -118,6 +143,20 @@ module ChangeMessageVisibility : sig
     'http_type Smaws_Lib.Context.t ->
     change_message_visibility_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `MessageNotInflight of message_not_inflight
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `ReceiptHandleIsInvalid of receipt_handle_is_invalid
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    change_message_visibility_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -217,6 +256,22 @@ module ChangeMessageVisibilityBatch : sig
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    change_message_visibility_batch_request ->
+    ( change_message_visibility_batch_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BatchEntryIdsNotDistinct of batch_entry_ids_not_distinct
+      | `EmptyBatchRequest of empty_batch_request
+      | `InvalidAddress of invalid_address
+      | `InvalidBatchEntryId of invalid_batch_entry_id
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Changes the visibility timeout of multiple messages. This is a batch version of \n\
@@ -251,6 +306,21 @@ module CreateQueue : sig
     'http_type Smaws_Lib.Context.t ->
     create_queue_request ->
     ( create_queue_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidAttributeName of invalid_attribute_name
+      | `InvalidAttributeValue of invalid_attribute_value
+      | `InvalidSecurity of invalid_security
+      | `QueueDeletedRecently of queue_deleted_recently
+      | `QueueNameExists of queue_name_exists
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_queue_request ->
+    ( create_queue_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidAttributeName of invalid_attribute_name
@@ -344,6 +414,20 @@ module DeleteMessage : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_message_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidIdFormat of invalid_id_format
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `ReceiptHandleIsInvalid of receipt_handle_is_invalid
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified message from the specified queue. To select the message to delete, use \
@@ -395,6 +479,22 @@ module DeleteMessageBatch : sig
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_message_batch_request ->
+    ( delete_message_batch_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BatchEntryIdsNotDistinct of batch_entry_ids_not_distinct
+      | `EmptyBatchRequest of empty_batch_request
+      | `InvalidAddress of invalid_address
+      | `InvalidBatchEntryId of invalid_batch_entry_id
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Deletes up to ten messages from the specified queue. This is a batch version of \n\
@@ -421,6 +521,18 @@ module DeleteQueue : sig
     'http_type Smaws_Lib.Context.t ->
     delete_queue_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_queue_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -476,6 +588,19 @@ module GetQueueAttributes : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_queue_attributes_request ->
+    ( get_queue_attributes_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidAttributeName of invalid_attribute_name
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Gets attributes for the specified queue.\n\n\
@@ -499,6 +624,18 @@ module GetQueueUrl : sig
     'http_type Smaws_Lib.Context.t ->
     get_queue_url_request ->
     ( get_queue_url_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_queue_url_request ->
+    ( get_queue_url_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -543,6 +680,18 @@ module ListDeadLetterSourceQueues : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_dead_letter_source_queues_request ->
+    ( list_dead_letter_source_queues_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of your queues that have the [RedrivePolicy] queue attribute configured with a \
@@ -573,6 +722,18 @@ module ListMessageMoveTasks : sig
     'http_type Smaws_Lib.Context.t ->
     list_message_move_tasks_request ->
     ( list_message_move_tasks_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `RequestThrottled of request_throttled
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_message_move_tasks_request ->
+    ( list_message_move_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -618,6 +779,18 @@ module ListQueueTags : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_queue_tags_request ->
+    ( list_queue_tags_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "List all cost allocation tags added to the specified Amazon SQS queue. For an overview, see \
@@ -642,6 +815,17 @@ module ListQueues : sig
     'http_type Smaws_Lib.Context.t ->
     list_queues_request ->
     ( list_queues_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_queues_request ->
+    ( list_queues_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -689,6 +873,19 @@ module PurgeQueue : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    purge_queue_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `PurgeQueueInProgress of purge_queue_in_progress
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Deletes available messages in a queue (including in-flight messages) specified by the \
@@ -727,6 +924,26 @@ module ReceiveMessage : sig
     'http_type Smaws_Lib.Context.t ->
     receive_message_request ->
     ( receive_message_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `KmsAccessDenied of kms_access_denied
+      | `KmsDisabled of kms_disabled
+      | `KmsInvalidKeyUsage of kms_invalid_key_usage
+      | `KmsInvalidState of kms_invalid_state
+      | `KmsNotFound of kms_not_found
+      | `KmsOptInRequired of kms_opt_in_required
+      | `KmsThrottled of kms_throttled
+      | `OverLimit of over_limit
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    receive_message_request ->
+    ( receive_message_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -814,6 +1031,18 @@ module RemovePermission : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_permission_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Revokes any permissions in the queue policy that matches the specified [Label] parameter.\n\n\
@@ -870,6 +1099,26 @@ module SendMessage : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_message_request ->
+    ( send_message_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidMessageContents of invalid_message_contents
+      | `InvalidSecurity of invalid_security
+      | `KmsAccessDenied of kms_access_denied
+      | `KmsDisabled of kms_disabled
+      | `KmsInvalidKeyUsage of kms_invalid_key_usage
+      | `KmsInvalidState of kms_invalid_state
+      | `KmsNotFound of kms_not_found
+      | `KmsOptInRequired of kms_opt_in_required
+      | `KmsThrottled of kms_throttled
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Delivers a message to the specified queue.\n\n\
@@ -911,6 +1160,30 @@ module SendMessageBatch : sig
     'http_type Smaws_Lib.Context.t ->
     send_message_batch_request ->
     ( send_message_batch_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BatchEntryIdsNotDistinct of batch_entry_ids_not_distinct
+      | `BatchRequestTooLong of batch_request_too_long
+      | `EmptyBatchRequest of empty_batch_request
+      | `InvalidAddress of invalid_address
+      | `InvalidBatchEntryId of invalid_batch_entry_id
+      | `InvalidSecurity of invalid_security
+      | `KmsAccessDenied of kms_access_denied
+      | `KmsDisabled of kms_disabled
+      | `KmsInvalidKeyUsage of kms_invalid_key_usage
+      | `KmsInvalidState of kms_invalid_state
+      | `KmsNotFound of kms_not_found
+      | `KmsOptInRequired of kms_opt_in_required
+      | `KmsThrottled of kms_throttled
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_message_batch_request ->
+    ( send_message_batch_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BatchEntryIdsNotDistinct of batch_entry_ids_not_distinct
       | `BatchRequestTooLong of batch_request_too_long
@@ -989,6 +1262,21 @@ module SetQueueAttributes : sig
       | `RequestThrottled of request_throttled
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    set_queue_attributes_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidAttributeName of invalid_attribute_name
+      | `InvalidAttributeValue of invalid_attribute_value
+      | `InvalidSecurity of invalid_security
+      | `OverLimit of over_limit
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Sets the value of one or more queue attributes, like a policy. When you change a queue's \
@@ -1036,6 +1324,18 @@ module StartMessageMoveTask : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `UnsupportedOperation of unsupported_operation ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_message_move_task_request ->
+    ( start_message_move_task_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `RequestThrottled of request_throttled
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
 end
 [@@ocaml.doc
   "Starts an asynchronous task to move messages from a specified source queue to a specified \
@@ -1073,6 +1373,18 @@ module TagQueue : sig
     'http_type Smaws_Lib.Context.t ->
     tag_queue_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_queue_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
@@ -1127,6 +1439,18 @@ module UntagQueue : sig
     'http_type Smaws_Lib.Context.t ->
     untag_queue_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidAddress of invalid_address
+      | `InvalidSecurity of invalid_security
+      | `QueueDoesNotExist of queue_does_not_exist
+      | `RequestThrottled of request_throttled
+      | `UnsupportedOperation of unsupported_operation ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_queue_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security

--- a/sdks/sqs/operations.mli
+++ b/sdks/sqs/operations.mli
@@ -34,7 +34,8 @@ module AddPermission : sig
       | `OverLimit of over_limit
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -106,7 +107,8 @@ module CancelMessageMoveTask : sig
       | `InvalidSecurity of invalid_security
       | `RequestThrottled of request_throttled
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -164,7 +166,8 @@ module ChangeMessageVisibility : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `ReceiptHandleIsInvalid of receipt_handle_is_invalid
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -270,7 +273,8 @@ module ChangeMessageVisibilityBatch : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -329,7 +333,8 @@ module CreateQueue : sig
       | `QueueDeletedRecently of queue_deleted_recently
       | `QueueNameExists of queue_name_exists
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -426,7 +431,8 @@ module DeleteMessage : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `ReceiptHandleIsInvalid of receipt_handle_is_invalid
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -493,7 +499,8 @@ module DeleteMessageBatch : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -538,7 +545,8 @@ module DeleteQueue : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -599,7 +607,8 @@ module GetQueueAttributes : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -641,7 +650,8 @@ module GetQueueUrl : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -690,7 +700,8 @@ module ListDeadLetterSourceQueues : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -739,7 +750,8 @@ module ListMessageMoveTasks : sig
       | `InvalidSecurity of invalid_security
       | `RequestThrottled of request_throttled
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -789,7 +801,8 @@ module ListQueueTags : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -830,7 +843,8 @@ module ListQueues : sig
       | `InvalidAddress of invalid_address
       | `InvalidSecurity of invalid_security
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -884,7 +898,8 @@ module PurgeQueue : sig
       | `PurgeQueueInProgress of purge_queue_in_progress
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -957,7 +972,8 @@ module ReceiveMessage : sig
       | `OverLimit of over_limit
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1041,7 +1057,8 @@ module RemovePermission : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1117,7 +1134,8 @@ module SendMessage : sig
       | `KmsThrottled of kms_throttled
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1201,7 +1219,8 @@ module SendMessageBatch : sig
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
       | `TooManyEntriesInBatchRequest of too_many_entries_in_batch_request
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1275,7 +1294,8 @@ module SetQueueAttributes : sig
       | `OverLimit of over_limit
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1334,7 +1354,8 @@ module StartMessageMoveTask : sig
       | `InvalidSecurity of invalid_security
       | `RequestThrottled of request_throttled
       | `ResourceNotFoundException of resource_not_found_exception
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1390,7 +1411,8 @@ module TagQueue : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1456,7 +1478,8 @@ module UntagQueue : sig
       | `InvalidSecurity of invalid_security
       | `QueueDoesNotExist of queue_does_not_exist
       | `RequestThrottled of request_throttled
-      | `UnsupportedOperation of unsupported_operation ] )
+      | `UnsupportedOperation of unsupported_operation ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/ssm/Smaws_Client_SSM.mli
+++ b/sdks/ssm/Smaws_Client_SSM.mli
@@ -2872,7 +2872,8 @@ module AddTagsToResource : sig
       | `InvalidResourceId of invalid_resource_id
       | `InvalidResourceType of invalid_resource_type
       | `TooManyTagsError of too_many_tags_error
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2951,7 +2952,8 @@ module AssociateOpsItemRelatedItem : sig
       | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
       | `OpsItemNotFoundException of ops_item_not_found_exception
       | `OpsItemRelatedItemAlreadyExistsException of ops_item_related_item_already_exists_exception
-      ] )
+      ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2987,7 +2989,8 @@ module CancelCommand : sig
       | `DuplicateInstanceId of duplicate_instance_id
       | `InternalServerError of internal_server_error
       | `InvalidCommandId of invalid_command_id
-      | `InvalidInstanceId of invalid_instance_id ] )
+      | `InvalidInstanceId of invalid_instance_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3016,7 +3019,8 @@ module CancelMaintenanceWindowExecution : sig
     ( cancel_maintenance_window_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3046,7 +3050,8 @@ module CreateActivation : sig
     ( create_activation_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidParameters of invalid_parameters ] )
+      | `InvalidParameters of invalid_parameters ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3119,7 +3124,8 @@ module CreateAssociation : sig
       | `InvalidTag of invalid_tag
       | `InvalidTarget of invalid_target
       | `InvalidTargetMaps of invalid_target_maps
-      | `UnsupportedPlatformType of unsupported_platform_type ] )
+      | `UnsupportedPlatformType of unsupported_platform_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3187,7 +3193,8 @@ module CreateAssociationBatch : sig
       | `InvalidSchedule of invalid_schedule
       | `InvalidTarget of invalid_target
       | `InvalidTargetMaps of invalid_target_maps
-      | `UnsupportedPlatformType of unsupported_platform_type ] )
+      | `UnsupportedPlatformType of unsupported_platform_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3241,7 +3248,8 @@ module CreateDocument : sig
       | `InvalidDocumentSchemaVersion of invalid_document_schema_version
       | `MaxDocumentSizeExceeded of max_document_size_exceeded
       | `NoLongerSupportedException of no_longer_supported_exception
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3276,7 +3284,8 @@ module CreateMaintenanceWindow : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3320,7 +3329,8 @@ module CreateOpsItem : sig
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
       | `OpsItemAlreadyExistsException of ops_item_already_exists_exception
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
-      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception ] )
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3366,7 +3376,8 @@ module CreateOpsMetadata : sig
       | `OpsMetadataAlreadyExistsException of ops_metadata_already_exists_exception
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
       | `OpsMetadataLimitExceededException of ops_metadata_limit_exceeded_exception
-      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
+      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3399,7 +3410,8 @@ module CreatePatchBaseline : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3440,7 +3452,8 @@ module CreateResourceDataSync : sig
       | `ResourceDataSyncAlreadyExistsException of resource_data_sync_already_exists_exception
       | `ResourceDataSyncCountExceededException of resource_data_sync_count_exceeded_exception
       | `ResourceDataSyncInvalidConfigurationException of
-        resource_data_sync_invalid_configuration_exception ] )
+        resource_data_sync_invalid_configuration_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3500,7 +3513,8 @@ module DeleteActivation : sig
       | `InternalServerError of internal_server_error
       | `InvalidActivation of invalid_activation
       | `InvalidActivationId of invalid_activation_id
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3539,7 +3553,8 @@ module DeleteAssociation : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidInstanceId of invalid_instance_id
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3583,7 +3598,8 @@ module DeleteDocument : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidDocumentOperation of invalid_document_operation
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3624,7 +3640,8 @@ module DeleteInventory : sig
       | `InvalidDeleteInventoryParametersException of invalid_delete_inventory_parameters_exception
       | `InvalidInventoryRequestException of invalid_inventory_request_exception
       | `InvalidOptionException of invalid_option_exception
-      | `InvalidTypeNameException of invalid_type_name_exception ] )
+      | `InvalidTypeNameException of invalid_type_name_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3646,7 +3663,8 @@ module DeleteMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     delete_maintenance_window_request ->
     ( delete_maintenance_window_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a maintenance window.\n"]
@@ -3673,7 +3691,8 @@ module DeleteOpsItem : sig
     ( delete_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3731,7 +3750,8 @@ module DeleteOpsMetadata : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
-      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete OpsMetadata related to an application.\n"]
@@ -3758,7 +3778,8 @@ module DeleteParameter : sig
     ( delete_parameter_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ParameterNotFound of parameter_not_found ] )
+      | `ParameterNotFound of parameter_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3780,7 +3801,8 @@ module DeleteParameters : sig
     'http_type Smaws_Lib.Context.t ->
     delete_parameters_request ->
     ( delete_parameters_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3809,7 +3831,8 @@ module DeletePatchBaseline : sig
     ( delete_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a patch baseline.\n"]
@@ -3842,7 +3865,8 @@ module DeleteResourceDataSync : sig
       | `InternalServerError of internal_server_error
       | `ResourceDataSyncInvalidConfigurationException of
         resource_data_sync_invalid_configuration_exception
-      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3884,7 +3908,8 @@ module DeleteResourcePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyConflictException of resource_policy_conflict_exception
       | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception
-      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ] )
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3928,7 +3953,8 @@ module DeregisterManagedInstance : sig
     ( deregister_managed_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidInstanceId of invalid_instance_id ] )
+      | `InvalidInstanceId of invalid_instance_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3964,7 +3990,8 @@ module DeregisterPatchBaselineForPatchGroup : sig
     ( deregister_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidResourceId of invalid_resource_id ] )
+      | `InvalidResourceId of invalid_resource_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a patch group from a patch baseline.\n"]
@@ -3994,7 +4021,8 @@ module DeregisterTargetFromMaintenanceWindow : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
-      | `TargetInUseException of target_in_use_exception ] )
+      | `TargetInUseException of target_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a target from a maintenance window.\n"]
@@ -4021,7 +4049,8 @@ module DeregisterTaskFromMaintenanceWindow : sig
     ( deregister_task_from_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a task from a maintenance window.\n"]
@@ -4051,7 +4080,8 @@ module DescribeActivations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4090,7 +4120,8 @@ module DescribeAssociation : sig
       | `InternalServerError of internal_server_error
       | `InvalidAssociationVersion of invalid_association_version
       | `InvalidDocument of invalid_document
-      | `InvalidInstanceId of invalid_instance_id ] )
+      | `InvalidInstanceId of invalid_instance_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4126,7 +4157,8 @@ module DescribeAssociationExecutionTargets : sig
       | `AssociationDoesNotExist of association_does_not_exist
       | `AssociationExecutionDoesNotExist of association_execution_does_not_exist
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Views information about a specific execution of a specific association.\n"]
@@ -4156,7 +4188,8 @@ module DescribeAssociationExecutions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Views all executions for a specific association ID. \n"]
@@ -4189,7 +4222,8 @@ module DescribeAutomationExecutions : sig
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidFilterValue of invalid_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides details about all active and terminated Automation executions.\n"]
@@ -4225,7 +4259,8 @@ module DescribeAutomationStepExecutions : sig
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidFilterValue of invalid_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4246,7 +4281,8 @@ module DescribeAvailablePatches : sig
     'http_type Smaws_Lib.Context.t ->
     describe_available_patches_request ->
     ( describe_available_patches_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4281,7 +4317,8 @@ module DescribeDocument : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `InvalidDocumentVersion of invalid_document_version ] )
+      | `InvalidDocumentVersion of invalid_document_version ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4318,7 +4355,8 @@ module DescribeDocumentPermission : sig
       | `InvalidDocument of invalid_document
       | `InvalidDocumentOperation of invalid_document_operation
       | `InvalidNextToken of invalid_next_token
-      | `InvalidPermissionType of invalid_permission_type ] )
+      | `InvalidPermissionType of invalid_permission_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4351,7 +4389,8 @@ module DescribeEffectiveInstanceAssociations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "All associations for the managed nodes.\n"]
@@ -4384,7 +4423,8 @@ module DescribeEffectivePatchesForPatchBaseline : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id
-      | `UnsupportedOperatingSystem of unsupported_operating_system ] )
+      | `UnsupportedOperatingSystem of unsupported_operating_system ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4416,7 +4456,8 @@ module DescribeInstanceAssociationsStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The status of the associations for the managed nodes.\n"]
@@ -4452,7 +4493,8 @@ module DescribeInstanceInformation : sig
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidInstanceInformationFilterValue of invalid_instance_information_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4491,7 +4533,8 @@ module DescribeInstancePatchStates : sig
     ( describe_instance_patch_states_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the high-level patch state of one or more managed nodes.\n"]
@@ -4521,7 +4564,8 @@ module DescribeInstancePatchStatesForPatchGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4555,7 +4599,8 @@ module DescribeInstancePatches : sig
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4599,7 +4644,8 @@ module DescribeInstanceProperties : sig
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidInstancePropertyFilterValue of invalid_instance_property_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4631,7 +4677,8 @@ module DescribeInventoryDeletions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDeletionIdException of invalid_deletion_id_exception
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes a specific delete inventory operation.\n"]
@@ -4658,7 +4705,8 @@ module DescribeMaintenanceWindowExecutionTaskInvocations : sig
     ( describe_maintenance_window_execution_task_invocations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4687,7 +4735,8 @@ module DescribeMaintenanceWindowExecutionTasks : sig
     ( describe_maintenance_window_execution_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "For a given maintenance window execution, lists the tasks that were run.\n"]
@@ -4707,7 +4756,8 @@ module DescribeMaintenanceWindowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_window_executions_request ->
     ( describe_maintenance_window_executions_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4737,7 +4787,8 @@ module DescribeMaintenanceWindowSchedule : sig
     ( describe_maintenance_window_schedule_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves information about upcoming executions of a maintenance window.\n"]
@@ -4764,7 +4815,8 @@ module DescribeMaintenanceWindowTargets : sig
     ( describe_maintenance_window_targets_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the targets registered with the maintenance window.\n"]
@@ -4791,7 +4843,8 @@ module DescribeMaintenanceWindowTasks : sig
     ( describe_maintenance_window_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4818,7 +4871,8 @@ module DescribeMaintenanceWindows : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_windows_request ->
     ( describe_maintenance_windows_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the maintenance windows in an Amazon Web Services account.\n"]
@@ -4838,7 +4892,8 @@ module DescribeMaintenanceWindowsForTarget : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_windows_for_target_request ->
     ( describe_maintenance_windows_for_target_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4860,7 +4915,8 @@ module DescribeOpsItems : sig
     'http_type Smaws_Lib.Context.t ->
     describe_ops_items_request ->
     ( describe_ops_items_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4906,7 +4962,8 @@ module DescribeParameters : sig
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidFilterOption of invalid_filter_option
       | `InvalidFilterValue of invalid_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4946,7 +5003,8 @@ module DescribePatchBaselines : sig
     'http_type Smaws_Lib.Context.t ->
     describe_patch_baselines_request ->
     ( describe_patch_baselines_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the patch baselines in your Amazon Web Services account.\n"]
@@ -4973,7 +5031,8 @@ module DescribePatchGroupState : sig
     ( describe_patch_group_state_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4994,7 +5053,8 @@ module DescribePatchGroups : sig
     'http_type Smaws_Lib.Context.t ->
     describe_patch_groups_request ->
     ( describe_patch_groups_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all patch groups that have been registered with patch baselines.\n"]
@@ -5014,7 +5074,8 @@ module DescribePatchProperties : sig
     'http_type Smaws_Lib.Context.t ->
     describe_patch_properties_request ->
     ( describe_patch_properties_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5081,7 +5142,8 @@ module DescribeSessions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5122,7 +5184,8 @@ module DisassociateOpsItemRelatedItem : sig
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
       | `OpsItemNotFoundException of ops_item_not_found_exception
       | `OpsItemRelatedItemAssociationNotFoundException of
-        ops_item_related_item_association_not_found_exception ] )
+        ops_item_related_item_association_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5161,7 +5224,8 @@ module GetAccessToken : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a credentials set to be used with just-in-time node access.\n"]
@@ -5188,7 +5252,8 @@ module GetAutomationExecution : sig
     ( get_automation_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed information about a particular Automation execution.\n"]
@@ -5221,7 +5286,8 @@ module GetCalendarState : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidDocumentType of invalid_document_type
-      | `UnsupportedCalendarException of unsupported_calendar_exception ] )
+      | `UnsupportedCalendarException of unsupported_calendar_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5272,7 +5338,8 @@ module GetCommandInvocation : sig
       | `InvalidCommandId of invalid_command_id
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidPluginName of invalid_plugin_name
-      | `InvocationDoesNotExist of invocation_does_not_exist ] )
+      | `InvocationDoesNotExist of invocation_does_not_exist ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5302,7 +5369,8 @@ module GetConnectionStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_connection_status_request ->
     ( get_connection_status_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5324,7 +5392,8 @@ module GetDefaultPatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     get_default_patch_baseline_request ->
     ( get_default_patch_baseline_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5360,7 +5429,8 @@ module GetDeployablePatchSnapshotForInstance : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `UnsupportedFeatureRequiredException of unsupported_feature_required_exception
-      | `UnsupportedOperatingSystem of unsupported_operating_system ] )
+      | `UnsupportedOperatingSystem of unsupported_operating_system ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5400,7 +5470,8 @@ module GetDocument : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `InvalidDocumentVersion of invalid_document_version ] )
+      | `InvalidDocumentVersion of invalid_document_version ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5428,7 +5499,8 @@ module GetExecutionPreview : sig
     ( get_execution_preview_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5472,7 +5544,8 @@ module GetInventory : sig
       | `InvalidInventoryGroupException of invalid_inventory_group_exception
       | `InvalidNextToken of invalid_next_token
       | `InvalidResultAttributeException of invalid_result_attribute_exception
-      | `InvalidTypeNameException of invalid_type_name_exception ] )
+      | `InvalidTypeNameException of invalid_type_name_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5504,7 +5577,8 @@ module GetInventorySchema : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token
-      | `InvalidTypeNameException of invalid_type_name_exception ] )
+      | `InvalidTypeNameException of invalid_type_name_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5533,7 +5607,8 @@ module GetMaintenanceWindow : sig
     ( get_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a maintenance window.\n"]
@@ -5560,7 +5635,8 @@ module GetMaintenanceWindowExecution : sig
     ( get_maintenance_window_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves details about a specific a maintenance window execution.\n"]
@@ -5587,7 +5663,8 @@ module GetMaintenanceWindowExecutionTask : sig
     ( get_maintenance_window_execution_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5615,7 +5692,8 @@ module GetMaintenanceWindowExecutionTaskInvocation : sig
     ( get_maintenance_window_execution_task_invocation_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves information about a specific task running on a specific target.\n"]
@@ -5642,7 +5720,8 @@ module GetMaintenanceWindowTask : sig
     ( get_maintenance_window_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5681,7 +5760,8 @@ module GetOpsItem : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
-      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+      | `OpsItemNotFoundException of ops_item_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5721,7 +5801,8 @@ module GetOpsMetadata : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
-      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "View operational metadata related to an application in Application Manager.\n"]
@@ -5760,7 +5841,8 @@ module GetOpsSummary : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token
       | `InvalidTypeNameException of invalid_type_name_exception
-      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5797,7 +5879,8 @@ module GetParameter : sig
       | `InternalServerError of internal_server_error
       | `InvalidKeyId of invalid_key_id
       | `ParameterNotFound of parameter_not_found
-      | `ParameterVersionNotFound of parameter_version_not_found ] )
+      | `ParameterVersionNotFound of parameter_version_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5838,7 +5921,8 @@ module GetParameterHistory : sig
       | `InternalServerError of internal_server_error
       | `InvalidKeyId of invalid_key_id
       | `InvalidNextToken of invalid_next_token
-      | `ParameterNotFound of parameter_not_found ] )
+      | `ParameterNotFound of parameter_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5875,7 +5959,8 @@ module GetParameters : sig
     ( get_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidKeyId of invalid_key_id ] )
+      | `InvalidKeyId of invalid_key_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5921,7 +6006,8 @@ module GetParametersByPath : sig
       | `InvalidFilterOption of invalid_filter_option
       | `InvalidFilterValue of invalid_filter_value
       | `InvalidKeyId of invalid_key_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5963,7 +6049,8 @@ module GetPatchBaseline : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
-      | `InvalidResourceId of invalid_resource_id ] )
+      | `InvalidResourceId of invalid_resource_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves information about a patch baseline.\n"]
@@ -5983,7 +6070,8 @@ module GetPatchBaselineForPatchGroup : sig
     'http_type Smaws_Lib.Context.t ->
     get_patch_baseline_for_patch_group_request ->
     ( get_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the patch baseline that should be used for the specified patch group.\n"]
@@ -6015,7 +6103,7 @@ module GetResourcePolicies : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of the [Policy] object.\n"]
@@ -6042,7 +6130,8 @@ module GetServiceSetting : sig
     ( get_service_setting_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ServiceSettingNotFound of service_setting_not_found ] )
+      | `ServiceSettingNotFound of service_setting_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6093,7 +6182,8 @@ module LabelParameterVersion : sig
       | `ParameterNotFound of parameter_not_found
       | `ParameterVersionLabelLimitExceeded of parameter_version_label_limit_exceeded
       | `ParameterVersionNotFound of parameter_version_not_found
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6167,7 +6257,8 @@ module ListAssociationVersions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves all versions of an association for a specific association ID.\n"]
@@ -6194,7 +6285,8 @@ module ListAssociations : sig
     ( list_associations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6234,7 +6326,8 @@ module ListCommandInvocations : sig
       | `InvalidCommandId of invalid_command_id
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6274,7 +6367,8 @@ module ListCommands : sig
       | `InvalidCommandId of invalid_command_id
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the commands requested by users of the Amazon Web Services account.\n"]
@@ -6310,7 +6404,8 @@ module ListComplianceItems : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token
       | `InvalidResourceId of invalid_resource_id
-      | `InvalidResourceType of invalid_resource_type ] )
+      | `InvalidResourceType of invalid_resource_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6343,7 +6438,8 @@ module ListComplianceSummaries : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6379,7 +6475,8 @@ module ListDocumentMetadataHistory : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidDocumentVersion of invalid_document_version
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6416,7 +6513,8 @@ module ListDocumentVersions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List all versions for a document.\n"]
@@ -6446,7 +6544,8 @@ module ListDocuments : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6484,7 +6583,8 @@ module ListInventoryEntries : sig
       | `InvalidFilter of invalid_filter
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidNextToken of invalid_next_token
-      | `InvalidTypeNameException of invalid_type_name_exception ] )
+      | `InvalidTypeNameException of invalid_type_name_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "A list of inventory items returned by the request.\n"]
@@ -6520,7 +6620,8 @@ module ListNodes : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token
       | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Takes in filters and returns a list of managed nodes matching the filter criteria.\n"]
@@ -6559,7 +6660,8 @@ module ListNodesSummary : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token
       | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6594,7 +6696,8 @@ module ListOpsItemEvents : sig
       | `InternalServerError of internal_server_error
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
       | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
-      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+      | `OpsItemNotFoundException of ops_item_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6624,7 +6727,8 @@ module ListOpsItemRelatedItems : sig
     ( list_ops_item_related_items_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6653,7 +6757,8 @@ module ListOpsMetadata : sig
     ( list_ops_metadata_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception ] )
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6685,7 +6790,8 @@ module ListResourceComplianceSummaries : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6721,7 +6827,8 @@ module ListResourceDataSync : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token
       | `ResourceDataSyncInvalidConfigurationException of
-        resource_data_sync_invalid_configuration_exception ] )
+        resource_data_sync_invalid_configuration_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6760,7 +6867,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id
-      | `InvalidResourceType of invalid_resource_type ] )
+      | `InvalidResourceType of invalid_resource_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6799,7 +6907,8 @@ module ModifyDocumentPermission : sig
       | `DocumentPermissionLimit of document_permission_limit
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `InvalidPermissionType of invalid_permission_type ] )
+      | `InvalidPermissionType of invalid_permission_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6845,7 +6954,8 @@ module PutComplianceItems : sig
       | `InvalidResourceId of invalid_resource_id
       | `InvalidResourceType of invalid_resource_type
       | `ItemSizeLimitExceededException of item_size_limit_exceeded_exception
-      | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception ] )
+      | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -6970,7 +7080,8 @@ module PutInventory : sig
       | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception
       | `UnsupportedInventoryItemContextException of unsupported_inventory_item_context_exception
       | `UnsupportedInventorySchemaVersionException of
-        unsupported_inventory_schema_version_exception ] )
+        unsupported_inventory_schema_version_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7038,7 +7149,8 @@ module PutParameter : sig
       | `ParameterPatternMismatchException of parameter_pattern_mismatch_exception
       | `PoliciesLimitExceededException of policies_limit_exceeded_exception
       | `TooManyUpdates of too_many_updates
-      | `UnsupportedParameterType of unsupported_parameter_type ] )
+      | `UnsupportedParameterType of unsupported_parameter_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Create or update a parameter in Parameter Store.\n"]
@@ -7080,7 +7192,8 @@ module PutResourcePolicy : sig
       | `ResourcePolicyConflictException of resource_policy_conflict_exception
       | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception
       | `ResourcePolicyLimitExceededException of resource_policy_limit_exceeded_exception
-      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ] )
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7152,7 +7265,8 @@ module RegisterDefaultPatchBaseline : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
-      | `InvalidResourceId of invalid_resource_id ] )
+      | `InvalidResourceId of invalid_resource_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7194,7 +7308,8 @@ module RegisterPatchBaselineForPatchGroup : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Registers a patch baseline for a patch group.\n"]
@@ -7227,7 +7342,8 @@ module RegisterTargetWithMaintenanceWindow : sig
       | `DoesNotExistException of does_not_exist_exception
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Registers a target with a maintenance window.\n"]
@@ -7263,7 +7379,8 @@ module RegisterTaskWithMaintenanceWindow : sig
       | `FeatureNotAvailableException of feature_not_available_exception
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds a new task to a maintenance window.\n"]
@@ -7296,7 +7413,8 @@ module RemoveTagsFromResource : sig
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id
       | `InvalidResourceType of invalid_resource_type
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tag keys from the specified resource.\n"]
@@ -7326,7 +7444,8 @@ module ResetServiceSetting : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7368,7 +7487,8 @@ module ResumeSession : sig
     ( resume_session_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7407,7 +7527,8 @@ module SendAutomationSignal : sig
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
       | `AutomationStepNotFoundException of automation_step_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidAutomationSignalException of invalid_automation_signal_exception ] )
+      | `InvalidAutomationSignalException of invalid_automation_signal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7463,7 +7584,8 @@ module SendCommand : sig
       | `InvalidParameters of invalid_parameters
       | `InvalidRole of invalid_role
       | `MaxDocumentSizeExceeded of max_document_size_exceeded
-      | `UnsupportedPlatformType of unsupported_platform_type ] )
+      | `UnsupportedPlatformType of unsupported_platform_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Runs commands on one or more managed nodes.\n"]
@@ -7502,7 +7624,8 @@ module StartAccessRequest : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Starts the workflow for just-in-time node access sessions.\n"]
@@ -7529,7 +7652,8 @@ module StartAssociationsOnce : sig
     ( start_associations_once_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
-      | `InvalidAssociation of invalid_association ] )
+      | `InvalidAssociation of invalid_association ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7579,7 +7703,8 @@ module StartAutomationExecution : sig
       | `InternalServerError of internal_server_error
       | `InvalidAutomationExecutionParametersException of
         invalid_automation_execution_parameters_exception
-      | `InvalidTarget of invalid_target ] )
+      | `InvalidTarget of invalid_target ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Initiates execution of an Automation runbook.\n"]
@@ -7630,7 +7755,8 @@ module StartChangeRequestExecution : sig
       | `InternalServerError of internal_server_error
       | `InvalidAutomationExecutionParametersException of
         invalid_automation_execution_parameters_exception
-      | `NoLongerSupportedException of no_longer_supported_exception ] )
+      | `NoLongerSupportedException of no_longer_supported_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7665,7 +7791,8 @@ module StartExecutionPreview : sig
     ( start_execution_preview_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7697,7 +7824,8 @@ module StartSession : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `TargetNotConnected of target_not_connected ] )
+      | `TargetNotConnected of target_not_connected ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7741,7 +7869,8 @@ module StopAutomationExecution : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidAutomationStatusUpdateException of invalid_automation_status_update_exception ] )
+      | `InvalidAutomationStatusUpdateException of invalid_automation_status_update_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Stop an Automation that is currently running.\n"]
@@ -7761,7 +7890,8 @@ module TerminateSession : sig
     'http_type Smaws_Lib.Context.t ->
     terminate_session_request ->
     ( terminate_session_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7796,7 +7926,8 @@ module UnlabelParameterVersion : sig
       | `InternalServerError of internal_server_error
       | `ParameterNotFound of parameter_not_found
       | `ParameterVersionNotFound of parameter_version_not_found
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7861,7 +7992,8 @@ module UpdateAssociation : sig
       | `InvalidTarget of invalid_target
       | `InvalidTargetMaps of invalid_target_maps
       | `InvalidUpdate of invalid_update
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7922,7 +8054,8 @@ module UpdateAssociationStatus : sig
       | `InvalidDocument of invalid_document
       | `InvalidInstanceId of invalid_instance_id
       | `StatusUnchanged of status_unchanged
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -7979,7 +8112,8 @@ module UpdateDocument : sig
       | `InvalidDocumentOperation of invalid_document_operation
       | `InvalidDocumentSchemaVersion of invalid_document_schema_version
       | `InvalidDocumentVersion of invalid_document_version
-      | `MaxDocumentSizeExceeded of max_document_size_exceeded ] )
+      | `MaxDocumentSizeExceeded of max_document_size_exceeded ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates one or more values for an SSM document.\n"]
@@ -8012,7 +8146,8 @@ module UpdateDocumentDefaultVersion : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidDocumentSchemaVersion of invalid_document_schema_version
-      | `InvalidDocumentVersion of invalid_document_version ] )
+      | `InvalidDocumentVersion of invalid_document_version ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8053,7 +8188,8 @@ module UpdateDocumentMetadata : sig
       | `InvalidDocument of invalid_document
       | `InvalidDocumentOperation of invalid_document_operation
       | `InvalidDocumentVersion of invalid_document_version
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8088,7 +8224,8 @@ module UpdateMaintenanceWindow : sig
     ( update_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8123,7 +8260,8 @@ module UpdateMaintenanceWindowTarget : sig
     ( update_maintenance_window_target_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8175,7 +8313,8 @@ module UpdateMaintenanceWindowTask : sig
     ( update_maintenance_window_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8247,7 +8386,8 @@ module UpdateManagedInstanceRole : sig
     ( update_managed_instance_role_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidInstanceId of invalid_instance_id ] )
+      | `InvalidInstanceId of invalid_instance_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8292,7 +8432,8 @@ module UpdateOpsItem : sig
       | `OpsItemConflictException of ops_item_conflict_exception
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
       | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
-      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+      | `OpsItemNotFoundException of ops_item_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8338,7 +8479,8 @@ module UpdateOpsMetadata : sig
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
       | `OpsMetadataKeyLimitExceededException of ops_metadata_key_limit_exceeded_exception
       | `OpsMetadataNotFoundException of ops_metadata_not_found_exception
-      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
+      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8367,7 +8509,8 @@ module UpdatePatchBaseline : sig
     ( update_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8408,7 +8551,8 @@ module UpdateResourceDataSync : sig
       | `ResourceDataSyncConflictException of resource_data_sync_conflict_exception
       | `ResourceDataSyncInvalidConfigurationException of
         resource_data_sync_invalid_configuration_exception
-      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -8449,7 +8593,8 @@ module UpdateServiceSetting : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/ssm/Smaws_Client_SSM.mli
+++ b/sdks/ssm/Smaws_Client_SSM.mli
@@ -2862,6 +2862,18 @@ module AddTagsToResource : sig
       | `TooManyTagsError of too_many_tags_error
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_to_resource_request ->
+    ( add_tags_to_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type
+      | `TooManyTagsError of too_many_tags_error
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Adds or overwrites one or more tags for the specified resource. {i Tags} are metadata that you \
@@ -2927,6 +2939,20 @@ module AssociateOpsItemRelatedItem : sig
       | `OpsItemRelatedItemAlreadyExistsException of ops_item_related_item_already_exists_exception
       ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_ops_item_related_item_request ->
+    ( associate_ops_item_related_item_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemConflictException of ops_item_conflict_exception
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception
+      | `OpsItemRelatedItemAlreadyExistsException of ops_item_related_item_already_exists_exception
+      ] )
+    result
 end
 [@@ocaml.doc
   "Associates a related item to a Systems Manager OpsCenter OpsItem. For example, you can \
@@ -2946,6 +2972,17 @@ module CancelCommand : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_command_request ->
     ( cancel_command_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateInstanceId of duplicate_instance_id
+      | `InternalServerError of internal_server_error
+      | `InvalidCommandId of invalid_command_id
+      | `InvalidInstanceId of invalid_instance_id ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_command_request ->
+    ( cancel_command_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateInstanceId of duplicate_instance_id
       | `InternalServerError of internal_server_error
@@ -2972,6 +3009,15 @@ module CancelMaintenanceWindowExecution : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_maintenance_window_execution_request ->
+    ( cancel_maintenance_window_execution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc
   "Stops a maintenance window execution that is already in progress and cancels any tasks in the \
@@ -2989,6 +3035,15 @@ module CreateActivation : sig
     'http_type Smaws_Lib.Context.t ->
     create_activation_request ->
     ( create_activation_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidParameters of invalid_parameters ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_activation_request ->
+    ( create_activation_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidParameters of invalid_parameters ] )
@@ -3031,6 +3086,26 @@ module CreateAssociation : sig
     'http_type Smaws_Lib.Context.t ->
     create_association_request ->
     ( create_association_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationAlreadyExists of association_already_exists
+      | `AssociationLimitExceeded of association_limit_exceeded
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidOutputLocation of invalid_output_location
+      | `InvalidParameters of invalid_parameters
+      | `InvalidSchedule of invalid_schedule
+      | `InvalidTag of invalid_tag
+      | `InvalidTarget of invalid_target
+      | `InvalidTargetMaps of invalid_target_maps
+      | `UnsupportedPlatformType of unsupported_platform_type ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_association_request ->
+    ( create_association_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationAlreadyExists of association_already_exists
       | `AssociationLimitExceeded of association_limit_exceeded
@@ -3095,6 +3170,25 @@ module CreateAssociationBatch : sig
       | `InvalidTargetMaps of invalid_target_maps
       | `UnsupportedPlatformType of unsupported_platform_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_association_batch_request ->
+    ( create_association_batch_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationLimitExceeded of association_limit_exceeded
+      | `DuplicateInstanceId of duplicate_instance_id
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidOutputLocation of invalid_output_location
+      | `InvalidParameters of invalid_parameters
+      | `InvalidSchedule of invalid_schedule
+      | `InvalidTarget of invalid_target
+      | `InvalidTargetMaps of invalid_target_maps
+      | `UnsupportedPlatformType of unsupported_platform_type ] )
+    result
 end
 [@@ocaml.doc
   "Associates the specified Amazon Web Services Systems Manager document (SSM document) with the \
@@ -3134,6 +3228,21 @@ module CreateDocument : sig
       | `NoLongerSupportedException of no_longer_supported_exception
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_document_request ->
+    ( create_document_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DocumentAlreadyExists of document_already_exists
+      | `DocumentLimitExceeded of document_limit_exceeded
+      | `InternalServerError of internal_server_error
+      | `InvalidDocumentContent of invalid_document_content
+      | `InvalidDocumentSchemaVersion of invalid_document_schema_version
+      | `MaxDocumentSizeExceeded of max_document_size_exceeded
+      | `NoLongerSupportedException of no_longer_supported_exception
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Creates a Amazon Web Services Systems Manager (SSM document). An SSM document defines the \
@@ -3154,6 +3263,16 @@ module CreateMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     create_maintenance_window_request ->
     ( create_maintenance_window_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_maintenance_window_request ->
+    ( create_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
@@ -3184,6 +3303,18 @@ module CreateOpsItem : sig
     'http_type Smaws_Lib.Context.t ->
     create_ops_item_request ->
     ( create_ops_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemAccessDeniedException of ops_item_access_denied_exception
+      | `OpsItemAlreadyExistsException of ops_item_already_exists_exception
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_ops_item_request ->
+    ( create_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
@@ -3225,6 +3356,18 @@ module CreateOpsMetadata : sig
       | `OpsMetadataLimitExceededException of ops_metadata_limit_exceeded_exception
       | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_ops_metadata_request ->
+    ( create_ops_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataAlreadyExistsException of ops_metadata_already_exists_exception
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
+      | `OpsMetadataLimitExceededException of ops_metadata_limit_exceeded_exception
+      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
+    result
 end
 [@@ocaml.doc
   "If you create a new application in Application Manager, Amazon Web Services Systems Manager \
@@ -3243,6 +3386,16 @@ module CreatePatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     create_patch_baseline_request ->
     ( create_patch_baseline_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_patch_baseline_request ->
+    ( create_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
@@ -3270,6 +3423,18 @@ module CreateResourceDataSync : sig
     'http_type Smaws_Lib.Context.t ->
     create_resource_data_sync_request ->
     ( create_resource_data_sync_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceDataSyncAlreadyExistsException of resource_data_sync_already_exists_exception
+      | `ResourceDataSyncCountExceededException of resource_data_sync_count_exceeded_exception
+      | `ResourceDataSyncInvalidConfigurationException of
+        resource_data_sync_invalid_configuration_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_resource_data_sync_request ->
+    ( create_resource_data_sync_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceDataSyncAlreadyExistsException of resource_data_sync_already_exists_exception
@@ -3326,6 +3491,17 @@ module DeleteActivation : sig
       | `InvalidActivationId of invalid_activation_id
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_activation_request ->
+    ( delete_activation_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidActivation of invalid_activation
+      | `InvalidActivationId of invalid_activation_id
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an activation. You aren't required to delete an activation. If you delete an \
@@ -3346,6 +3522,18 @@ module DeleteAssociation : sig
     'http_type Smaws_Lib.Context.t ->
     delete_association_request ->
     ( delete_association_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidInstanceId of invalid_instance_id
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_association_request ->
+    ( delete_association_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `InternalServerError of internal_server_error
@@ -3385,6 +3573,18 @@ module DeleteDocument : sig
       | `InvalidDocumentOperation of invalid_document_operation
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_document_request ->
+    ( delete_document_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociatedInstances of associated_instances
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentOperation of invalid_document_operation
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the Amazon Web Services Systems Manager document (SSM document) and all managed node \
@@ -3414,6 +3614,18 @@ module DeleteInventory : sig
       | `InvalidOptionException of invalid_option_exception
       | `InvalidTypeNameException of invalid_type_name_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_inventory_request ->
+    ( delete_inventory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDeleteInventoryParametersException of invalid_delete_inventory_parameters_exception
+      | `InvalidInventoryRequestException of invalid_inventory_request_exception
+      | `InvalidOptionException of invalid_option_exception
+      | `InvalidTypeNameException of invalid_type_name_exception ] )
+    result
 end
 [@@ocaml.doc
   "Delete a custom inventory type or the data associated with a custom Inventory type. Deleting a \
@@ -3427,6 +3639,13 @@ module DeleteMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     delete_maintenance_window_request ->
     ( delete_maintenance_window_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_maintenance_window_request ->
+    ( delete_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -3443,6 +3662,15 @@ module DeleteOpsItem : sig
     'http_type Smaws_Lib.Context.t ->
     delete_ops_item_request ->
     ( delete_ops_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ops_item_request ->
+    ( delete_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
@@ -3495,6 +3723,16 @@ module DeleteOpsMetadata : sig
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
       | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ops_metadata_request ->
+    ( delete_ops_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Delete OpsMetadata related to an application.\n"]
 
@@ -3513,6 +3751,15 @@ module DeleteParameter : sig
       | `InternalServerError of internal_server_error
       | `ParameterNotFound of parameter_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_parameter_request ->
+    ( delete_parameter_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ParameterNotFound of parameter_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Delete a parameter from the system. After deleting a parameter, wait for at least 30 seconds to \
@@ -3526,6 +3773,13 @@ module DeleteParameters : sig
     'http_type Smaws_Lib.Context.t ->
     delete_parameters_request ->
     ( delete_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_parameters_request ->
+    ( delete_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -3548,6 +3802,15 @@ module DeletePatchBaseline : sig
       | `InternalServerError of internal_server_error
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_patch_baseline_request ->
+    ( delete_patch_baseline_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a patch baseline.\n"]
 
@@ -3564,6 +3827,17 @@ module DeleteResourceDataSync : sig
     'http_type Smaws_Lib.Context.t ->
     delete_resource_data_sync_request ->
     ( delete_resource_data_sync_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceDataSyncInvalidConfigurationException of
+        resource_data_sync_invalid_configuration_exception
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_data_sync_request ->
+    ( delete_resource_data_sync_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceDataSyncInvalidConfigurationException of
@@ -3591,6 +3865,19 @@ module DeleteResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_resource_policy_request ->
     ( delete_resource_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `MalformedResourcePolicyDocumentException of malformed_resource_policy_document_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyConflictException of resource_policy_conflict_exception
+      | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_policy_request ->
+    ( delete_resource_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `MalformedResourcePolicyDocumentException of malformed_resource_policy_document_exception
@@ -3634,6 +3921,15 @@ module DeregisterManagedInstance : sig
       | `InternalServerError of internal_server_error
       | `InvalidInstanceId of invalid_instance_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_managed_instance_request ->
+    ( deregister_managed_instance_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id ] )
+    result
 end
 [@@ocaml.doc
   "Removes the server or virtual machine from the list of registered servers.\n\n\
@@ -3661,6 +3957,15 @@ module DeregisterPatchBaselineForPatchGroup : sig
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_patch_baseline_for_patch_group_request ->
+    ( deregister_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id ] )
+    result
 end
 [@@ocaml.doc "Removes a patch group from a patch baseline.\n"]
 
@@ -3676,6 +3981,16 @@ module DeregisterTargetFromMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     deregister_target_from_maintenance_window_request ->
     ( deregister_target_from_maintenance_window_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `TargetInUseException of target_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_target_from_maintenance_window_request ->
+    ( deregister_target_from_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
@@ -3699,6 +4014,15 @@ module DeregisterTaskFromMaintenanceWindow : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_task_from_maintenance_window_request ->
+    ( deregister_task_from_maintenance_window_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Removes a task from a maintenance window.\n"]
 
@@ -3714,6 +4038,16 @@ module DescribeActivations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_activations_request ->
     ( describe_activations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_activations_request ->
+    ( describe_activations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -3746,6 +4080,18 @@ module DescribeAssociation : sig
       | `InvalidDocument of invalid_document
       | `InvalidInstanceId of invalid_instance_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_association_request ->
+    ( describe_association_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidAssociationVersion of invalid_association_version
+      | `InvalidDocument of invalid_document
+      | `InvalidInstanceId of invalid_instance_id ] )
+    result
 end
 [@@ocaml.doc
   "Describes the association for the specified target or managed node. If you created the \
@@ -3765,6 +4111,17 @@ module DescribeAssociationExecutionTargets : sig
     'http_type Smaws_Lib.Context.t ->
     describe_association_execution_targets_request ->
     ( describe_association_execution_targets_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `AssociationExecutionDoesNotExist of association_execution_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_association_execution_targets_request ->
+    ( describe_association_execution_targets_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `AssociationExecutionDoesNotExist of association_execution_does_not_exist
@@ -3791,6 +4148,16 @@ module DescribeAssociationExecutions : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_association_executions_request ->
+    ( describe_association_executions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Views all executions for a specific association ID. \n"]
 
@@ -3807,6 +4174,17 @@ module DescribeAutomationExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     describe_automation_executions_request ->
     ( describe_automation_executions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidFilterValue of invalid_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_automation_executions_request ->
+    ( describe_automation_executions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -3837,6 +4215,18 @@ module DescribeAutomationStepExecutions : sig
       | `InvalidFilterValue of invalid_filter_value
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_automation_step_executions_request ->
+    ( describe_automation_step_executions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidFilterValue of invalid_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Information about all active and terminated step executions in an Automation workflow.\n"]
@@ -3849,6 +4239,13 @@ module DescribeAvailablePatches : sig
     'http_type Smaws_Lib.Context.t ->
     describe_available_patches_request ->
     ( describe_available_patches_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_available_patches_request ->
+    ( describe_available_patches_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -3871,6 +4268,16 @@ module DescribeDocument : sig
     'http_type Smaws_Lib.Context.t ->
     describe_document_request ->
     ( describe_document_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_document_request ->
+    ( describe_document_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -3901,6 +4308,18 @@ module DescribeDocumentPermission : sig
       | `InvalidNextToken of invalid_next_token
       | `InvalidPermissionType of invalid_permission_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_document_permission_request ->
+    ( describe_document_permission_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentOperation of invalid_document_operation
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidPermissionType of invalid_permission_type ] )
+    result
 end
 [@@ocaml.doc
   "Describes the permissions for a Amazon Web Services Systems Manager document (SSM document). If \
@@ -3924,6 +4343,16 @@ module DescribeEffectiveInstanceAssociations : sig
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_effective_instance_associations_request ->
+    ( describe_effective_instance_associations_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "All associations for the managed nodes.\n"]
 
@@ -3940,6 +4369,17 @@ module DescribeEffectivePatchesForPatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     describe_effective_patches_for_patch_baseline_request ->
     ( describe_effective_patches_for_patch_baseline_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `UnsupportedOperatingSystem of unsupported_operating_system ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_effective_patches_for_patch_baseline_request ->
+    ( describe_effective_patches_for_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
@@ -3968,6 +4408,16 @@ module DescribeInstanceAssociationsStatus : sig
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_associations_status_request ->
+    ( describe_instance_associations_status_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "The status of the associations for the managed nodes.\n"]
 
@@ -3985,6 +4435,18 @@ module DescribeInstanceInformation : sig
     'http_type Smaws_Lib.Context.t ->
     describe_instance_information_request ->
     ( describe_instance_information_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidInstanceInformationFilterValue of invalid_instance_information_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_information_request ->
+    ( describe_instance_information_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -4022,6 +4484,15 @@ module DescribeInstancePatchStates : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_patch_states_request ->
+    ( describe_instance_patch_states_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Retrieves the high-level patch state of one or more managed nodes.\n"]
 
@@ -4037,6 +4508,16 @@ module DescribeInstancePatchStatesForPatchGroup : sig
     'http_type Smaws_Lib.Context.t ->
     describe_instance_patch_states_for_patch_group_request ->
     ( describe_instance_patch_states_for_patch_group_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_patch_states_for_patch_group_request ->
+    ( describe_instance_patch_states_for_patch_group_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -4059,6 +4540,17 @@ module DescribeInstancePatches : sig
     'http_type Smaws_Lib.Context.t ->
     describe_instance_patches_request ->
     ( describe_instance_patches_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_patches_request ->
+    ( describe_instance_patches_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -4095,6 +4587,20 @@ module DescribeInstanceProperties : sig
       | `InvalidInstancePropertyFilterValue of invalid_instance_property_filter_value
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_properties_request ->
+    ( describe_instance_properties_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidActivationId of invalid_activation_id
+      | `InvalidDocument of invalid_document
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidInstancePropertyFilterValue of invalid_instance_property_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "An API operation used by the Systems Manager console to display information about Systems \
@@ -4117,6 +4623,16 @@ module DescribeInventoryDeletions : sig
       | `InvalidDeletionIdException of invalid_deletion_id_exception
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_inventory_deletions_request ->
+    ( describe_inventory_deletions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDeletionIdException of invalid_deletion_id_exception
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Describes a specific delete inventory operation.\n"]
 
@@ -4131,6 +4647,15 @@ module DescribeMaintenanceWindowExecutionTaskInvocations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_window_execution_task_invocations_request ->
     ( describe_maintenance_window_execution_task_invocations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_execution_task_invocations_request ->
+    ( describe_maintenance_window_execution_task_invocations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -4155,6 +4680,15 @@ module DescribeMaintenanceWindowExecutionTasks : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_execution_tasks_request ->
+    ( describe_maintenance_window_execution_tasks_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "For a given maintenance window execution, lists the tasks that were run.\n"]
 
@@ -4166,6 +4700,13 @@ module DescribeMaintenanceWindowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_window_executions_request ->
     ( describe_maintenance_window_executions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_executions_request ->
+    ( describe_maintenance_window_executions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -4189,6 +4730,15 @@ module DescribeMaintenanceWindowSchedule : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_schedule_request ->
+    ( describe_maintenance_window_schedule_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves information about upcoming executions of a maintenance window.\n"]
 
@@ -4207,6 +4757,15 @@ module DescribeMaintenanceWindowTargets : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_targets_request ->
+    ( describe_maintenance_window_targets_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Lists the targets registered with the maintenance window.\n"]
 
@@ -4221,6 +4780,15 @@ module DescribeMaintenanceWindowTasks : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_window_tasks_request ->
     ( describe_maintenance_window_tasks_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_tasks_request ->
+    ( describe_maintenance_window_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -4245,6 +4813,13 @@ module DescribeMaintenanceWindows : sig
     ( describe_maintenance_windows_result,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_windows_request ->
+    ( describe_maintenance_windows_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves the maintenance windows in an Amazon Web Services account.\n"]
 
@@ -4256,6 +4831,13 @@ module DescribeMaintenanceWindowsForTarget : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_windows_for_target_request ->
     ( describe_maintenance_windows_for_target_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_windows_for_target_request ->
+    ( describe_maintenance_windows_for_target_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -4271,6 +4853,13 @@ module DescribeOpsItems : sig
     'http_type Smaws_Lib.Context.t ->
     describe_ops_items_request ->
     ( describe_ops_items_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_ops_items_request ->
+    ( describe_ops_items_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -4300,6 +4889,18 @@ module DescribeParameters : sig
     'http_type Smaws_Lib.Context.t ->
     describe_parameters_request ->
     ( describe_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidFilterOption of invalid_filter_option
+      | `InvalidFilterValue of invalid_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_parameters_request ->
+    ( describe_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -4340,6 +4941,13 @@ module DescribePatchBaselines : sig
     ( describe_patch_baselines_result,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_patch_baselines_request ->
+    ( describe_patch_baselines_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Lists the patch baselines in your Amazon Web Services account.\n"]
 
@@ -4358,6 +4966,15 @@ module DescribePatchGroupState : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_patch_group_state_request ->
+    ( describe_patch_group_state_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Returns high-level aggregated patch compliance state information for a patch group.\n"]
@@ -4372,6 +4989,13 @@ module DescribePatchGroups : sig
     ( describe_patch_groups_result,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_patch_groups_request ->
+    ( describe_patch_groups_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Lists all patch groups that have been registered with patch baselines.\n"]
 
@@ -4383,6 +5007,13 @@ module DescribePatchProperties : sig
     'http_type Smaws_Lib.Context.t ->
     describe_patch_properties_request ->
     ( describe_patch_properties_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_patch_properties_request ->
+    ( describe_patch_properties_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -4442,6 +5073,16 @@ module DescribeSessions : sig
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_sessions_request ->
+    ( describe_sessions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of all active sessions (both connected and disconnected) or terminated \
@@ -4462,6 +5103,19 @@ module DisassociateOpsItemRelatedItem : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_ops_item_related_item_request ->
     ( disassociate_ops_item_related_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemConflictException of ops_item_conflict_exception
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception
+      | `OpsItemRelatedItemAssociationNotFoundException of
+        ops_item_related_item_association_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_ops_item_related_item_request ->
+    ( disassociate_ops_item_related_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemConflictException of ops_item_conflict_exception
@@ -4497,6 +5151,18 @@ module GetAccessToken : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_access_token_request ->
+    ( get_access_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a credentials set to be used with just-in-time node access.\n"]
 
@@ -4511,6 +5177,15 @@ module GetAutomationExecution : sig
     'http_type Smaws_Lib.Context.t ->
     get_automation_execution_request ->
     ( get_automation_execution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_automation_execution_request ->
+    ( get_automation_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
       | `InternalServerError of internal_server_error ] )
@@ -4531,6 +5206,17 @@ module GetCalendarState : sig
     'http_type Smaws_Lib.Context.t ->
     get_calendar_state_request ->
     ( get_calendar_state_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentType of invalid_document_type
+      | `UnsupportedCalendarException of unsupported_calendar_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_calendar_state_request ->
+    ( get_calendar_state_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -4576,6 +5262,18 @@ module GetCommandInvocation : sig
       | `InvalidPluginName of invalid_plugin_name
       | `InvocationDoesNotExist of invocation_does_not_exist ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_command_invocation_request ->
+    ( get_command_invocation_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidCommandId of invalid_command_id
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidPluginName of invalid_plugin_name
+      | `InvocationDoesNotExist of invocation_does_not_exist ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed information about command execution for an invocation or plugin. The Run \
@@ -4599,6 +5297,13 @@ module GetConnectionStatus : sig
     ( get_connection_status_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_connection_status_request ->
+    ( get_connection_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the Session Manager connection status for a managed node to determine whether it is \
@@ -4612,6 +5317,13 @@ module GetDefaultPatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     get_default_patch_baseline_request ->
     ( get_default_patch_baseline_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_default_patch_baseline_request ->
+    ( get_default_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -4635,6 +5347,16 @@ module GetDeployablePatchSnapshotForInstance : sig
     'http_type Smaws_Lib.Context.t ->
     get_deployable_patch_snapshot_for_instance_request ->
     ( get_deployable_patch_snapshot_for_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `UnsupportedFeatureRequiredException of unsupported_feature_required_exception
+      | `UnsupportedOperatingSystem of unsupported_operating_system ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_deployable_patch_snapshot_for_instance_request ->
+    ( get_deployable_patch_snapshot_for_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `UnsupportedFeatureRequiredException of unsupported_feature_required_exception
@@ -4670,6 +5392,16 @@ module GetDocument : sig
       | `InvalidDocument of invalid_document
       | `InvalidDocumentVersion of invalid_document_version ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_document_request ->
+    ( get_document_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version ] )
+    result
 end
 [@@ocaml.doc
   "Gets the contents of the specified Amazon Web Services Systems Manager document (SSM document).\n"]
@@ -4685,6 +5417,15 @@ module GetExecutionPreview : sig
     'http_type Smaws_Lib.Context.t ->
     get_execution_preview_request ->
     ( get_execution_preview_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_execution_preview_request ->
+    ( get_execution_preview_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -4719,6 +5460,20 @@ module GetInventory : sig
       | `InvalidResultAttributeException of invalid_result_attribute_exception
       | `InvalidTypeNameException of invalid_type_name_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_inventory_request ->
+    ( get_inventory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidAggregatorException of invalid_aggregator_exception
+      | `InvalidFilter of invalid_filter
+      | `InvalidInventoryGroupException of invalid_inventory_group_exception
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidResultAttributeException of invalid_result_attribute_exception
+      | `InvalidTypeNameException of invalid_type_name_exception ] )
+    result
 end
 [@@ocaml.doc
   "Query inventory information. This includes managed node status, such as [Stopped] or \
@@ -4736,6 +5491,16 @@ module GetInventorySchema : sig
     'http_type Smaws_Lib.Context.t ->
     get_inventory_schema_request ->
     ( get_inventory_schema_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidTypeNameException of invalid_type_name_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_inventory_schema_request ->
+    ( get_inventory_schema_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token
@@ -4761,6 +5526,15 @@ module GetMaintenanceWindow : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_request ->
+    ( get_maintenance_window_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves a maintenance window.\n"]
 
@@ -4779,6 +5553,15 @@ module GetMaintenanceWindowExecution : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_execution_request ->
+    ( get_maintenance_window_execution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves details about a specific a maintenance window execution.\n"]
 
@@ -4793,6 +5576,15 @@ module GetMaintenanceWindowExecutionTask : sig
     'http_type Smaws_Lib.Context.t ->
     get_maintenance_window_execution_task_request ->
     ( get_maintenance_window_execution_task_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_execution_task_request ->
+    ( get_maintenance_window_execution_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -4816,6 +5608,15 @@ module GetMaintenanceWindowExecutionTaskInvocation : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_execution_task_invocation_request ->
+    ( get_maintenance_window_execution_task_invocation_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves information about a specific task running on a specific target.\n"]
 
@@ -4830,6 +5631,15 @@ module GetMaintenanceWindowTask : sig
     'http_type Smaws_Lib.Context.t ->
     get_maintenance_window_task_request ->
     ( get_maintenance_window_task_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_task_request ->
+    ( get_maintenance_window_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -4858,6 +5668,16 @@ module GetOpsItem : sig
     'http_type Smaws_Lib.Context.t ->
     get_ops_item_request ->
     ( get_ops_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemAccessDeniedException of ops_item_access_denied_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ops_item_request ->
+    ( get_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
@@ -4893,6 +5713,16 @@ module GetOpsMetadata : sig
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
       | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ops_metadata_request ->
+    ( get_ops_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "View operational metadata related to an application in Application Manager.\n"]
 
@@ -4911,6 +5741,19 @@ module GetOpsSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_ops_summary_request ->
     ( get_ops_summary_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidAggregatorException of invalid_aggregator_exception
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidTypeNameException of invalid_type_name_exception
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ops_summary_request ->
+    ( get_ops_summary_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidAggregatorException of invalid_aggregator_exception
@@ -4939,6 +5782,17 @@ module GetParameter : sig
     'http_type Smaws_Lib.Context.t ->
     get_parameter_request ->
     ( get_parameter_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidKeyId of invalid_key_id
+      | `ParameterNotFound of parameter_not_found
+      | `ParameterVersionNotFound of parameter_version_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameter_request ->
+    ( get_parameter_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidKeyId of invalid_key_id
@@ -4975,6 +5829,17 @@ module GetParameterHistory : sig
       | `InvalidNextToken of invalid_next_token
       | `ParameterNotFound of parameter_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameter_history_request ->
+    ( get_parameter_history_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidKeyId of invalid_key_id
+      | `InvalidNextToken of invalid_next_token
+      | `ParameterNotFound of parameter_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the history of all changes to a parameter.\n\n\
@@ -4999,6 +5864,15 @@ module GetParameters : sig
     'http_type Smaws_Lib.Context.t ->
     get_parameters_request ->
     ( get_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidKeyId of invalid_key_id ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameters_request ->
+    ( get_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidKeyId of invalid_key_id ] )
@@ -5028,6 +5902,19 @@ module GetParametersByPath : sig
     'http_type Smaws_Lib.Context.t ->
     get_parameters_by_path_request ->
     ( get_parameters_by_path_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidFilterOption of invalid_filter_option
+      | `InvalidFilterValue of invalid_filter_value
+      | `InvalidKeyId of invalid_key_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameters_by_path_request ->
+    ( get_parameters_by_path_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -5068,6 +5955,16 @@ module GetPatchBaseline : sig
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_patch_baseline_request ->
+    ( get_patch_baseline_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id ] )
+    result
 end
 [@@ocaml.doc "Retrieves information about a patch baseline.\n"]
 
@@ -5079,6 +5976,13 @@ module GetPatchBaselineForPatchGroup : sig
     'http_type Smaws_Lib.Context.t ->
     get_patch_baseline_for_patch_group_request ->
     ( get_patch_baseline_for_patch_group_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_patch_baseline_for_patch_group_request ->
+    ( get_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -5102,6 +6006,17 @@ module GetResourcePolicies : sig
       | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_policies_request ->
+    ( get_resource_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception ]
+    )
+    result
 end
 [@@ocaml.doc "Returns an array of the [Policy] object.\n"]
 
@@ -5116,6 +6031,15 @@ module GetServiceSetting : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_setting_request ->
     ( get_service_setting_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ServiceSettingNotFound of service_setting_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_setting_request ->
+    ( get_service_setting_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found ] )
@@ -5152,6 +6076,18 @@ module LabelParameterVersion : sig
     'http_type Smaws_Lib.Context.t ->
     label_parameter_version_request ->
     ( label_parameter_version_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ParameterNotFound of parameter_not_found
+      | `ParameterVersionLabelLimitExceeded of parameter_version_label_limit_exceeded
+      | `ParameterVersionNotFound of parameter_version_not_found
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    label_parameter_version_request ->
+    ( label_parameter_version_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ParameterNotFound of parameter_not_found
@@ -5223,6 +6159,16 @@ module ListAssociationVersions : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_association_versions_request ->
+    ( list_association_versions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Retrieves all versions of an association for a specific association ID.\n"]
 
@@ -5237,6 +6183,15 @@ module ListAssociations : sig
     'http_type Smaws_Lib.Context.t ->
     list_associations_request ->
     ( list_associations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_associations_request ->
+    ( list_associations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
@@ -5262,6 +6217,18 @@ module ListCommandInvocations : sig
     'http_type Smaws_Lib.Context.t ->
     list_command_invocations_request ->
     ( list_command_invocations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidCommandId of invalid_command_id
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_command_invocations_request ->
+    ( list_command_invocations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidCommandId of invalid_command_id
@@ -5297,6 +6264,18 @@ module ListCommands : sig
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_commands_request ->
+    ( list_commands_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidCommandId of invalid_command_id
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Lists the commands requested by users of the Amazon Web Services account.\n"]
 
@@ -5314,6 +6293,18 @@ module ListComplianceItems : sig
     'http_type Smaws_Lib.Context.t ->
     list_compliance_items_request ->
     ( list_compliance_items_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_compliance_items_request ->
+    ( list_compliance_items_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -5344,6 +6335,16 @@ module ListComplianceSummaries : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_compliance_summaries_request ->
+    ( list_compliance_summaries_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Returns a summary count of compliant and non-compliant resources for a compliance type. For \
@@ -5363,6 +6364,17 @@ module ListDocumentMetadataHistory : sig
     'http_type Smaws_Lib.Context.t ->
     list_document_metadata_history_request ->
     ( list_document_metadata_history_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_document_metadata_history_request ->
+    ( list_document_metadata_history_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -5396,6 +6408,16 @@ module ListDocumentVersions : sig
       | `InvalidDocument of invalid_document
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_document_versions_request ->
+    ( list_document_versions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "List all versions for a document.\n"]
 
@@ -5411,6 +6433,16 @@ module ListDocuments : sig
     'http_type Smaws_Lib.Context.t ->
     list_documents_request ->
     ( list_documents_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_documents_request ->
+    ( list_documents_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -5442,6 +6474,18 @@ module ListInventoryEntries : sig
       | `InvalidNextToken of invalid_next_token
       | `InvalidTypeNameException of invalid_type_name_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_inventory_entries_request ->
+    ( list_inventory_entries_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidTypeNameException of invalid_type_name_exception ] )
+    result
 end
 [@@ocaml.doc "A list of inventory items returned by the request.\n"]
 
@@ -5459,6 +6503,18 @@ module ListNodes : sig
     'http_type Smaws_Lib.Context.t ->
     list_nodes_request ->
     ( list_nodes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_nodes_request ->
+    ( list_nodes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -5492,6 +6548,19 @@ module ListNodesSummary : sig
       | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_nodes_summary_request ->
+    ( list_nodes_summary_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidAggregatorException of invalid_aggregator_exception
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Generates a summary of managed instance/node metadata based on the filters and aggregators you \
@@ -5510,6 +6579,17 @@ module ListOpsItemEvents : sig
     'http_type Smaws_Lib.Context.t ->
     list_ops_item_events_request ->
     ( list_ops_item_events_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ops_item_events_request ->
+    ( list_ops_item_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
@@ -5537,6 +6617,15 @@ module ListOpsItemRelatedItems : sig
       | `InternalServerError of internal_server_error
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ops_item_related_items_request ->
+    ( list_ops_item_related_items_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all related-item resources associated with a Systems Manager OpsCenter OpsItem. OpsCenter \
@@ -5553,6 +6642,15 @@ module ListOpsMetadata : sig
     'http_type Smaws_Lib.Context.t ->
     list_ops_metadata_request ->
     ( list_ops_metadata_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ops_metadata_request ->
+    ( list_ops_metadata_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception ] )
@@ -5579,6 +6677,16 @@ module ListResourceComplianceSummaries : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_compliance_summaries_request ->
+    ( list_resource_compliance_summaries_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Returns a resource-level summary count. The summary includes information about compliant and \
@@ -5598,6 +6706,17 @@ module ListResourceDataSync : sig
     'http_type Smaws_Lib.Context.t ->
     list_resource_data_sync_request ->
     ( list_resource_data_sync_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token
+      | `ResourceDataSyncInvalidConfigurationException of
+        resource_data_sync_invalid_configuration_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_data_sync_request ->
+    ( list_resource_data_sync_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token
@@ -5633,6 +6752,16 @@ module ListTagsForResource : sig
       | `InvalidResourceId of invalid_resource_id
       | `InvalidResourceType of invalid_resource_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of the tags assigned to the specified resource.\n\n\
@@ -5653,6 +6782,18 @@ module ModifyDocumentPermission : sig
     'http_type Smaws_Lib.Context.t ->
     modify_document_permission_request ->
     ( modify_document_permission_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DocumentLimitExceeded of document_limit_exceeded
+      | `DocumentPermissionLimit of document_permission_limit
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidPermissionType of invalid_permission_type ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    modify_document_permission_request ->
+    ( modify_document_permission_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DocumentLimitExceeded of document_limit_exceeded
       | `DocumentPermissionLimit of document_permission_limit
@@ -5683,6 +6824,20 @@ module PutComplianceItems : sig
     'http_type Smaws_Lib.Context.t ->
     put_compliance_items_request ->
     ( put_compliance_items_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ComplianceTypeCountLimitExceededException of compliance_type_count_limit_exceeded_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidItemContentException of invalid_item_content_exception
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type
+      | `ItemSizeLimitExceededException of item_size_limit_exceeded_exception
+      | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_compliance_items_request ->
+    ( put_compliance_items_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ComplianceTypeCountLimitExceededException of compliance_type_count_limit_exceeded_exception
       | `InternalServerError of internal_server_error
@@ -5797,6 +6952,26 @@ module PutInventory : sig
       | `UnsupportedInventorySchemaVersionException of
         unsupported_inventory_schema_version_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_inventory_request ->
+    ( put_inventory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomSchemaCountLimitExceededException of custom_schema_count_limit_exceeded_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidInventoryItemContextException of invalid_inventory_item_context_exception
+      | `InvalidItemContentException of invalid_item_content_exception
+      | `InvalidTypeNameException of invalid_type_name_exception
+      | `ItemContentMismatchException of item_content_mismatch_exception
+      | `ItemSizeLimitExceededException of item_size_limit_exceeded_exception
+      | `SubTypeCountLimitExceededException of sub_type_count_limit_exceeded_exception
+      | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception
+      | `UnsupportedInventoryItemContextException of unsupported_inventory_item_context_exception
+      | `UnsupportedInventorySchemaVersionException of
+        unsupported_inventory_schema_version_exception ] )
+    result
 end
 [@@ocaml.doc
   "Bulk update custom inventory items on one or more managed nodes. The request adds an inventory \
@@ -5843,6 +7018,28 @@ module PutParameter : sig
       | `TooManyUpdates of too_many_updates
       | `UnsupportedParameterType of unsupported_parameter_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_parameter_request ->
+    ( put_parameter_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `HierarchyLevelLimitExceededException of hierarchy_level_limit_exceeded_exception
+      | `HierarchyTypeMismatchException of hierarchy_type_mismatch_exception
+      | `IncompatiblePolicyException of incompatible_policy_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidAllowedPatternException of invalid_allowed_pattern_exception
+      | `InvalidKeyId of invalid_key_id
+      | `InvalidPolicyAttributeException of invalid_policy_attribute_exception
+      | `InvalidPolicyTypeException of invalid_policy_type_exception
+      | `ParameterAlreadyExists of parameter_already_exists
+      | `ParameterLimitExceeded of parameter_limit_exceeded
+      | `ParameterMaxVersionLimitExceeded of parameter_max_version_limit_exceeded
+      | `ParameterPatternMismatchException of parameter_pattern_mismatch_exception
+      | `PoliciesLimitExceededException of policies_limit_exceeded_exception
+      | `TooManyUpdates of too_many_updates
+      | `UnsupportedParameterType of unsupported_parameter_type ] )
+    result
 end
 [@@ocaml.doc "Create or update a parameter in Parameter Store.\n"]
 
@@ -5862,6 +7059,20 @@ module PutResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     put_resource_policy_request ->
     ( put_resource_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `MalformedResourcePolicyDocumentException of malformed_resource_policy_document_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyConflictException of resource_policy_conflict_exception
+      | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception
+      | `ResourcePolicyLimitExceededException of resource_policy_limit_exceeded_exception
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_policy_request ->
+    ( put_resource_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `MalformedResourcePolicyDocumentException of malformed_resource_policy_document_exception
@@ -5933,6 +7144,16 @@ module RegisterDefaultPatchBaseline : sig
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_default_patch_baseline_request ->
+    ( register_default_patch_baseline_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id ] )
+    result
 end
 [@@ocaml.doc
   "Defines the default patch baseline for the relevant operating system.\n\n\
@@ -5963,6 +7184,18 @@ module RegisterPatchBaselineForPatchGroup : sig
       | `InvalidResourceId of invalid_resource_id
       | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_patch_baseline_for_patch_group_request ->
+    ( register_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AlreadyExistsException of already_exists_exception
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc "Registers a patch baseline for a patch group.\n"]
 
@@ -5979,6 +7212,17 @@ module RegisterTargetWithMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     register_target_with_maintenance_window_request ->
     ( register_target_with_maintenance_window_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_target_with_maintenance_window_request ->
+    ( register_target_with_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
@@ -6009,6 +7253,18 @@ module RegisterTaskWithMaintenanceWindow : sig
       | `InternalServerError of internal_server_error
       | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_task_with_maintenance_window_request ->
+    ( register_task_with_maintenance_window_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `FeatureNotAvailableException of feature_not_available_exception
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc "Adds a new task to a maintenance window.\n"]
 
@@ -6031,6 +7287,17 @@ module RemoveTagsFromResource : sig
       | `InvalidResourceType of invalid_resource_type
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_from_resource_request ->
+    ( remove_tags_from_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc "Removes tag keys from the specified resource.\n"]
 
@@ -6046,6 +7313,16 @@ module ResetServiceSetting : sig
     'http_type Smaws_Lib.Context.t ->
     reset_service_setting_request ->
     ( reset_service_setting_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ServiceSettingNotFound of service_setting_not_found
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reset_service_setting_request ->
+    ( reset_service_setting_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found
@@ -6084,6 +7361,15 @@ module ResumeSession : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    resume_session_request ->
+    ( resume_session_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc
   "Reconnects a session to a managed node after it has been disconnected. Connections can be \
@@ -6106,6 +7392,17 @@ module SendAutomationSignal : sig
     'http_type Smaws_Lib.Context.t ->
     send_automation_signal_request ->
     ( send_automation_signal_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
+      | `AutomationStepNotFoundException of automation_step_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidAutomationSignalException of invalid_automation_signal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_automation_signal_request ->
+    ( send_automation_signal_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
       | `AutomationStepNotFoundException of automation_step_not_found_exception
@@ -6150,6 +7447,24 @@ module SendCommand : sig
       | `MaxDocumentSizeExceeded of max_document_size_exceeded
       | `UnsupportedPlatformType of unsupported_platform_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_command_request ->
+    ( send_command_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateInstanceId of duplicate_instance_id
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNotificationConfig of invalid_notification_config
+      | `InvalidOutputFolder of invalid_output_folder
+      | `InvalidParameters of invalid_parameters
+      | `InvalidRole of invalid_role
+      | `MaxDocumentSizeExceeded of max_document_size_exceeded
+      | `UnsupportedPlatformType of unsupported_platform_type ] )
+    result
 end
 [@@ocaml.doc "Runs commands on one or more managed nodes.\n"]
 
@@ -6176,6 +7491,19 @@ module StartAccessRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_access_request_request ->
+    ( start_access_request_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Starts the workflow for just-in-time node access sessions.\n"]
 
@@ -6190,6 +7518,15 @@ module StartAssociationsOnce : sig
     'http_type Smaws_Lib.Context.t ->
     start_associations_once_request ->
     ( start_associations_once_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InvalidAssociation of invalid_association ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_associations_once_request ->
+    ( start_associations_once_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `InvalidAssociation of invalid_association ] )
@@ -6217,6 +7554,22 @@ module StartAutomationExecution : sig
     'http_type Smaws_Lib.Context.t ->
     start_automation_execution_request ->
     ( start_automation_execution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationDefinitionNotFoundException of automation_definition_not_found_exception
+      | `AutomationDefinitionVersionNotFoundException of
+        automation_definition_version_not_found_exception
+      | `AutomationExecutionLimitExceededException of automation_execution_limit_exceeded_exception
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `InvalidAutomationExecutionParametersException of
+        invalid_automation_execution_parameters_exception
+      | `InvalidTarget of invalid_target ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_automation_execution_request ->
+    ( start_automation_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationDefinitionNotFoundException of automation_definition_not_found_exception
       | `AutomationDefinitionVersionNotFoundException of
@@ -6262,6 +7615,23 @@ module StartChangeRequestExecution : sig
         invalid_automation_execution_parameters_exception
       | `NoLongerSupportedException of no_longer_supported_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_change_request_execution_request ->
+    ( start_change_request_execution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationDefinitionNotApprovedException of automation_definition_not_approved_exception
+      | `AutomationDefinitionNotFoundException of automation_definition_not_found_exception
+      | `AutomationDefinitionVersionNotFoundException of
+        automation_definition_version_not_found_exception
+      | `AutomationExecutionLimitExceededException of automation_execution_limit_exceeded_exception
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `InvalidAutomationExecutionParametersException of
+        invalid_automation_execution_parameters_exception
+      | `NoLongerSupportedException of no_longer_supported_exception ] )
+    result
 end
 [@@ocaml.doc
   " Amazon Web Services Systems Manager Change Manager is no longer open to new customers. \
@@ -6288,6 +7658,15 @@ module StartExecutionPreview : sig
       | `InternalServerError of internal_server_error
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_execution_preview_request ->
+    ( start_execution_preview_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Initiates the process of creating a preview showing the effects that running a specified \
@@ -6305,6 +7684,16 @@ module StartSession : sig
     'http_type Smaws_Lib.Context.t ->
     start_session_request ->
     ( start_session_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `TargetNotConnected of target_not_connected ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_session_request ->
+    ( start_session_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -6344,6 +7733,16 @@ module StopAutomationExecution : sig
       | `InternalServerError of internal_server_error
       | `InvalidAutomationStatusUpdateException of invalid_automation_status_update_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_automation_execution_request ->
+    ( stop_automation_execution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidAutomationStatusUpdateException of invalid_automation_status_update_exception ] )
+    result
 end
 [@@ocaml.doc "Stop an Automation that is currently running.\n"]
 
@@ -6355,6 +7754,13 @@ module TerminateSession : sig
     'http_type Smaws_Lib.Context.t ->
     terminate_session_request ->
     ( terminate_session_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    terminate_session_request ->
+    ( terminate_session_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -6375,6 +7781,17 @@ module UnlabelParameterVersion : sig
     'http_type Smaws_Lib.Context.t ->
     unlabel_parameter_version_request ->
     ( unlabel_parameter_version_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ParameterNotFound of parameter_not_found
+      | `ParameterVersionNotFound of parameter_version_not_found
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unlabel_parameter_version_request ->
+    ( unlabel_parameter_version_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ParameterNotFound of parameter_not_found
@@ -6411,6 +7828,26 @@ module UpdateAssociation : sig
     'http_type Smaws_Lib.Context.t ->
     update_association_request ->
     ( update_association_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `AssociationVersionLimitExceeded of association_version_limit_exceeded
+      | `InternalServerError of internal_server_error
+      | `InvalidAssociationVersion of invalid_association_version
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidOutputLocation of invalid_output_location
+      | `InvalidParameters of invalid_parameters
+      | `InvalidSchedule of invalid_schedule
+      | `InvalidTarget of invalid_target
+      | `InvalidTargetMaps of invalid_target_maps
+      | `InvalidUpdate of invalid_update
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_association_request ->
+    ( update_association_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `AssociationVersionLimitExceeded of association_version_limit_exceeded
@@ -6474,6 +7911,19 @@ module UpdateAssociationStatus : sig
       | `StatusUnchanged of status_unchanged
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_association_status_request ->
+    ( update_association_status_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidInstanceId of invalid_instance_id
+      | `StatusUnchanged of status_unchanged
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Updates the status of the Amazon Web Services Systems Manager document (SSM document) \
@@ -6514,6 +7964,23 @@ module UpdateDocument : sig
       | `InvalidDocumentVersion of invalid_document_version
       | `MaxDocumentSizeExceeded of max_document_size_exceeded ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_document_request ->
+    ( update_document_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DocumentVersionLimitExceeded of document_version_limit_exceeded
+      | `DuplicateDocumentContent of duplicate_document_content
+      | `DuplicateDocumentVersionName of duplicate_document_version_name
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentContent of invalid_document_content
+      | `InvalidDocumentOperation of invalid_document_operation
+      | `InvalidDocumentSchemaVersion of invalid_document_schema_version
+      | `InvalidDocumentVersion of invalid_document_version
+      | `MaxDocumentSizeExceeded of max_document_size_exceeded ] )
+    result
 end
 [@@ocaml.doc "Updates one or more values for an SSM document.\n"]
 
@@ -6530,6 +7997,17 @@ module UpdateDocumentDefaultVersion : sig
     'http_type Smaws_Lib.Context.t ->
     update_document_default_version_request ->
     ( update_document_default_version_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentSchemaVersion of invalid_document_schema_version
+      | `InvalidDocumentVersion of invalid_document_version ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_document_default_version_request ->
+    ( update_document_default_version_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -6565,6 +8043,18 @@ module UpdateDocumentMetadata : sig
       | `InvalidDocumentVersion of invalid_document_version
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_document_metadata_request ->
+    ( update_document_metadata_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentOperation of invalid_document_operation
+      | `InvalidDocumentVersion of invalid_document_version
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   " Amazon Web Services Systems Manager Change Manager is no longer open to new customers. \
@@ -6591,6 +8081,15 @@ module UpdateMaintenanceWindow : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_maintenance_window_request ->
+    ( update_maintenance_window_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing maintenance window. Only specified parameters are modified.\n\n\
@@ -6613,6 +8112,15 @@ module UpdateMaintenanceWindowTarget : sig
     'http_type Smaws_Lib.Context.t ->
     update_maintenance_window_target_request ->
     ( update_maintenance_window_target_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_maintenance_window_target_request ->
+    ( update_maintenance_window_target_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -6656,6 +8164,15 @@ module UpdateMaintenanceWindowTask : sig
     'http_type Smaws_Lib.Context.t ->
     update_maintenance_window_task_request ->
     ( update_maintenance_window_task_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_maintenance_window_task_request ->
+    ( update_maintenance_window_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -6723,6 +8240,15 @@ module UpdateManagedInstanceRole : sig
       | `InternalServerError of internal_server_error
       | `InvalidInstanceId of invalid_instance_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_managed_instance_role_request ->
+    ( update_managed_instance_role_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id ] )
+    result
 end
 [@@ocaml.doc
   "Changes the Identity and Access Management (IAM) role that is assigned to the on-premises \
@@ -6745,6 +8271,20 @@ module UpdateOpsItem : sig
     'http_type Smaws_Lib.Context.t ->
     update_ops_item_request ->
     ( update_ops_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemAccessDeniedException of ops_item_access_denied_exception
+      | `OpsItemAlreadyExistsException of ops_item_already_exists_exception
+      | `OpsItemConflictException of ops_item_conflict_exception
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_ops_item_request ->
+    ( update_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
@@ -6788,6 +8328,18 @@ module UpdateOpsMetadata : sig
       | `OpsMetadataNotFoundException of ops_metadata_not_found_exception
       | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_ops_metadata_request ->
+    ( update_ops_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
+      | `OpsMetadataKeyLimitExceededException of ops_metadata_key_limit_exceeded_exception
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception
+      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
+    result
 end
 [@@ocaml.doc
   "Amazon Web Services Systems Manager calls this API operation when you edit OpsMetadata in \
@@ -6804,6 +8356,15 @@ module UpdatePatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     update_patch_baseline_request ->
     ( update_patch_baseline_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_patch_baseline_request ->
+    ( update_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -6837,6 +8398,18 @@ module UpdateResourceDataSync : sig
         resource_data_sync_invalid_configuration_exception
       | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_resource_data_sync_request ->
+    ( update_resource_data_sync_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceDataSyncConflictException of resource_data_sync_conflict_exception
+      | `ResourceDataSyncInvalidConfigurationException of
+        resource_data_sync_invalid_configuration_exception
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Update a resource data sync. After you create a resource data sync for a Region, you can't \
@@ -6863,6 +8436,16 @@ module UpdateServiceSetting : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_setting_request ->
     ( update_service_setting_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ServiceSettingNotFound of service_setting_not_found
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_setting_request ->
+    ( update_service_setting_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found

--- a/sdks/ssm/operations.ml
+++ b/sdks/ssm/operations.ml
@@ -32,6 +32,13 @@ module AddTagsToResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.AddTagsToResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.add_tags_to_resource_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : add_tags_to_resource_request) =
+    let input = Json_serializers.add_tags_to_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.AddTagsToResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.add_tags_to_resource_result_of_yojson
+      ~error_deserializer
 end
 
 module AssociateOpsItemRelatedItem = struct
@@ -75,6 +82,13 @@ module AssociateOpsItemRelatedItem = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.associate_ops_item_related_item_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_ops_item_related_item_request) =
+    let input = Json_serializers.associate_ops_item_related_item_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.AssociateOpsItemRelatedItem" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_ops_item_related_item_response_of_yojson
+      ~error_deserializer
 end
 
 module CancelCommand = struct
@@ -105,6 +119,12 @@ module CancelCommand = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.CancelCommand" ~service ~context
       ~input ~output_deserializer:Json_deserializers.cancel_command_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : cancel_command_request) =
+    let input = Json_serializers.cancel_command_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.CancelCommand" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.cancel_command_result_of_yojson
+      ~error_deserializer
 end
 
 module CancelMaintenanceWindowExecution = struct
@@ -128,6 +148,13 @@ module CancelMaintenanceWindowExecution = struct
     let input = Json_serializers.cancel_maintenance_window_execution_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.CancelMaintenanceWindowExecution"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_maintenance_window_execution_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : cancel_maintenance_window_execution_request) =
+    let input = Json_serializers.cancel_maintenance_window_execution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.CancelMaintenanceWindowExecution" ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_maintenance_window_execution_result_of_yojson
       ~error_deserializer
 end
@@ -154,6 +181,12 @@ module CreateActivation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.CreateActivation" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_activation_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_activation_request) =
+    let input = Json_serializers.create_activation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.CreateActivation"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_activation_result_of_yojson ~error_deserializer
 end
 
 module CreateAssociation = struct
@@ -212,6 +245,13 @@ module CreateAssociation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.CreateAssociation" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_association_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_association_request) =
+    let input = Json_serializers.create_association_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.CreateAssociation"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_association_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateAssociationBatch = struct
@@ -268,6 +308,13 @@ module CreateAssociationBatch = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_association_batch_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_association_batch_request) =
+    let input = Json_serializers.create_association_batch_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.CreateAssociationBatch"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_association_batch_result_of_yojson
+      ~error_deserializer
 end
 
 module CreateDocument = struct
@@ -313,6 +360,12 @@ module CreateDocument = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.CreateDocument" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_document_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_document_request) =
+    let input = Json_serializers.create_document_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.CreateDocument"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_document_result_of_yojson ~error_deserializer
 end
 
 module CreateMaintenanceWindow = struct
@@ -341,6 +394,13 @@ module CreateMaintenanceWindow = struct
     let input = Json_serializers.create_maintenance_window_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.CreateMaintenanceWindow" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.create_maintenance_window_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_maintenance_window_request) =
+    let input = Json_serializers.create_maintenance_window_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.CreateMaintenanceWindow" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_maintenance_window_result_of_yojson
       ~error_deserializer
 end
@@ -379,6 +439,12 @@ module CreateOpsItem = struct
     let input = Json_serializers.create_ops_item_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.CreateOpsItem" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_ops_item_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_ops_item_request) =
+    let input = Json_serializers.create_ops_item_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.CreateOpsItem" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.create_ops_item_response_of_yojson
       ~error_deserializer
 end
 
@@ -419,6 +485,13 @@ module CreateOpsMetadata = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.CreateOpsMetadata" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_ops_metadata_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_ops_metadata_request) =
+    let input = Json_serializers.create_ops_metadata_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.CreateOpsMetadata"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_ops_metadata_result_of_yojson
+      ~error_deserializer
 end
 
 module CreatePatchBaseline = struct
@@ -447,6 +520,13 @@ module CreatePatchBaseline = struct
     let input = Json_serializers.create_patch_baseline_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.CreatePatchBaseline" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_patch_baseline_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_patch_baseline_request) =
+    let input = Json_serializers.create_patch_baseline_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.CreatePatchBaseline"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_patch_baseline_result_of_yojson
       ~error_deserializer
 end
 
@@ -486,6 +566,13 @@ module CreateResourceDataSync = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_resource_data_sync_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_resource_data_sync_request) =
+    let input = Json_serializers.create_resource_data_sync_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.CreateResourceDataSync"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_resource_data_sync_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteActivation = struct
@@ -516,6 +603,12 @@ module DeleteActivation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteActivation" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_activation_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_activation_request) =
+    let input = Json_serializers.delete_activation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteActivation"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_activation_result_of_yojson ~error_deserializer
 end
 
 module DeleteAssociation = struct
@@ -549,6 +642,13 @@ module DeleteAssociation = struct
     let input = Json_serializers.delete_association_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteAssociation" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_association_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_association_request) =
+    let input = Json_serializers.delete_association_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteAssociation"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_association_result_of_yojson
       ~error_deserializer
 end
 
@@ -584,6 +684,12 @@ module DeleteDocument = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteDocument" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_document_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_document_request) =
+    let input = Json_serializers.delete_document_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteDocument"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_document_result_of_yojson ~error_deserializer
 end
 
 module DeleteInventory = struct
@@ -621,6 +727,12 @@ module DeleteInventory = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteInventory" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_inventory_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_inventory_request) =
+    let input = Json_serializers.delete_inventory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteInventory"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_inventory_result_of_yojson ~error_deserializer
 end
 
 module DeleteMaintenanceWindow = struct
@@ -641,6 +753,13 @@ module DeleteMaintenanceWindow = struct
     let input = Json_serializers.delete_maintenance_window_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteMaintenanceWindow" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.delete_maintenance_window_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_maintenance_window_request) =
+    let input = Json_serializers.delete_maintenance_window_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DeleteMaintenanceWindow" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_maintenance_window_result_of_yojson
       ~error_deserializer
 end
@@ -667,6 +786,12 @@ module DeleteOpsItem = struct
     let input = Json_serializers.delete_ops_item_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteOpsItem" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_ops_item_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_ops_item_request) =
+    let input = Json_serializers.delete_ops_item_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteOpsItem" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.delete_ops_item_response_of_yojson
       ~error_deserializer
 end
 
@@ -698,6 +823,13 @@ module DeleteOpsMetadata = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteOpsMetadata" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_ops_metadata_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_ops_metadata_request) =
+    let input = Json_serializers.delete_ops_metadata_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteOpsMetadata"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_ops_metadata_result_of_yojson
+      ~error_deserializer
 end
 
 module DeleteParameter = struct
@@ -722,6 +854,12 @@ module DeleteParameter = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteParameter" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_parameter_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_parameter_request) =
+    let input = Json_serializers.delete_parameter_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteParameter"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_parameter_result_of_yojson ~error_deserializer
 end
 
 module DeleteParameters = struct
@@ -743,6 +881,12 @@ module DeleteParameters = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteParameters" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_parameters_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_parameters_request) =
+    let input = Json_serializers.delete_parameters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteParameters"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_parameters_result_of_yojson ~error_deserializer
 end
 
 module DeletePatchBaseline = struct
@@ -766,6 +910,13 @@ module DeletePatchBaseline = struct
     let input = Json_serializers.delete_patch_baseline_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeletePatchBaseline" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_patch_baseline_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_patch_baseline_request) =
+    let input = Json_serializers.delete_patch_baseline_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeletePatchBaseline"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_patch_baseline_result_of_yojson
       ~error_deserializer
 end
 
@@ -797,6 +948,13 @@ module DeleteResourceDataSync = struct
     let input = Json_serializers.delete_resource_data_sync_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeleteResourceDataSync" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.delete_resource_data_sync_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_resource_data_sync_request) =
+    let input = Json_serializers.delete_resource_data_sync_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteResourceDataSync"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_resource_data_sync_result_of_yojson
       ~error_deserializer
 end
@@ -843,6 +1001,13 @@ module DeleteResourcePolicy = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.delete_resource_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_resource_policy_request) =
+    let input = Json_serializers.delete_resource_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DeleteResourcePolicy"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_resource_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module DeregisterManagedInstance = struct
@@ -866,6 +1031,13 @@ module DeregisterManagedInstance = struct
     let input = Json_serializers.deregister_managed_instance_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeregisterManagedInstance" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.deregister_managed_instance_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : deregister_managed_instance_request) =
+    let input = Json_serializers.deregister_managed_instance_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DeregisterManagedInstance" ~service ~context ~input
       ~output_deserializer:Json_deserializers.deregister_managed_instance_result_of_yojson
       ~error_deserializer
 end
@@ -893,6 +1065,16 @@ module DeregisterPatchBaselineForPatchGroup = struct
     in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DeregisterPatchBaselineForPatchGroup"
       ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.deregister_patch_baseline_for_patch_group_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : deregister_patch_baseline_for_patch_group_request) =
+    let input =
+      Json_serializers.deregister_patch_baseline_for_patch_group_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DeregisterPatchBaselineForPatchGroup" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.deregister_patch_baseline_for_patch_group_result_of_yojson
       ~error_deserializer
@@ -927,6 +1109,16 @@ module DeregisterTargetFromMaintenanceWindow = struct
       ~output_deserializer:
         Json_deserializers.deregister_target_from_maintenance_window_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deregister_target_from_maintenance_window_request) =
+    let input =
+      Json_serializers.deregister_target_from_maintenance_window_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DeregisterTargetFromMaintenanceWindow" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.deregister_target_from_maintenance_window_result_of_yojson
+      ~error_deserializer
 end
 
 module DeregisterTaskFromMaintenanceWindow = struct
@@ -955,6 +1147,16 @@ module DeregisterTaskFromMaintenanceWindow = struct
       ~output_deserializer:
         Json_deserializers.deregister_task_from_maintenance_window_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deregister_task_from_maintenance_window_request) =
+    let input =
+      Json_serializers.deregister_task_from_maintenance_window_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DeregisterTaskFromMaintenanceWindow" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.deregister_task_from_maintenance_window_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeActivations = struct
@@ -980,6 +1182,13 @@ module DescribeActivations = struct
     let input = Json_serializers.describe_activations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeActivations" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_activations_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_activations_request) =
+    let input = Json_serializers.describe_activations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DescribeActivations"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_activations_result_of_yojson
       ~error_deserializer
 end
 
@@ -1016,6 +1225,13 @@ module DescribeAssociation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeAssociation" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_association_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_association_request) =
+    let input = Json_serializers.describe_association_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DescribeAssociation"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_association_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAssociationExecutionTargets = struct
@@ -1050,6 +1266,14 @@ module DescribeAssociationExecutionTargets = struct
       ~output_deserializer:
         Json_deserializers.describe_association_execution_targets_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_association_execution_targets_request) =
+    let input = Json_serializers.describe_association_execution_targets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeAssociationExecutionTargets" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_association_execution_targets_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAssociationExecutions = struct
@@ -1077,6 +1301,13 @@ module DescribeAssociationExecutions = struct
     let input = Json_serializers.describe_association_executions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeAssociationExecutions"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_association_executions_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_association_executions_request) =
+    let input = Json_serializers.describe_association_executions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeAssociationExecutions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_association_executions_result_of_yojson
       ~error_deserializer
 end
@@ -1108,6 +1339,13 @@ module DescribeAutomationExecutions = struct
     let input = Json_serializers.describe_automation_executions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeAutomationExecutions"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_automation_executions_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_automation_executions_request) =
+    let input = Json_serializers.describe_automation_executions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeAutomationExecutions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_automation_executions_result_of_yojson
       ~error_deserializer
 end
@@ -1146,6 +1384,13 @@ module DescribeAutomationStepExecutions = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_automation_step_executions_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_automation_step_executions_request) =
+    let input = Json_serializers.describe_automation_step_executions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeAutomationStepExecutions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_automation_step_executions_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeAvailablePatches = struct
@@ -1166,6 +1411,13 @@ module DescribeAvailablePatches = struct
     let input = Json_serializers.describe_available_patches_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeAvailablePatches" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_available_patches_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_available_patches_request) =
+    let input = Json_serializers.describe_available_patches_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeAvailablePatches" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_available_patches_result_of_yojson
       ~error_deserializer
 end
@@ -1195,6 +1447,12 @@ module DescribeDocument = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeDocument" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_document_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_document_request) =
+    let input = Json_serializers.describe_document_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DescribeDocument"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_document_result_of_yojson ~error_deserializer
 end
 
 module DescribeDocumentPermission = struct
@@ -1230,6 +1488,13 @@ module DescribeDocumentPermission = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.describe_document_permission_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_document_permission_request) =
+    let input = Json_serializers.describe_document_permission_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeDocumentPermission" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_document_permission_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeEffectiveInstanceAssociations = struct
@@ -1257,6 +1522,16 @@ module DescribeEffectiveInstanceAssociations = struct
       Json_serializers.describe_effective_instance_associations_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AmazonSSM.DescribeEffectiveInstanceAssociations" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_effective_instance_associations_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_effective_instance_associations_request) =
+    let input =
+      Json_serializers.describe_effective_instance_associations_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AmazonSSM.DescribeEffectiveInstanceAssociations" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.describe_effective_instance_associations_result_of_yojson
@@ -1296,6 +1571,17 @@ module DescribeEffectivePatchesForPatchBaseline = struct
       ~output_deserializer:
         Json_deserializers.describe_effective_patches_for_patch_baseline_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : describe_effective_patches_for_patch_baseline_request) =
+    let input =
+      Json_serializers.describe_effective_patches_for_patch_baseline_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeEffectivePatchesForPatchBaseline" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_effective_patches_for_patch_baseline_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeInstanceAssociationsStatus = struct
@@ -1322,6 +1608,13 @@ module DescribeInstanceAssociationsStatus = struct
     let input = Json_serializers.describe_instance_associations_status_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeInstanceAssociationsStatus"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_instance_associations_status_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_instance_associations_status_request) =
+    let input = Json_serializers.describe_instance_associations_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeInstanceAssociationsStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_instance_associations_status_result_of_yojson
       ~error_deserializer
 end
@@ -1360,6 +1653,13 @@ module DescribeInstanceInformation = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.describe_instance_information_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_instance_information_request) =
+    let input = Json_serializers.describe_instance_information_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeInstanceInformation" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_instance_information_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeInstancePatchStates = struct
@@ -1383,6 +1683,13 @@ module DescribeInstancePatchStates = struct
     let input = Json_serializers.describe_instance_patch_states_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeInstancePatchStates" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_instance_patch_states_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_instance_patch_states_request) =
+    let input = Json_serializers.describe_instance_patch_states_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeInstancePatchStates" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_instance_patch_states_result_of_yojson
       ~error_deserializer
 end
@@ -1415,6 +1722,17 @@ module DescribeInstancePatchStatesForPatchGroup = struct
       ~output_deserializer:
         Json_deserializers.describe_instance_patch_states_for_patch_group_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : describe_instance_patch_states_for_patch_group_request) =
+    let input =
+      Json_serializers.describe_instance_patch_states_for_patch_group_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeInstancePatchStatesForPatchGroup" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_instance_patch_states_for_patch_group_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeInstancePatches = struct
@@ -1443,6 +1761,13 @@ module DescribeInstancePatches = struct
     let input = Json_serializers.describe_instance_patches_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeInstancePatches" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_instance_patches_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_instance_patches_request) =
+    let input = Json_serializers.describe_instance_patches_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeInstancePatches" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_instance_patches_result_of_yojson
       ~error_deserializer
 end
@@ -1487,6 +1812,13 @@ module DescribeInstanceProperties = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.describe_instance_properties_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_instance_properties_request) =
+    let input = Json_serializers.describe_instance_properties_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeInstanceProperties" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_instance_properties_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeInventoryDeletions = struct
@@ -1516,6 +1848,13 @@ module DescribeInventoryDeletions = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.describe_inventory_deletions_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_inventory_deletions_request) =
+    let input = Json_serializers.describe_inventory_deletions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeInventoryDeletions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_inventory_deletions_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeMaintenanceWindowExecutionTaskInvocations = struct
@@ -1541,6 +1880,19 @@ module DescribeMaintenanceWindowExecutionTaskInvocations = struct
         request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AmazonSSM.DescribeMaintenanceWindowExecutionTaskInvocations" ~service ~context
+      ~input
+      ~output_deserializer:
+        Json_deserializers.describe_maintenance_window_execution_task_invocations_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context
+      (request : describe_maintenance_window_execution_task_invocations_request) =
+    let input =
+      Json_serializers.describe_maintenance_window_execution_task_invocations_request_to_yojson
+        request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AmazonSSM.DescribeMaintenanceWindowExecutionTaskInvocations" ~service ~context
       ~input
       ~output_deserializer:
@@ -1574,6 +1926,17 @@ module DescribeMaintenanceWindowExecutionTasks = struct
       ~output_deserializer:
         Json_deserializers.describe_maintenance_window_execution_tasks_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_maintenance_window_execution_tasks_request)
+      =
+    let input =
+      Json_serializers.describe_maintenance_window_execution_tasks_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeMaintenanceWindowExecutionTasks" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_maintenance_window_execution_tasks_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeMaintenanceWindowExecutions = struct
@@ -1594,6 +1957,14 @@ module DescribeMaintenanceWindowExecutions = struct
     let input = Json_serializers.describe_maintenance_window_executions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeMaintenanceWindowExecutions"
       ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_maintenance_window_executions_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_maintenance_window_executions_request) =
+    let input = Json_serializers.describe_maintenance_window_executions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeMaintenanceWindowExecutions" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.describe_maintenance_window_executions_result_of_yojson
       ~error_deserializer
@@ -1622,6 +1993,13 @@ module DescribeMaintenanceWindowSchedule = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_maintenance_window_schedule_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_maintenance_window_schedule_request) =
+    let input = Json_serializers.describe_maintenance_window_schedule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeMaintenanceWindowSchedule" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_maintenance_window_schedule_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeMaintenanceWindowTargets = struct
@@ -1645,6 +2023,13 @@ module DescribeMaintenanceWindowTargets = struct
     let input = Json_serializers.describe_maintenance_window_targets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeMaintenanceWindowTargets"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_maintenance_window_targets_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_maintenance_window_targets_request) =
+    let input = Json_serializers.describe_maintenance_window_targets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeMaintenanceWindowTargets" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_maintenance_window_targets_result_of_yojson
       ~error_deserializer
 end
@@ -1672,6 +2057,13 @@ module DescribeMaintenanceWindowTasks = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_maintenance_window_tasks_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_maintenance_window_tasks_request) =
+    let input = Json_serializers.describe_maintenance_window_tasks_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeMaintenanceWindowTasks" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_maintenance_window_tasks_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeMaintenanceWindows = struct
@@ -1692,6 +2084,13 @@ module DescribeMaintenanceWindows = struct
     let input = Json_serializers.describe_maintenance_windows_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeMaintenanceWindows" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_maintenance_windows_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_maintenance_windows_request) =
+    let input = Json_serializers.describe_maintenance_windows_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeMaintenanceWindows" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_maintenance_windows_result_of_yojson
       ~error_deserializer
 end
@@ -1719,6 +2118,16 @@ module DescribeMaintenanceWindowsForTarget = struct
       ~output_deserializer:
         Json_deserializers.describe_maintenance_windows_for_target_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_maintenance_windows_for_target_request) =
+    let input =
+      Json_serializers.describe_maintenance_windows_for_target_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribeMaintenanceWindowsForTarget" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_maintenance_windows_for_target_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribeOpsItems = struct
@@ -1739,6 +2148,13 @@ module DescribeOpsItems = struct
     let input = Json_serializers.describe_ops_items_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeOpsItems" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_ops_items_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_ops_items_request) =
+    let input = Json_serializers.describe_ops_items_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DescribeOpsItems"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_ops_items_response_of_yojson
       ~error_deserializer
 end
 
@@ -1773,6 +2189,13 @@ module DescribeParameters = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeParameters" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_parameters_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_parameters_request) =
+    let input = Json_serializers.describe_parameters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DescribeParameters"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_parameters_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribePatchBaselines = struct
@@ -1793,6 +2216,13 @@ module DescribePatchBaselines = struct
     let input = Json_serializers.describe_patch_baselines_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribePatchBaselines" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_patch_baselines_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_patch_baselines_request) =
+    let input = Json_serializers.describe_patch_baselines_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DescribePatchBaselines"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_patch_baselines_result_of_yojson
       ~error_deserializer
 end
@@ -1820,6 +2250,13 @@ module DescribePatchGroupState = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.describe_patch_group_state_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_patch_group_state_request) =
+    let input = Json_serializers.describe_patch_group_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribePatchGroupState" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_patch_group_state_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribePatchGroups = struct
@@ -1841,6 +2278,13 @@ module DescribePatchGroups = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribePatchGroups" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_patch_groups_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_patch_groups_request) =
+    let input = Json_serializers.describe_patch_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DescribePatchGroups"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_patch_groups_result_of_yojson
+      ~error_deserializer
 end
 
 module DescribePatchProperties = struct
@@ -1861,6 +2305,13 @@ module DescribePatchProperties = struct
     let input = Json_serializers.describe_patch_properties_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribePatchProperties" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_patch_properties_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_patch_properties_request) =
+    let input = Json_serializers.describe_patch_properties_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DescribePatchProperties" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_patch_properties_result_of_yojson
       ~error_deserializer
 end
@@ -1889,6 +2340,13 @@ module DescribeSessions = struct
     let input = Json_serializers.describe_sessions_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.DescribeSessions" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_sessions_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_sessions_request) =
+    let input = Json_serializers.describe_sessions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.DescribeSessions"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_sessions_response_of_yojson
       ~error_deserializer
 end
 
@@ -1930,6 +2388,13 @@ module DisassociateOpsItemRelatedItem = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_ops_item_related_item_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_ops_item_related_item_request) =
+    let input = Json_serializers.disassociate_ops_item_related_item_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.DisassociateOpsItemRelatedItem" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_ops_item_related_item_response_of_yojson
+      ~error_deserializer
 end
 
 module GetAccessToken = struct
@@ -1964,6 +2429,13 @@ module GetAccessToken = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetAccessToken" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_access_token_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_access_token_request) =
+    let input = Json_serializers.get_access_token_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetAccessToken"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_access_token_response_of_yojson
+      ~error_deserializer
 end
 
 module GetAutomationExecution = struct
@@ -1989,6 +2461,13 @@ module GetAutomationExecution = struct
     let input = Json_serializers.get_automation_execution_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetAutomationExecution" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_automation_execution_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_automation_execution_request) =
+    let input = Json_serializers.get_automation_execution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetAutomationExecution"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_automation_execution_result_of_yojson
       ~error_deserializer
 end
@@ -2021,6 +2500,13 @@ module GetCalendarState = struct
     let input = Json_serializers.get_calendar_state_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetCalendarState" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_calendar_state_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_calendar_state_request) =
+    let input = Json_serializers.get_calendar_state_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetCalendarState"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_calendar_state_response_of_yojson
       ~error_deserializer
 end
 
@@ -2056,6 +2542,13 @@ module GetCommandInvocation = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_command_invocation_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_command_invocation_request) =
+    let input = Json_serializers.get_command_invocation_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetCommandInvocation"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_command_invocation_result_of_yojson
+      ~error_deserializer
 end
 
 module GetConnectionStatus = struct
@@ -2078,6 +2571,13 @@ module GetConnectionStatus = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_connection_status_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_connection_status_request) =
+    let input = Json_serializers.get_connection_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetConnectionStatus"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_connection_status_response_of_yojson
+      ~error_deserializer
 end
 
 module GetDefaultPatchBaseline = struct
@@ -2098,6 +2598,13 @@ module GetDefaultPatchBaseline = struct
     let input = Json_serializers.get_default_patch_baseline_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetDefaultPatchBaseline" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_default_patch_baseline_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_default_patch_baseline_request) =
+    let input = Json_serializers.get_default_patch_baseline_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.GetDefaultPatchBaseline" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_default_patch_baseline_result_of_yojson
       ~error_deserializer
 end
@@ -2134,6 +2641,16 @@ module GetDeployablePatchSnapshotForInstance = struct
       ~output_deserializer:
         Json_deserializers.get_deployable_patch_snapshot_for_instance_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_deployable_patch_snapshot_for_instance_request) =
+    let input =
+      Json_serializers.get_deployable_patch_snapshot_for_instance_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.GetDeployablePatchSnapshotForInstance" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_deployable_patch_snapshot_for_instance_result_of_yojson
+      ~error_deserializer
 end
 
 module GetDocument = struct
@@ -2160,6 +2677,12 @@ module GetDocument = struct
     let input = Json_serializers.get_document_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetDocument" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_document_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_document_request) =
+    let input = Json_serializers.get_document_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetDocument" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.get_document_result_of_yojson
+      ~error_deserializer
 end
 
 module GetExecutionPreview = struct
@@ -2184,6 +2707,13 @@ module GetExecutionPreview = struct
     let input = Json_serializers.get_execution_preview_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetExecutionPreview" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_execution_preview_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_execution_preview_request) =
+    let input = Json_serializers.get_execution_preview_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetExecutionPreview"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_execution_preview_response_of_yojson
       ~error_deserializer
 end
@@ -2228,6 +2758,12 @@ module GetInventory = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetInventory" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_inventory_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_inventory_request) =
+    let input = Json_serializers.get_inventory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetInventory" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.get_inventory_result_of_yojson
+      ~error_deserializer
 end
 
 module GetInventorySchema = struct
@@ -2256,6 +2792,13 @@ module GetInventorySchema = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetInventorySchema" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_inventory_schema_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_inventory_schema_request) =
+    let input = Json_serializers.get_inventory_schema_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetInventorySchema"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_inventory_schema_result_of_yojson
+      ~error_deserializer
 end
 
 module GetMaintenanceWindow = struct
@@ -2279,6 +2822,13 @@ module GetMaintenanceWindow = struct
     let input = Json_serializers.get_maintenance_window_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetMaintenanceWindow" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_maintenance_window_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_maintenance_window_request) =
+    let input = Json_serializers.get_maintenance_window_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetMaintenanceWindow"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_maintenance_window_result_of_yojson
       ~error_deserializer
 end
@@ -2306,6 +2856,13 @@ module GetMaintenanceWindowExecution = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_maintenance_window_execution_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_maintenance_window_execution_request) =
+    let input = Json_serializers.get_maintenance_window_execution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.GetMaintenanceWindowExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_maintenance_window_execution_result_of_yojson
+      ~error_deserializer
 end
 
 module GetMaintenanceWindowExecutionTask = struct
@@ -2329,6 +2886,13 @@ module GetMaintenanceWindowExecutionTask = struct
     let input = Json_serializers.get_maintenance_window_execution_task_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetMaintenanceWindowExecutionTask"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_maintenance_window_execution_task_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_maintenance_window_execution_task_request) =
+    let input = Json_serializers.get_maintenance_window_execution_task_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.GetMaintenanceWindowExecutionTask" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_maintenance_window_execution_task_result_of_yojson
       ~error_deserializer
 end
@@ -2359,6 +2923,17 @@ module GetMaintenanceWindowExecutionTaskInvocation = struct
       ~output_deserializer:
         Json_deserializers.get_maintenance_window_execution_task_invocation_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context
+      (request : get_maintenance_window_execution_task_invocation_request) =
+    let input =
+      Json_serializers.get_maintenance_window_execution_task_invocation_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.GetMaintenanceWindowExecutionTaskInvocation" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_maintenance_window_execution_task_invocation_result_of_yojson
+      ~error_deserializer
 end
 
 module GetMaintenanceWindowTask = struct
@@ -2382,6 +2957,13 @@ module GetMaintenanceWindowTask = struct
     let input = Json_serializers.get_maintenance_window_task_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetMaintenanceWindowTask" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_maintenance_window_task_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_maintenance_window_task_request) =
+    let input = Json_serializers.get_maintenance_window_task_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.GetMaintenanceWindowTask" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_maintenance_window_task_result_of_yojson
       ~error_deserializer
 end
@@ -2412,6 +2994,12 @@ module GetOpsItem = struct
     let input = Json_serializers.get_ops_item_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetOpsItem" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_ops_item_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_ops_item_request) =
+    let input = Json_serializers.get_ops_item_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetOpsItem" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.get_ops_item_response_of_yojson
+      ~error_deserializer
 end
 
 module GetOpsMetadata = struct
@@ -2442,6 +3030,12 @@ module GetOpsMetadata = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetOpsMetadata" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_ops_metadata_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_ops_metadata_request) =
+    let input = Json_serializers.get_ops_metadata_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetOpsMetadata"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_ops_metadata_result_of_yojson ~error_deserializer
 end
 
 module GetOpsSummary = struct
@@ -2480,6 +3074,12 @@ module GetOpsSummary = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetOpsSummary" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_ops_summary_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_ops_summary_request) =
+    let input = Json_serializers.get_ops_summary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetOpsSummary" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.get_ops_summary_result_of_yojson
+      ~error_deserializer
 end
 
 module GetParameter = struct
@@ -2510,6 +3110,12 @@ module GetParameter = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetParameter" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_parameter_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_parameter_request) =
+    let input = Json_serializers.get_parameter_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetParameter" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.get_parameter_result_of_yojson
+      ~error_deserializer
 end
 
 module GetParameterHistory = struct
@@ -2539,6 +3145,13 @@ module GetParameterHistory = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetParameterHistory" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_parameter_history_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_parameter_history_request) =
+    let input = Json_serializers.get_parameter_history_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetParameterHistory"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_parameter_history_result_of_yojson
+      ~error_deserializer
 end
 
 module GetParameters = struct
@@ -2561,6 +3174,12 @@ module GetParameters = struct
     let input = Json_serializers.get_parameters_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetParameters" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_parameters_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_parameters_request) =
+    let input = Json_serializers.get_parameters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetParameters" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.get_parameters_result_of_yojson
       ~error_deserializer
 end
 
@@ -2598,6 +3217,13 @@ module GetParametersByPath = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_parameters_by_path_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_parameters_by_path_request) =
+    let input = Json_serializers.get_parameters_by_path_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetParametersByPath"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_parameters_by_path_result_of_yojson
+      ~error_deserializer
 end
 
 module GetPatchBaseline = struct
@@ -2625,6 +3251,13 @@ module GetPatchBaseline = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetPatchBaseline" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_patch_baseline_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_patch_baseline_request) =
+    let input = Json_serializers.get_patch_baseline_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetPatchBaseline"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_patch_baseline_result_of_yojson
+      ~error_deserializer
 end
 
 module GetPatchBaselineForPatchGroup = struct
@@ -2645,6 +3278,13 @@ module GetPatchBaselineForPatchGroup = struct
     let input = Json_serializers.get_patch_baseline_for_patch_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetPatchBaselineForPatchGroup"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_patch_baseline_for_patch_group_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_patch_baseline_for_patch_group_request) =
+    let input = Json_serializers.get_patch_baseline_for_patch_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.GetPatchBaselineForPatchGroup" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_patch_baseline_for_patch_group_result_of_yojson
       ~error_deserializer
 end
@@ -2678,6 +3318,13 @@ module GetResourcePolicies = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_resource_policies_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_resource_policies_request) =
+    let input = Json_serializers.get_resource_policies_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetResourcePolicies"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_resource_policies_response_of_yojson
+      ~error_deserializer
 end
 
 module GetServiceSetting = struct
@@ -2701,6 +3348,13 @@ module GetServiceSetting = struct
     let input = Json_serializers.get_service_setting_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.GetServiceSetting" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_service_setting_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_service_setting_request) =
+    let input = Json_serializers.get_service_setting_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.GetServiceSetting"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_service_setting_result_of_yojson
       ~error_deserializer
 end
 
@@ -2739,6 +3393,13 @@ module LabelParameterVersion = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.label_parameter_version_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : label_parameter_version_request) =
+    let input = Json_serializers.label_parameter_version_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.LabelParameterVersion"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.label_parameter_version_result_of_yojson
+      ~error_deserializer
 end
 
 module ListAssociationVersions = struct
@@ -2768,6 +3429,13 @@ module ListAssociationVersions = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_association_versions_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_association_versions_request) =
+    let input = Json_serializers.list_association_versions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.ListAssociationVersions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_association_versions_result_of_yojson
+      ~error_deserializer
 end
 
 module ListAssociations = struct
@@ -2792,6 +3460,12 @@ module ListAssociations = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListAssociations" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_associations_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_associations_request) =
+    let input = Json_serializers.list_associations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListAssociations"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_associations_result_of_yojson ~error_deserializer
 end
 
 module ListCommandInvocations = struct
@@ -2824,6 +3498,13 @@ module ListCommandInvocations = struct
     let input = Json_serializers.list_command_invocations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListCommandInvocations" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_command_invocations_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_command_invocations_request) =
+    let input = Json_serializers.list_command_invocations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListCommandInvocations"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_command_invocations_result_of_yojson
       ~error_deserializer
 end
@@ -2859,6 +3540,12 @@ module ListCommands = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListCommands" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_commands_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_commands_request) =
+    let input = Json_serializers.list_commands_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListCommands" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_commands_result_of_yojson
+      ~error_deserializer
 end
 
 module ListComplianceItems = struct
@@ -2891,6 +3578,13 @@ module ListComplianceItems = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListComplianceItems" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_compliance_items_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_compliance_items_request) =
+    let input = Json_serializers.list_compliance_items_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListComplianceItems"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_compliance_items_result_of_yojson
+      ~error_deserializer
 end
 
 module ListComplianceSummaries = struct
@@ -2916,6 +3610,13 @@ module ListComplianceSummaries = struct
     let input = Json_serializers.list_compliance_summaries_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListComplianceSummaries" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_compliance_summaries_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_compliance_summaries_request) =
+    let input = Json_serializers.list_compliance_summaries_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.ListComplianceSummaries" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_compliance_summaries_result_of_yojson
       ~error_deserializer
 end
@@ -2949,6 +3650,13 @@ module ListDocumentMetadataHistory = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_document_metadata_history_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_document_metadata_history_request) =
+    let input = Json_serializers.list_document_metadata_history_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.ListDocumentMetadataHistory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_document_metadata_history_response_of_yojson
+      ~error_deserializer
 end
 
 module ListDocumentVersions = struct
@@ -2977,6 +3685,13 @@ module ListDocumentVersions = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_document_versions_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_document_versions_request) =
+    let input = Json_serializers.list_document_versions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListDocumentVersions"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_document_versions_result_of_yojson
+      ~error_deserializer
 end
 
 module ListDocuments = struct
@@ -3003,6 +3718,12 @@ module ListDocuments = struct
     let input = Json_serializers.list_documents_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListDocuments" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_documents_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_documents_request) =
+    let input = Json_serializers.list_documents_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListDocuments" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_documents_result_of_yojson
       ~error_deserializer
 end
 
@@ -3038,6 +3759,13 @@ module ListInventoryEntries = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_inventory_entries_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_inventory_entries_request) =
+    let input = Json_serializers.list_inventory_entries_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListInventoryEntries"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_inventory_entries_result_of_yojson
+      ~error_deserializer
 end
 
 module ListNodes = struct
@@ -3071,6 +3799,12 @@ module ListNodes = struct
     let input = Json_serializers.list_nodes_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListNodes" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_nodes_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_nodes_request) =
+    let input = Json_serializers.list_nodes_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListNodes" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.list_nodes_result_of_yojson
+      ~error_deserializer
 end
 
 module ListNodesSummary = struct
@@ -3109,6 +3843,13 @@ module ListNodesSummary = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListNodesSummary" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_nodes_summary_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_nodes_summary_request) =
+    let input = Json_serializers.list_nodes_summary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListNodesSummary"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_nodes_summary_result_of_yojson
+      ~error_deserializer
 end
 
 module ListOpsItemEvents = struct
@@ -3142,6 +3883,13 @@ module ListOpsItemEvents = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListOpsItemEvents" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_ops_item_events_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_ops_item_events_request) =
+    let input = Json_serializers.list_ops_item_events_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListOpsItemEvents"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_ops_item_events_response_of_yojson
+      ~error_deserializer
 end
 
 module ListOpsItemRelatedItems = struct
@@ -3166,6 +3914,13 @@ module ListOpsItemRelatedItems = struct
     let input = Json_serializers.list_ops_item_related_items_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListOpsItemRelatedItems" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_ops_item_related_items_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_ops_item_related_items_request) =
+    let input = Json_serializers.list_ops_item_related_items_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.ListOpsItemRelatedItems" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_ops_item_related_items_response_of_yojson
       ~error_deserializer
 end
@@ -3194,6 +3949,12 @@ module ListOpsMetadata = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListOpsMetadata" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_ops_metadata_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_ops_metadata_request) =
+    let input = Json_serializers.list_ops_metadata_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListOpsMetadata"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_ops_metadata_result_of_yojson ~error_deserializer
 end
 
 module ListResourceComplianceSummaries = struct
@@ -3219,6 +3980,13 @@ module ListResourceComplianceSummaries = struct
     let input = Json_serializers.list_resource_compliance_summaries_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListResourceComplianceSummaries"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resource_compliance_summaries_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_resource_compliance_summaries_request) =
+    let input = Json_serializers.list_resource_compliance_summaries_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.ListResourceComplianceSummaries" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_resource_compliance_summaries_result_of_yojson
       ~error_deserializer
 end
@@ -3252,6 +4020,13 @@ module ListResourceDataSync = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_resource_data_sync_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_resource_data_sync_request) =
+    let input = Json_serializers.list_resource_data_sync_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListResourceDataSync"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resource_data_sync_result_of_yojson
+      ~error_deserializer
 end
 
 module ListTagsForResource = struct
@@ -3278,6 +4053,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ListTagsForResource" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ListTagsForResource"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_result_of_yojson
       ~error_deserializer
 end
@@ -3313,6 +4095,13 @@ module ModifyDocumentPermission = struct
     let input = Json_serializers.modify_document_permission_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ModifyDocumentPermission" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.modify_document_permission_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : modify_document_permission_request) =
+    let input = Json_serializers.modify_document_permission_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.ModifyDocumentPermission" ~service ~context ~input
       ~output_deserializer:Json_deserializers.modify_document_permission_response_of_yojson
       ~error_deserializer
 end
@@ -3358,6 +4147,13 @@ module PutComplianceItems = struct
     let input = Json_serializers.put_compliance_items_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.PutComplianceItems" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_compliance_items_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_compliance_items_request) =
+    let input = Json_serializers.put_compliance_items_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.PutComplianceItems"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_compliance_items_result_of_yojson
       ~error_deserializer
 end
 
@@ -3427,6 +4223,12 @@ module PutInventory = struct
     let input = Json_serializers.put_inventory_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.PutInventory" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_inventory_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_inventory_request) =
+    let input = Json_serializers.put_inventory_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.PutInventory" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.put_inventory_result_of_yojson
       ~error_deserializer
 end
 
@@ -3501,6 +4303,12 @@ module PutParameter = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.PutParameter" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_parameter_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_parameter_request) =
+    let input = Json_serializers.put_parameter_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.PutParameter" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.put_parameter_result_of_yojson
+      ~error_deserializer
 end
 
 module PutResourcePolicy = struct
@@ -3549,6 +4357,13 @@ module PutResourcePolicy = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.PutResourcePolicy" ~service ~context
       ~input ~output_deserializer:Json_deserializers.put_resource_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_resource_policy_request) =
+    let input = Json_serializers.put_resource_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.PutResourcePolicy"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_resource_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module RegisterDefaultPatchBaseline = struct
@@ -3575,6 +4390,13 @@ module RegisterDefaultPatchBaseline = struct
     let input = Json_serializers.register_default_patch_baseline_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.RegisterDefaultPatchBaseline"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.register_default_patch_baseline_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : register_default_patch_baseline_request) =
+    let input = Json_serializers.register_default_patch_baseline_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.RegisterDefaultPatchBaseline" ~service ~context ~input
       ~output_deserializer:Json_deserializers.register_default_patch_baseline_result_of_yojson
       ~error_deserializer
 end
@@ -3615,6 +4437,16 @@ module RegisterPatchBaselineForPatchGroup = struct
       ~output_deserializer:
         Json_deserializers.register_patch_baseline_for_patch_group_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : register_patch_baseline_for_patch_group_request) =
+    let input =
+      Json_serializers.register_patch_baseline_for_patch_group_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.RegisterPatchBaselineForPatchGroup" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.register_patch_baseline_for_patch_group_result_of_yojson
+      ~error_deserializer
 end
 
 module RegisterTargetWithMaintenanceWindow = struct
@@ -3648,6 +4480,16 @@ module RegisterTargetWithMaintenanceWindow = struct
     in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.RegisterTargetWithMaintenanceWindow"
       ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.register_target_with_maintenance_window_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : register_target_with_maintenance_window_request) =
+    let input =
+      Json_serializers.register_target_with_maintenance_window_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.RegisterTargetWithMaintenanceWindow" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.register_target_with_maintenance_window_result_of_yojson
       ~error_deserializer
@@ -3688,6 +4530,13 @@ module RegisterTaskWithMaintenanceWindow = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.register_task_with_maintenance_window_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : register_task_with_maintenance_window_request) =
+    let input = Json_serializers.register_task_with_maintenance_window_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.RegisterTaskWithMaintenanceWindow" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.register_task_with_maintenance_window_result_of_yojson
+      ~error_deserializer
 end
 
 module RemoveTagsFromResource = struct
@@ -3719,6 +4568,13 @@ module RemoveTagsFromResource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.remove_tags_from_resource_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : remove_tags_from_resource_request) =
+    let input = Json_serializers.remove_tags_from_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.RemoveTagsFromResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.remove_tags_from_resource_result_of_yojson
+      ~error_deserializer
 end
 
 module ResetServiceSetting = struct
@@ -3746,6 +4602,13 @@ module ResetServiceSetting = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ResetServiceSetting" ~service
       ~context ~input ~output_deserializer:Json_deserializers.reset_service_setting_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : reset_service_setting_request) =
+    let input = Json_serializers.reset_service_setting_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ResetServiceSetting"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.reset_service_setting_result_of_yojson
+      ~error_deserializer
 end
 
 module ResumeSession = struct
@@ -3769,6 +4632,12 @@ module ResumeSession = struct
     let input = Json_serializers.resume_session_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.ResumeSession" ~service ~context
       ~input ~output_deserializer:Json_deserializers.resume_session_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : resume_session_request) =
+    let input = Json_serializers.resume_session_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.ResumeSession" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.resume_session_response_of_yojson
       ~error_deserializer
 end
 
@@ -3803,6 +4672,13 @@ module SendAutomationSignal = struct
     let input = Json_serializers.send_automation_signal_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.SendAutomationSignal" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.send_automation_signal_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : send_automation_signal_request) =
+    let input = Json_serializers.send_automation_signal_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.SendAutomationSignal"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.send_automation_signal_result_of_yojson
       ~error_deserializer
 end
@@ -3857,6 +4733,12 @@ module SendCommand = struct
     let input = Json_serializers.send_command_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.SendCommand" ~service ~context ~input
       ~output_deserializer:Json_deserializers.send_command_result_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : send_command_request) =
+    let input = Json_serializers.send_command_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.SendCommand" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.send_command_result_of_yojson
+      ~error_deserializer
 end
 
 module StartAccessRequest = struct
@@ -3895,6 +4777,13 @@ module StartAccessRequest = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.StartAccessRequest" ~service ~context
       ~input ~output_deserializer:Json_deserializers.start_access_request_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_access_request_request) =
+    let input = Json_serializers.start_access_request_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.StartAccessRequest"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_access_request_response_of_yojson
+      ~error_deserializer
 end
 
 module StartAssociationsOnce = struct
@@ -3919,6 +4808,13 @@ module StartAssociationsOnce = struct
     let input = Json_serializers.start_associations_once_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.StartAssociationsOnce" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.start_associations_once_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_associations_once_request) =
+    let input = Json_serializers.start_associations_once_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.StartAssociationsOnce"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_associations_once_result_of_yojson
       ~error_deserializer
 end
@@ -3969,6 +4865,13 @@ module StartAutomationExecution = struct
     let input = Json_serializers.start_automation_execution_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.StartAutomationExecution" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.start_automation_execution_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_automation_execution_request) =
+    let input = Json_serializers.start_automation_execution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.StartAutomationExecution" ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_automation_execution_result_of_yojson
       ~error_deserializer
 end
@@ -4028,6 +4931,13 @@ module StartChangeRequestExecution = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.start_change_request_execution_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_change_request_execution_request) =
+    let input = Json_serializers.start_change_request_execution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.StartChangeRequestExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_change_request_execution_result_of_yojson
+      ~error_deserializer
 end
 
 module StartExecutionPreview = struct
@@ -4051,6 +4961,13 @@ module StartExecutionPreview = struct
     let input = Json_serializers.start_execution_preview_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.StartExecutionPreview" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.start_execution_preview_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_execution_preview_request) =
+    let input = Json_serializers.start_execution_preview_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.StartExecutionPreview"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_execution_preview_response_of_yojson
       ~error_deserializer
 end
@@ -4079,6 +4996,12 @@ module StartSession = struct
     let input = Json_serializers.start_session_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.StartSession" ~service ~context
       ~input ~output_deserializer:Json_deserializers.start_session_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_session_request) =
+    let input = Json_serializers.start_session_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.StartSession" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.start_session_response_of_yojson
       ~error_deserializer
 end
 
@@ -4112,6 +5035,13 @@ module StopAutomationExecution = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.stop_automation_execution_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : stop_automation_execution_request) =
+    let input = Json_serializers.stop_automation_execution_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.StopAutomationExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.stop_automation_execution_result_of_yojson
+      ~error_deserializer
 end
 
 module TerminateSession = struct
@@ -4132,6 +5062,13 @@ module TerminateSession = struct
     let input = Json_serializers.terminate_session_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.TerminateSession" ~service ~context
       ~input ~output_deserializer:Json_deserializers.terminate_session_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : terminate_session_request) =
+    let input = Json_serializers.terminate_session_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.TerminateSession"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.terminate_session_response_of_yojson
       ~error_deserializer
 end
 
@@ -4163,6 +5100,13 @@ module UnlabelParameterVersion = struct
     let input = Json_serializers.unlabel_parameter_version_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UnlabelParameterVersion" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.unlabel_parameter_version_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : unlabel_parameter_version_request) =
+    let input = Json_serializers.unlabel_parameter_version_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.UnlabelParameterVersion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.unlabel_parameter_version_result_of_yojson
       ~error_deserializer
 end
@@ -4223,6 +5167,13 @@ module UpdateAssociation = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdateAssociation" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_association_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_association_request) =
+    let input = Json_serializers.update_association_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.UpdateAssociation"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_association_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateAssociationStatus = struct
@@ -4259,6 +5210,13 @@ module UpdateAssociationStatus = struct
     let input = Json_serializers.update_association_status_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdateAssociationStatus" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_association_status_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_association_status_request) =
+    let input = Json_serializers.update_association_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.UpdateAssociationStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_association_status_result_of_yojson
       ~error_deserializer
 end
@@ -4315,6 +5273,12 @@ module UpdateDocument = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdateDocument" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_document_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_document_request) =
+    let input = Json_serializers.update_document_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.UpdateDocument"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_document_result_of_yojson ~error_deserializer
 end
 
 module UpdateDocumentDefaultVersion = struct
@@ -4345,6 +5309,13 @@ module UpdateDocumentDefaultVersion = struct
     let input = Json_serializers.update_document_default_version_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdateDocumentDefaultVersion"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_document_default_version_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_document_default_version_request) =
+    let input = Json_serializers.update_document_default_version_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.UpdateDocumentDefaultVersion" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_document_default_version_result_of_yojson
       ~error_deserializer
 end
@@ -4382,6 +5353,13 @@ module UpdateDocumentMetadata = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_document_metadata_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_document_metadata_request) =
+    let input = Json_serializers.update_document_metadata_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.UpdateDocumentMetadata"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_document_metadata_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateMaintenanceWindow = struct
@@ -4405,6 +5383,13 @@ module UpdateMaintenanceWindow = struct
     let input = Json_serializers.update_maintenance_window_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdateMaintenanceWindow" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_maintenance_window_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_maintenance_window_request) =
+    let input = Json_serializers.update_maintenance_window_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.UpdateMaintenanceWindow" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_maintenance_window_result_of_yojson
       ~error_deserializer
 end
@@ -4432,6 +5417,13 @@ module UpdateMaintenanceWindowTarget = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_maintenance_window_target_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_maintenance_window_target_request) =
+    let input = Json_serializers.update_maintenance_window_target_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.UpdateMaintenanceWindowTarget" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_maintenance_window_target_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateMaintenanceWindowTask = struct
@@ -4457,6 +5449,13 @@ module UpdateMaintenanceWindowTask = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_maintenance_window_task_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_maintenance_window_task_request) =
+    let input = Json_serializers.update_maintenance_window_task_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.UpdateMaintenanceWindowTask" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_maintenance_window_task_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateManagedInstanceRole = struct
@@ -4480,6 +5479,13 @@ module UpdateManagedInstanceRole = struct
     let input = Json_serializers.update_managed_instance_role_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdateManagedInstanceRole" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_managed_instance_role_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_managed_instance_role_request) =
+    let input = Json_serializers.update_managed_instance_role_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AmazonSSM.UpdateManagedInstanceRole" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_managed_instance_role_result_of_yojson
       ~error_deserializer
 end
@@ -4527,6 +5533,12 @@ module UpdateOpsItem = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdateOpsItem" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_ops_item_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_ops_item_request) =
+    let input = Json_serializers.update_ops_item_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.UpdateOpsItem" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.update_ops_item_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateOpsMetadata = struct
@@ -4567,6 +5579,13 @@ module UpdateOpsMetadata = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdateOpsMetadata" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_ops_metadata_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_ops_metadata_request) =
+    let input = Json_serializers.update_ops_metadata_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.UpdateOpsMetadata"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_ops_metadata_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdatePatchBaseline = struct
@@ -4590,6 +5609,13 @@ module UpdatePatchBaseline = struct
     let input = Json_serializers.update_patch_baseline_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdatePatchBaseline" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_patch_baseline_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_patch_baseline_request) =
+    let input = Json_serializers.update_patch_baseline_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.UpdatePatchBaseline"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_patch_baseline_result_of_yojson
       ~error_deserializer
 end
 
@@ -4627,6 +5653,13 @@ module UpdateResourceDataSync = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_resource_data_sync_result_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_resource_data_sync_request) =
+    let input = Json_serializers.update_resource_data_sync_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.UpdateResourceDataSync"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_resource_data_sync_result_of_yojson
+      ~error_deserializer
 end
 
 module UpdateServiceSetting = struct
@@ -4653,6 +5686,13 @@ module UpdateServiceSetting = struct
     let input = Json_serializers.update_service_setting_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AmazonSSM.UpdateServiceSetting" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_service_setting_result_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_service_setting_request) =
+    let input = Json_serializers.update_service_setting_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AmazonSSM.UpdateServiceSetting"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_service_setting_result_of_yojson
       ~error_deserializer
 end

--- a/sdks/ssm/operations.mli
+++ b/sdks/ssm/operations.mli
@@ -21,6 +21,18 @@ module AddTagsToResource : sig
       | `TooManyTagsError of too_many_tags_error
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    add_tags_to_resource_request ->
+    ( add_tags_to_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type
+      | `TooManyTagsError of too_many_tags_error
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Adds or overwrites one or more tags for the specified resource. {i Tags} are metadata that you \
@@ -86,6 +98,20 @@ module AssociateOpsItemRelatedItem : sig
       | `OpsItemRelatedItemAlreadyExistsException of ops_item_related_item_already_exists_exception
       ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_ops_item_related_item_request ->
+    ( associate_ops_item_related_item_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemConflictException of ops_item_conflict_exception
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception
+      | `OpsItemRelatedItemAlreadyExistsException of ops_item_related_item_already_exists_exception
+      ] )
+    result
 end
 [@@ocaml.doc
   "Associates a related item to a Systems Manager OpsCenter OpsItem. For example, you can \
@@ -105,6 +131,17 @@ module CancelCommand : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_command_request ->
     ( cancel_command_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateInstanceId of duplicate_instance_id
+      | `InternalServerError of internal_server_error
+      | `InvalidCommandId of invalid_command_id
+      | `InvalidInstanceId of invalid_instance_id ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_command_request ->
+    ( cancel_command_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DuplicateInstanceId of duplicate_instance_id
       | `InternalServerError of internal_server_error
@@ -131,6 +168,15 @@ module CancelMaintenanceWindowExecution : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_maintenance_window_execution_request ->
+    ( cancel_maintenance_window_execution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc
   "Stops a maintenance window execution that is already in progress and cancels any tasks in the \
@@ -148,6 +194,15 @@ module CreateActivation : sig
     'http_type Smaws_Lib.Context.t ->
     create_activation_request ->
     ( create_activation_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidParameters of invalid_parameters ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_activation_request ->
+    ( create_activation_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidParameters of invalid_parameters ] )
@@ -190,6 +245,26 @@ module CreateAssociation : sig
     'http_type Smaws_Lib.Context.t ->
     create_association_request ->
     ( create_association_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationAlreadyExists of association_already_exists
+      | `AssociationLimitExceeded of association_limit_exceeded
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidOutputLocation of invalid_output_location
+      | `InvalidParameters of invalid_parameters
+      | `InvalidSchedule of invalid_schedule
+      | `InvalidTag of invalid_tag
+      | `InvalidTarget of invalid_target
+      | `InvalidTargetMaps of invalid_target_maps
+      | `UnsupportedPlatformType of unsupported_platform_type ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_association_request ->
+    ( create_association_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationAlreadyExists of association_already_exists
       | `AssociationLimitExceeded of association_limit_exceeded
@@ -254,6 +329,25 @@ module CreateAssociationBatch : sig
       | `InvalidTargetMaps of invalid_target_maps
       | `UnsupportedPlatformType of unsupported_platform_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_association_batch_request ->
+    ( create_association_batch_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationLimitExceeded of association_limit_exceeded
+      | `DuplicateInstanceId of duplicate_instance_id
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidOutputLocation of invalid_output_location
+      | `InvalidParameters of invalid_parameters
+      | `InvalidSchedule of invalid_schedule
+      | `InvalidTarget of invalid_target
+      | `InvalidTargetMaps of invalid_target_maps
+      | `UnsupportedPlatformType of unsupported_platform_type ] )
+    result
 end
 [@@ocaml.doc
   "Associates the specified Amazon Web Services Systems Manager document (SSM document) with the \
@@ -293,6 +387,21 @@ module CreateDocument : sig
       | `NoLongerSupportedException of no_longer_supported_exception
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_document_request ->
+    ( create_document_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DocumentAlreadyExists of document_already_exists
+      | `DocumentLimitExceeded of document_limit_exceeded
+      | `InternalServerError of internal_server_error
+      | `InvalidDocumentContent of invalid_document_content
+      | `InvalidDocumentSchemaVersion of invalid_document_schema_version
+      | `MaxDocumentSizeExceeded of max_document_size_exceeded
+      | `NoLongerSupportedException of no_longer_supported_exception
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Creates a Amazon Web Services Systems Manager (SSM document). An SSM document defines the \
@@ -313,6 +422,16 @@ module CreateMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     create_maintenance_window_request ->
     ( create_maintenance_window_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_maintenance_window_request ->
+    ( create_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
@@ -343,6 +462,18 @@ module CreateOpsItem : sig
     'http_type Smaws_Lib.Context.t ->
     create_ops_item_request ->
     ( create_ops_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemAccessDeniedException of ops_item_access_denied_exception
+      | `OpsItemAlreadyExistsException of ops_item_already_exists_exception
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_ops_item_request ->
+    ( create_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
@@ -384,6 +515,18 @@ module CreateOpsMetadata : sig
       | `OpsMetadataLimitExceededException of ops_metadata_limit_exceeded_exception
       | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_ops_metadata_request ->
+    ( create_ops_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataAlreadyExistsException of ops_metadata_already_exists_exception
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
+      | `OpsMetadataLimitExceededException of ops_metadata_limit_exceeded_exception
+      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
+    result
 end
 [@@ocaml.doc
   "If you create a new application in Application Manager, Amazon Web Services Systems Manager \
@@ -402,6 +545,16 @@ module CreatePatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     create_patch_baseline_request ->
     ( create_patch_baseline_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_patch_baseline_request ->
+    ( create_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
@@ -429,6 +582,18 @@ module CreateResourceDataSync : sig
     'http_type Smaws_Lib.Context.t ->
     create_resource_data_sync_request ->
     ( create_resource_data_sync_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceDataSyncAlreadyExistsException of resource_data_sync_already_exists_exception
+      | `ResourceDataSyncCountExceededException of resource_data_sync_count_exceeded_exception
+      | `ResourceDataSyncInvalidConfigurationException of
+        resource_data_sync_invalid_configuration_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_resource_data_sync_request ->
+    ( create_resource_data_sync_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceDataSyncAlreadyExistsException of resource_data_sync_already_exists_exception
@@ -485,6 +650,17 @@ module DeleteActivation : sig
       | `InvalidActivationId of invalid_activation_id
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_activation_request ->
+    ( delete_activation_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidActivation of invalid_activation
+      | `InvalidActivationId of invalid_activation_id
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Deletes an activation. You aren't required to delete an activation. If you delete an \
@@ -505,6 +681,18 @@ module DeleteAssociation : sig
     'http_type Smaws_Lib.Context.t ->
     delete_association_request ->
     ( delete_association_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidInstanceId of invalid_instance_id
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_association_request ->
+    ( delete_association_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `InternalServerError of internal_server_error
@@ -544,6 +732,18 @@ module DeleteDocument : sig
       | `InvalidDocumentOperation of invalid_document_operation
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_document_request ->
+    ( delete_document_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociatedInstances of associated_instances
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentOperation of invalid_document_operation
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the Amazon Web Services Systems Manager document (SSM document) and all managed node \
@@ -573,6 +773,18 @@ module DeleteInventory : sig
       | `InvalidOptionException of invalid_option_exception
       | `InvalidTypeNameException of invalid_type_name_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_inventory_request ->
+    ( delete_inventory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDeleteInventoryParametersException of invalid_delete_inventory_parameters_exception
+      | `InvalidInventoryRequestException of invalid_inventory_request_exception
+      | `InvalidOptionException of invalid_option_exception
+      | `InvalidTypeNameException of invalid_type_name_exception ] )
+    result
 end
 [@@ocaml.doc
   "Delete a custom inventory type or the data associated with a custom Inventory type. Deleting a \
@@ -586,6 +798,13 @@ module DeleteMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     delete_maintenance_window_request ->
     ( delete_maintenance_window_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_maintenance_window_request ->
+    ( delete_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -602,6 +821,15 @@ module DeleteOpsItem : sig
     'http_type Smaws_Lib.Context.t ->
     delete_ops_item_request ->
     ( delete_ops_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ops_item_request ->
+    ( delete_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
@@ -654,6 +882,16 @@ module DeleteOpsMetadata : sig
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
       | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ops_metadata_request ->
+    ( delete_ops_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Delete OpsMetadata related to an application.\n"]
 
@@ -672,6 +910,15 @@ module DeleteParameter : sig
       | `InternalServerError of internal_server_error
       | `ParameterNotFound of parameter_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_parameter_request ->
+    ( delete_parameter_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ParameterNotFound of parameter_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Delete a parameter from the system. After deleting a parameter, wait for at least 30 seconds to \
@@ -685,6 +932,13 @@ module DeleteParameters : sig
     'http_type Smaws_Lib.Context.t ->
     delete_parameters_request ->
     ( delete_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_parameters_request ->
+    ( delete_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -707,6 +961,15 @@ module DeletePatchBaseline : sig
       | `InternalServerError of internal_server_error
       | `ResourceInUseException of resource_in_use_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_patch_baseline_request ->
+    ( delete_patch_baseline_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceInUseException of resource_in_use_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a patch baseline.\n"]
 
@@ -723,6 +986,17 @@ module DeleteResourceDataSync : sig
     'http_type Smaws_Lib.Context.t ->
     delete_resource_data_sync_request ->
     ( delete_resource_data_sync_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceDataSyncInvalidConfigurationException of
+        resource_data_sync_invalid_configuration_exception
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_data_sync_request ->
+    ( delete_resource_data_sync_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceDataSyncInvalidConfigurationException of
@@ -750,6 +1024,19 @@ module DeleteResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_resource_policy_request ->
     ( delete_resource_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `MalformedResourcePolicyDocumentException of malformed_resource_policy_document_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyConflictException of resource_policy_conflict_exception
+      | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_policy_request ->
+    ( delete_resource_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `MalformedResourcePolicyDocumentException of malformed_resource_policy_document_exception
@@ -793,6 +1080,15 @@ module DeregisterManagedInstance : sig
       | `InternalServerError of internal_server_error
       | `InvalidInstanceId of invalid_instance_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_managed_instance_request ->
+    ( deregister_managed_instance_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id ] )
+    result
 end
 [@@ocaml.doc
   "Removes the server or virtual machine from the list of registered servers.\n\n\
@@ -820,6 +1116,15 @@ module DeregisterPatchBaselineForPatchGroup : sig
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_patch_baseline_for_patch_group_request ->
+    ( deregister_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id ] )
+    result
 end
 [@@ocaml.doc "Removes a patch group from a patch baseline.\n"]
 
@@ -835,6 +1140,16 @@ module DeregisterTargetFromMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     deregister_target_from_maintenance_window_request ->
     ( deregister_target_from_maintenance_window_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `TargetInUseException of target_in_use_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_target_from_maintenance_window_request ->
+    ( deregister_target_from_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
@@ -858,6 +1173,15 @@ module DeregisterTaskFromMaintenanceWindow : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_task_from_maintenance_window_request ->
+    ( deregister_task_from_maintenance_window_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Removes a task from a maintenance window.\n"]
 
@@ -873,6 +1197,16 @@ module DescribeActivations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_activations_request ->
     ( describe_activations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_activations_request ->
+    ( describe_activations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -905,6 +1239,18 @@ module DescribeAssociation : sig
       | `InvalidDocument of invalid_document
       | `InvalidInstanceId of invalid_instance_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_association_request ->
+    ( describe_association_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidAssociationVersion of invalid_association_version
+      | `InvalidDocument of invalid_document
+      | `InvalidInstanceId of invalid_instance_id ] )
+    result
 end
 [@@ocaml.doc
   "Describes the association for the specified target or managed node. If you created the \
@@ -924,6 +1270,17 @@ module DescribeAssociationExecutionTargets : sig
     'http_type Smaws_Lib.Context.t ->
     describe_association_execution_targets_request ->
     ( describe_association_execution_targets_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `AssociationExecutionDoesNotExist of association_execution_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_association_execution_targets_request ->
+    ( describe_association_execution_targets_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `AssociationExecutionDoesNotExist of association_execution_does_not_exist
@@ -950,6 +1307,16 @@ module DescribeAssociationExecutions : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_association_executions_request ->
+    ( describe_association_executions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Views all executions for a specific association ID. \n"]
 
@@ -966,6 +1333,17 @@ module DescribeAutomationExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     describe_automation_executions_request ->
     ( describe_automation_executions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidFilterValue of invalid_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_automation_executions_request ->
+    ( describe_automation_executions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -996,6 +1374,18 @@ module DescribeAutomationStepExecutions : sig
       | `InvalidFilterValue of invalid_filter_value
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_automation_step_executions_request ->
+    ( describe_automation_step_executions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidFilterValue of invalid_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Information about all active and terminated step executions in an Automation workflow.\n"]
@@ -1008,6 +1398,13 @@ module DescribeAvailablePatches : sig
     'http_type Smaws_Lib.Context.t ->
     describe_available_patches_request ->
     ( describe_available_patches_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_available_patches_request ->
+    ( describe_available_patches_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -1030,6 +1427,16 @@ module DescribeDocument : sig
     'http_type Smaws_Lib.Context.t ->
     describe_document_request ->
     ( describe_document_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_document_request ->
+    ( describe_document_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -1060,6 +1467,18 @@ module DescribeDocumentPermission : sig
       | `InvalidNextToken of invalid_next_token
       | `InvalidPermissionType of invalid_permission_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_document_permission_request ->
+    ( describe_document_permission_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentOperation of invalid_document_operation
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidPermissionType of invalid_permission_type ] )
+    result
 end
 [@@ocaml.doc
   "Describes the permissions for a Amazon Web Services Systems Manager document (SSM document). If \
@@ -1083,6 +1502,16 @@ module DescribeEffectiveInstanceAssociations : sig
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_effective_instance_associations_request ->
+    ( describe_effective_instance_associations_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "All associations for the managed nodes.\n"]
 
@@ -1099,6 +1528,17 @@ module DescribeEffectivePatchesForPatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     describe_effective_patches_for_patch_baseline_request ->
     ( describe_effective_patches_for_patch_baseline_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `UnsupportedOperatingSystem of unsupported_operating_system ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_effective_patches_for_patch_baseline_request ->
+    ( describe_effective_patches_for_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
@@ -1127,6 +1567,16 @@ module DescribeInstanceAssociationsStatus : sig
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_associations_status_request ->
+    ( describe_instance_associations_status_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "The status of the associations for the managed nodes.\n"]
 
@@ -1144,6 +1594,18 @@ module DescribeInstanceInformation : sig
     'http_type Smaws_Lib.Context.t ->
     describe_instance_information_request ->
     ( describe_instance_information_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidInstanceInformationFilterValue of invalid_instance_information_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_information_request ->
+    ( describe_instance_information_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -1181,6 +1643,15 @@ module DescribeInstancePatchStates : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_patch_states_request ->
+    ( describe_instance_patch_states_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Retrieves the high-level patch state of one or more managed nodes.\n"]
 
@@ -1196,6 +1667,16 @@ module DescribeInstancePatchStatesForPatchGroup : sig
     'http_type Smaws_Lib.Context.t ->
     describe_instance_patch_states_for_patch_group_request ->
     ( describe_instance_patch_states_for_patch_group_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_patch_states_for_patch_group_request ->
+    ( describe_instance_patch_states_for_patch_group_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -1218,6 +1699,17 @@ module DescribeInstancePatches : sig
     'http_type Smaws_Lib.Context.t ->
     describe_instance_patches_request ->
     ( describe_instance_patches_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_patches_request ->
+    ( describe_instance_patches_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -1254,6 +1746,20 @@ module DescribeInstanceProperties : sig
       | `InvalidInstancePropertyFilterValue of invalid_instance_property_filter_value
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_instance_properties_request ->
+    ( describe_instance_properties_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidActivationId of invalid_activation_id
+      | `InvalidDocument of invalid_document
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidInstancePropertyFilterValue of invalid_instance_property_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "An API operation used by the Systems Manager console to display information about Systems \
@@ -1276,6 +1782,16 @@ module DescribeInventoryDeletions : sig
       | `InvalidDeletionIdException of invalid_deletion_id_exception
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_inventory_deletions_request ->
+    ( describe_inventory_deletions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDeletionIdException of invalid_deletion_id_exception
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Describes a specific delete inventory operation.\n"]
 
@@ -1290,6 +1806,15 @@ module DescribeMaintenanceWindowExecutionTaskInvocations : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_window_execution_task_invocations_request ->
     ( describe_maintenance_window_execution_task_invocations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_execution_task_invocations_request ->
+    ( describe_maintenance_window_execution_task_invocations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -1314,6 +1839,15 @@ module DescribeMaintenanceWindowExecutionTasks : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_execution_tasks_request ->
+    ( describe_maintenance_window_execution_tasks_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "For a given maintenance window execution, lists the tasks that were run.\n"]
 
@@ -1325,6 +1859,13 @@ module DescribeMaintenanceWindowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_window_executions_request ->
     ( describe_maintenance_window_executions_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_executions_request ->
+    ( describe_maintenance_window_executions_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -1348,6 +1889,15 @@ module DescribeMaintenanceWindowSchedule : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_schedule_request ->
+    ( describe_maintenance_window_schedule_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves information about upcoming executions of a maintenance window.\n"]
 
@@ -1366,6 +1916,15 @@ module DescribeMaintenanceWindowTargets : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_targets_request ->
+    ( describe_maintenance_window_targets_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Lists the targets registered with the maintenance window.\n"]
 
@@ -1380,6 +1939,15 @@ module DescribeMaintenanceWindowTasks : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_window_tasks_request ->
     ( describe_maintenance_window_tasks_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_window_tasks_request ->
+    ( describe_maintenance_window_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -1404,6 +1972,13 @@ module DescribeMaintenanceWindows : sig
     ( describe_maintenance_windows_result,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_windows_request ->
+    ( describe_maintenance_windows_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves the maintenance windows in an Amazon Web Services account.\n"]
 
@@ -1415,6 +1990,13 @@ module DescribeMaintenanceWindowsForTarget : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_windows_for_target_request ->
     ( describe_maintenance_windows_for_target_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_maintenance_windows_for_target_request ->
+    ( describe_maintenance_windows_for_target_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -1430,6 +2012,13 @@ module DescribeOpsItems : sig
     'http_type Smaws_Lib.Context.t ->
     describe_ops_items_request ->
     ( describe_ops_items_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_ops_items_request ->
+    ( describe_ops_items_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -1459,6 +2048,18 @@ module DescribeParameters : sig
     'http_type Smaws_Lib.Context.t ->
     describe_parameters_request ->
     ( describe_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidFilterOption of invalid_filter_option
+      | `InvalidFilterValue of invalid_filter_value
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_parameters_request ->
+    ( describe_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -1499,6 +2100,13 @@ module DescribePatchBaselines : sig
     ( describe_patch_baselines_result,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_patch_baselines_request ->
+    ( describe_patch_baselines_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Lists the patch baselines in your Amazon Web Services account.\n"]
 
@@ -1517,6 +2125,15 @@ module DescribePatchGroupState : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_patch_group_state_request ->
+    ( describe_patch_group_state_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Returns high-level aggregated patch compliance state information for a patch group.\n"]
@@ -1531,6 +2148,13 @@ module DescribePatchGroups : sig
     ( describe_patch_groups_result,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_patch_groups_request ->
+    ( describe_patch_groups_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Lists all patch groups that have been registered with patch baselines.\n"]
 
@@ -1542,6 +2166,13 @@ module DescribePatchProperties : sig
     'http_type Smaws_Lib.Context.t ->
     describe_patch_properties_request ->
     ( describe_patch_properties_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_patch_properties_request ->
+    ( describe_patch_properties_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -1601,6 +2232,16 @@ module DescribeSessions : sig
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_sessions_request ->
+    ( describe_sessions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of all active sessions (both connected and disconnected) or terminated \
@@ -1621,6 +2262,19 @@ module DisassociateOpsItemRelatedItem : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_ops_item_related_item_request ->
     ( disassociate_ops_item_related_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemConflictException of ops_item_conflict_exception
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception
+      | `OpsItemRelatedItemAssociationNotFoundException of
+        ops_item_related_item_association_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_ops_item_related_item_request ->
+    ( disassociate_ops_item_related_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemConflictException of ops_item_conflict_exception
@@ -1656,6 +2310,18 @@ module GetAccessToken : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_access_token_request ->
+    ( get_access_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a credentials set to be used with just-in-time node access.\n"]
 
@@ -1670,6 +2336,15 @@ module GetAutomationExecution : sig
     'http_type Smaws_Lib.Context.t ->
     get_automation_execution_request ->
     ( get_automation_execution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_automation_execution_request ->
+    ( get_automation_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
       | `InternalServerError of internal_server_error ] )
@@ -1690,6 +2365,17 @@ module GetCalendarState : sig
     'http_type Smaws_Lib.Context.t ->
     get_calendar_state_request ->
     ( get_calendar_state_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentType of invalid_document_type
+      | `UnsupportedCalendarException of unsupported_calendar_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_calendar_state_request ->
+    ( get_calendar_state_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -1735,6 +2421,18 @@ module GetCommandInvocation : sig
       | `InvalidPluginName of invalid_plugin_name
       | `InvocationDoesNotExist of invocation_does_not_exist ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_command_invocation_request ->
+    ( get_command_invocation_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidCommandId of invalid_command_id
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidPluginName of invalid_plugin_name
+      | `InvocationDoesNotExist of invocation_does_not_exist ] )
+    result
 end
 [@@ocaml.doc
   "Returns detailed information about command execution for an invocation or plugin. The Run \
@@ -1758,6 +2456,13 @@ module GetConnectionStatus : sig
     ( get_connection_status_response,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_connection_status_request ->
+    ( get_connection_status_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the Session Manager connection status for a managed node to determine whether it is \
@@ -1771,6 +2476,13 @@ module GetDefaultPatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     get_default_patch_baseline_request ->
     ( get_default_patch_baseline_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_default_patch_baseline_request ->
+    ( get_default_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -1794,6 +2506,16 @@ module GetDeployablePatchSnapshotForInstance : sig
     'http_type Smaws_Lib.Context.t ->
     get_deployable_patch_snapshot_for_instance_request ->
     ( get_deployable_patch_snapshot_for_instance_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `UnsupportedFeatureRequiredException of unsupported_feature_required_exception
+      | `UnsupportedOperatingSystem of unsupported_operating_system ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_deployable_patch_snapshot_for_instance_request ->
+    ( get_deployable_patch_snapshot_for_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `UnsupportedFeatureRequiredException of unsupported_feature_required_exception
@@ -1829,6 +2551,16 @@ module GetDocument : sig
       | `InvalidDocument of invalid_document
       | `InvalidDocumentVersion of invalid_document_version ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_document_request ->
+    ( get_document_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version ] )
+    result
 end
 [@@ocaml.doc
   "Gets the contents of the specified Amazon Web Services Systems Manager document (SSM document).\n"]
@@ -1844,6 +2576,15 @@ module GetExecutionPreview : sig
     'http_type Smaws_Lib.Context.t ->
     get_execution_preview_request ->
     ( get_execution_preview_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_execution_preview_request ->
+    ( get_execution_preview_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception ] )
@@ -1878,6 +2619,20 @@ module GetInventory : sig
       | `InvalidResultAttributeException of invalid_result_attribute_exception
       | `InvalidTypeNameException of invalid_type_name_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_inventory_request ->
+    ( get_inventory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidAggregatorException of invalid_aggregator_exception
+      | `InvalidFilter of invalid_filter
+      | `InvalidInventoryGroupException of invalid_inventory_group_exception
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidResultAttributeException of invalid_result_attribute_exception
+      | `InvalidTypeNameException of invalid_type_name_exception ] )
+    result
 end
 [@@ocaml.doc
   "Query inventory information. This includes managed node status, such as [Stopped] or \
@@ -1895,6 +2650,16 @@ module GetInventorySchema : sig
     'http_type Smaws_Lib.Context.t ->
     get_inventory_schema_request ->
     ( get_inventory_schema_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidTypeNameException of invalid_type_name_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_inventory_schema_request ->
+    ( get_inventory_schema_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token
@@ -1920,6 +2685,15 @@ module GetMaintenanceWindow : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_request ->
+    ( get_maintenance_window_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves a maintenance window.\n"]
 
@@ -1938,6 +2712,15 @@ module GetMaintenanceWindowExecution : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_execution_request ->
+    ( get_maintenance_window_execution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves details about a specific a maintenance window execution.\n"]
 
@@ -1952,6 +2735,15 @@ module GetMaintenanceWindowExecutionTask : sig
     'http_type Smaws_Lib.Context.t ->
     get_maintenance_window_execution_task_request ->
     ( get_maintenance_window_execution_task_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_execution_task_request ->
+    ( get_maintenance_window_execution_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -1975,6 +2767,15 @@ module GetMaintenanceWindowExecutionTaskInvocation : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_execution_task_invocation_request ->
+    ( get_maintenance_window_execution_task_invocation_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc "Retrieves information about a specific task running on a specific target.\n"]
 
@@ -1989,6 +2790,15 @@ module GetMaintenanceWindowTask : sig
     'http_type Smaws_Lib.Context.t ->
     get_maintenance_window_task_request ->
     ( get_maintenance_window_task_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_maintenance_window_task_request ->
+    ( get_maintenance_window_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -2017,6 +2827,16 @@ module GetOpsItem : sig
     'http_type Smaws_Lib.Context.t ->
     get_ops_item_request ->
     ( get_ops_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemAccessDeniedException of ops_item_access_denied_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ops_item_request ->
+    ( get_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
@@ -2052,6 +2872,16 @@ module GetOpsMetadata : sig
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
       | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ops_metadata_request ->
+    ( get_ops_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "View operational metadata related to an application in Application Manager.\n"]
 
@@ -2070,6 +2900,19 @@ module GetOpsSummary : sig
     'http_type Smaws_Lib.Context.t ->
     get_ops_summary_request ->
     ( get_ops_summary_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidAggregatorException of invalid_aggregator_exception
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidTypeNameException of invalid_type_name_exception
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ops_summary_request ->
+    ( get_ops_summary_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidAggregatorException of invalid_aggregator_exception
@@ -2098,6 +2941,17 @@ module GetParameter : sig
     'http_type Smaws_Lib.Context.t ->
     get_parameter_request ->
     ( get_parameter_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidKeyId of invalid_key_id
+      | `ParameterNotFound of parameter_not_found
+      | `ParameterVersionNotFound of parameter_version_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameter_request ->
+    ( get_parameter_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidKeyId of invalid_key_id
@@ -2134,6 +2988,17 @@ module GetParameterHistory : sig
       | `InvalidNextToken of invalid_next_token
       | `ParameterNotFound of parameter_not_found ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameter_history_request ->
+    ( get_parameter_history_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidKeyId of invalid_key_id
+      | `InvalidNextToken of invalid_next_token
+      | `ParameterNotFound of parameter_not_found ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the history of all changes to a parameter.\n\n\
@@ -2158,6 +3023,15 @@ module GetParameters : sig
     'http_type Smaws_Lib.Context.t ->
     get_parameters_request ->
     ( get_parameters_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidKeyId of invalid_key_id ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameters_request ->
+    ( get_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidKeyId of invalid_key_id ] )
@@ -2187,6 +3061,19 @@ module GetParametersByPath : sig
     'http_type Smaws_Lib.Context.t ->
     get_parameters_by_path_request ->
     ( get_parameters_by_path_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidFilterOption of invalid_filter_option
+      | `InvalidFilterValue of invalid_filter_value
+      | `InvalidKeyId of invalid_key_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_parameters_by_path_request ->
+    ( get_parameters_by_path_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -2227,6 +3114,16 @@ module GetPatchBaseline : sig
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_patch_baseline_request ->
+    ( get_patch_baseline_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id ] )
+    result
 end
 [@@ocaml.doc "Retrieves information about a patch baseline.\n"]
 
@@ -2238,6 +3135,13 @@ module GetPatchBaselineForPatchGroup : sig
     'http_type Smaws_Lib.Context.t ->
     get_patch_baseline_for_patch_group_request ->
     ( get_patch_baseline_for_patch_group_result,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_patch_baseline_for_patch_group_request ->
+    ( get_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -2261,6 +3165,17 @@ module GetResourcePolicies : sig
       | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_resource_policies_request ->
+    ( get_resource_policies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception ]
+    )
+    result
 end
 [@@ocaml.doc "Returns an array of the [Policy] object.\n"]
 
@@ -2275,6 +3190,15 @@ module GetServiceSetting : sig
     'http_type Smaws_Lib.Context.t ->
     get_service_setting_request ->
     ( get_service_setting_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ServiceSettingNotFound of service_setting_not_found ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_service_setting_request ->
+    ( get_service_setting_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found ] )
@@ -2311,6 +3235,18 @@ module LabelParameterVersion : sig
     'http_type Smaws_Lib.Context.t ->
     label_parameter_version_request ->
     ( label_parameter_version_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ParameterNotFound of parameter_not_found
+      | `ParameterVersionLabelLimitExceeded of parameter_version_label_limit_exceeded
+      | `ParameterVersionNotFound of parameter_version_not_found
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    label_parameter_version_request ->
+    ( label_parameter_version_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ParameterNotFound of parameter_not_found
@@ -2382,6 +3318,16 @@ module ListAssociationVersions : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_association_versions_request ->
+    ( list_association_versions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Retrieves all versions of an association for a specific association ID.\n"]
 
@@ -2396,6 +3342,15 @@ module ListAssociations : sig
     'http_type Smaws_Lib.Context.t ->
     list_associations_request ->
     ( list_associations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_associations_request ->
+    ( list_associations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token ] )
@@ -2421,6 +3376,18 @@ module ListCommandInvocations : sig
     'http_type Smaws_Lib.Context.t ->
     list_command_invocations_request ->
     ( list_command_invocations_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidCommandId of invalid_command_id
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_command_invocations_request ->
+    ( list_command_invocations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidCommandId of invalid_command_id
@@ -2456,6 +3423,18 @@ module ListCommands : sig
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_commands_request ->
+    ( list_commands_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidCommandId of invalid_command_id
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "Lists the commands requested by users of the Amazon Web Services account.\n"]
 
@@ -2473,6 +3452,18 @@ module ListComplianceItems : sig
     'http_type Smaws_Lib.Context.t ->
     list_compliance_items_request ->
     ( list_compliance_items_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_compliance_items_request ->
+    ( list_compliance_items_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -2503,6 +3494,16 @@ module ListComplianceSummaries : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_compliance_summaries_request ->
+    ( list_compliance_summaries_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Returns a summary count of compliant and non-compliant resources for a compliance type. For \
@@ -2522,6 +3523,17 @@ module ListDocumentMetadataHistory : sig
     'http_type Smaws_Lib.Context.t ->
     list_document_metadata_history_request ->
     ( list_document_metadata_history_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_document_metadata_history_request ->
+    ( list_document_metadata_history_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -2555,6 +3567,16 @@ module ListDocumentVersions : sig
       | `InvalidDocument of invalid_document
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_document_versions_request ->
+    ( list_document_versions_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc "List all versions for a document.\n"]
 
@@ -2570,6 +3592,16 @@ module ListDocuments : sig
     'http_type Smaws_Lib.Context.t ->
     list_documents_request ->
     ( list_documents_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilterKey of invalid_filter_key
+      | `InvalidNextToken of invalid_next_token ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_documents_request ->
+    ( list_documents_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
@@ -2601,6 +3633,18 @@ module ListInventoryEntries : sig
       | `InvalidNextToken of invalid_next_token
       | `InvalidTypeNameException of invalid_type_name_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_inventory_entries_request ->
+    ( list_inventory_entries_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNextToken of invalid_next_token
+      | `InvalidTypeNameException of invalid_type_name_exception ] )
+    result
 end
 [@@ocaml.doc "A list of inventory items returned by the request.\n"]
 
@@ -2618,6 +3662,18 @@ module ListNodes : sig
     'http_type Smaws_Lib.Context.t ->
     list_nodes_request ->
     ( list_nodes_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_nodes_request ->
+    ( list_nodes_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
@@ -2651,6 +3707,19 @@ module ListNodesSummary : sig
       | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_nodes_summary_request ->
+    ( list_nodes_summary_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidAggregatorException of invalid_aggregator_exception
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Generates a summary of managed instance/node metadata based on the filters and aggregators you \
@@ -2669,6 +3738,17 @@ module ListOpsItemEvents : sig
     'http_type Smaws_Lib.Context.t ->
     list_ops_item_events_request ->
     ( list_ops_item_events_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ops_item_events_request ->
+    ( list_ops_item_events_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
@@ -2696,6 +3776,15 @@ module ListOpsItemRelatedItems : sig
       | `InternalServerError of internal_server_error
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ops_item_related_items_request ->
+    ( list_ops_item_related_items_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all related-item resources associated with a Systems Manager OpsCenter OpsItem. OpsCenter \
@@ -2712,6 +3801,15 @@ module ListOpsMetadata : sig
     'http_type Smaws_Lib.Context.t ->
     list_ops_metadata_request ->
     ( list_ops_metadata_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ops_metadata_request ->
+    ( list_ops_metadata_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception ] )
@@ -2738,6 +3836,16 @@ module ListResourceComplianceSummaries : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_compliance_summaries_request ->
+    ( list_resource_compliance_summaries_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidFilter of invalid_filter
+      | `InvalidNextToken of invalid_next_token ] )
+    result
 end
 [@@ocaml.doc
   "Returns a resource-level summary count. The summary includes information about compliant and \
@@ -2757,6 +3865,17 @@ module ListResourceDataSync : sig
     'http_type Smaws_Lib.Context.t ->
     list_resource_data_sync_request ->
     ( list_resource_data_sync_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidNextToken of invalid_next_token
+      | `ResourceDataSyncInvalidConfigurationException of
+        resource_data_sync_invalid_configuration_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_data_sync_request ->
+    ( list_resource_data_sync_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token
@@ -2792,6 +3911,16 @@ module ListTagsForResource : sig
       | `InvalidResourceId of invalid_resource_id
       | `InvalidResourceType of invalid_resource_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type ] )
+    result
 end
 [@@ocaml.doc
   "Returns a list of the tags assigned to the specified resource.\n\n\
@@ -2812,6 +3941,18 @@ module ModifyDocumentPermission : sig
     'http_type Smaws_Lib.Context.t ->
     modify_document_permission_request ->
     ( modify_document_permission_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DocumentLimitExceeded of document_limit_exceeded
+      | `DocumentPermissionLimit of document_permission_limit
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidPermissionType of invalid_permission_type ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    modify_document_permission_request ->
+    ( modify_document_permission_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DocumentLimitExceeded of document_limit_exceeded
       | `DocumentPermissionLimit of document_permission_limit
@@ -2842,6 +3983,20 @@ module PutComplianceItems : sig
     'http_type Smaws_Lib.Context.t ->
     put_compliance_items_request ->
     ( put_compliance_items_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ComplianceTypeCountLimitExceededException of compliance_type_count_limit_exceeded_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidItemContentException of invalid_item_content_exception
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type
+      | `ItemSizeLimitExceededException of item_size_limit_exceeded_exception
+      | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_compliance_items_request ->
+    ( put_compliance_items_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ComplianceTypeCountLimitExceededException of compliance_type_count_limit_exceeded_exception
       | `InternalServerError of internal_server_error
@@ -2956,6 +4111,26 @@ module PutInventory : sig
       | `UnsupportedInventorySchemaVersionException of
         unsupported_inventory_schema_version_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_inventory_request ->
+    ( put_inventory_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `CustomSchemaCountLimitExceededException of custom_schema_count_limit_exceeded_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidInventoryItemContextException of invalid_inventory_item_context_exception
+      | `InvalidItemContentException of invalid_item_content_exception
+      | `InvalidTypeNameException of invalid_type_name_exception
+      | `ItemContentMismatchException of item_content_mismatch_exception
+      | `ItemSizeLimitExceededException of item_size_limit_exceeded_exception
+      | `SubTypeCountLimitExceededException of sub_type_count_limit_exceeded_exception
+      | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception
+      | `UnsupportedInventoryItemContextException of unsupported_inventory_item_context_exception
+      | `UnsupportedInventorySchemaVersionException of
+        unsupported_inventory_schema_version_exception ] )
+    result
 end
 [@@ocaml.doc
   "Bulk update custom inventory items on one or more managed nodes. The request adds an inventory \
@@ -3002,6 +4177,28 @@ module PutParameter : sig
       | `TooManyUpdates of too_many_updates
       | `UnsupportedParameterType of unsupported_parameter_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_parameter_request ->
+    ( put_parameter_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `HierarchyLevelLimitExceededException of hierarchy_level_limit_exceeded_exception
+      | `HierarchyTypeMismatchException of hierarchy_type_mismatch_exception
+      | `IncompatiblePolicyException of incompatible_policy_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidAllowedPatternException of invalid_allowed_pattern_exception
+      | `InvalidKeyId of invalid_key_id
+      | `InvalidPolicyAttributeException of invalid_policy_attribute_exception
+      | `InvalidPolicyTypeException of invalid_policy_type_exception
+      | `ParameterAlreadyExists of parameter_already_exists
+      | `ParameterLimitExceeded of parameter_limit_exceeded
+      | `ParameterMaxVersionLimitExceeded of parameter_max_version_limit_exceeded
+      | `ParameterPatternMismatchException of parameter_pattern_mismatch_exception
+      | `PoliciesLimitExceededException of policies_limit_exceeded_exception
+      | `TooManyUpdates of too_many_updates
+      | `UnsupportedParameterType of unsupported_parameter_type ] )
+    result
 end
 [@@ocaml.doc "Create or update a parameter in Parameter Store.\n"]
 
@@ -3021,6 +4218,20 @@ module PutResourcePolicy : sig
     'http_type Smaws_Lib.Context.t ->
     put_resource_policy_request ->
     ( put_resource_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `MalformedResourcePolicyDocumentException of malformed_resource_policy_document_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ResourcePolicyConflictException of resource_policy_conflict_exception
+      | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception
+      | `ResourcePolicyLimitExceededException of resource_policy_limit_exceeded_exception
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_resource_policy_request ->
+    ( put_resource_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `MalformedResourcePolicyDocumentException of malformed_resource_policy_document_exception
@@ -3092,6 +4303,16 @@ module RegisterDefaultPatchBaseline : sig
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_default_patch_baseline_request ->
+    ( register_default_patch_baseline_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id ] )
+    result
 end
 [@@ocaml.doc
   "Defines the default patch baseline for the relevant operating system.\n\n\
@@ -3122,6 +4343,18 @@ module RegisterPatchBaselineForPatchGroup : sig
       | `InvalidResourceId of invalid_resource_id
       | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_patch_baseline_for_patch_group_request ->
+    ( register_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AlreadyExistsException of already_exists_exception
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc "Registers a patch baseline for a patch group.\n"]
 
@@ -3138,6 +4371,17 @@ module RegisterTargetWithMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     register_target_with_maintenance_window_request ->
     ( register_target_with_maintenance_window_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_target_with_maintenance_window_request ->
+    ( register_target_with_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
@@ -3168,6 +4412,18 @@ module RegisterTaskWithMaintenanceWindow : sig
       | `InternalServerError of internal_server_error
       | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_task_with_maintenance_window_request ->
+    ( register_task_with_maintenance_window_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `FeatureNotAvailableException of feature_not_available_exception
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc "Adds a new task to a maintenance window.\n"]
 
@@ -3190,6 +4446,17 @@ module RemoveTagsFromResource : sig
       | `InvalidResourceType of invalid_resource_type
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    remove_tags_from_resource_request ->
+    ( remove_tags_from_resource_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidResourceId of invalid_resource_id
+      | `InvalidResourceType of invalid_resource_type
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc "Removes tag keys from the specified resource.\n"]
 
@@ -3205,6 +4472,16 @@ module ResetServiceSetting : sig
     'http_type Smaws_Lib.Context.t ->
     reset_service_setting_request ->
     ( reset_service_setting_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ServiceSettingNotFound of service_setting_not_found
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reset_service_setting_request ->
+    ( reset_service_setting_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found
@@ -3243,6 +4520,15 @@ module ResumeSession : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    resume_session_request ->
+    ( resume_session_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc
   "Reconnects a session to a managed node after it has been disconnected. Connections can be \
@@ -3265,6 +4551,17 @@ module SendAutomationSignal : sig
     'http_type Smaws_Lib.Context.t ->
     send_automation_signal_request ->
     ( send_automation_signal_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
+      | `AutomationStepNotFoundException of automation_step_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidAutomationSignalException of invalid_automation_signal_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_automation_signal_request ->
+    ( send_automation_signal_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
       | `AutomationStepNotFoundException of automation_step_not_found_exception
@@ -3309,6 +4606,24 @@ module SendCommand : sig
       | `MaxDocumentSizeExceeded of max_document_size_exceeded
       | `UnsupportedPlatformType of unsupported_platform_type ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    send_command_request ->
+    ( send_command_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DuplicateInstanceId of duplicate_instance_id
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidInstanceId of invalid_instance_id
+      | `InvalidNotificationConfig of invalid_notification_config
+      | `InvalidOutputFolder of invalid_output_folder
+      | `InvalidParameters of invalid_parameters
+      | `InvalidRole of invalid_role
+      | `MaxDocumentSizeExceeded of max_document_size_exceeded
+      | `UnsupportedPlatformType of unsupported_platform_type ] )
+    result
 end
 [@@ocaml.doc "Runs commands on one or more managed nodes.\n"]
 
@@ -3335,6 +4650,19 @@ module StartAccessRequest : sig
       | `ThrottlingException of throttling_exception
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_access_request_request ->
+    ( start_access_request_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AccessDeniedException of access_denied_exception
+      | `InternalServerError of internal_server_error
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `ServiceQuotaExceededException of service_quota_exceeded_exception
+      | `ThrottlingException of throttling_exception
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc "Starts the workflow for just-in-time node access sessions.\n"]
 
@@ -3349,6 +4677,15 @@ module StartAssociationsOnce : sig
     'http_type Smaws_Lib.Context.t ->
     start_associations_once_request ->
     ( start_associations_once_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InvalidAssociation of invalid_association ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_associations_once_request ->
+    ( start_associations_once_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `InvalidAssociation of invalid_association ] )
@@ -3376,6 +4713,22 @@ module StartAutomationExecution : sig
     'http_type Smaws_Lib.Context.t ->
     start_automation_execution_request ->
     ( start_automation_execution_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationDefinitionNotFoundException of automation_definition_not_found_exception
+      | `AutomationDefinitionVersionNotFoundException of
+        automation_definition_version_not_found_exception
+      | `AutomationExecutionLimitExceededException of automation_execution_limit_exceeded_exception
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `InvalidAutomationExecutionParametersException of
+        invalid_automation_execution_parameters_exception
+      | `InvalidTarget of invalid_target ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_automation_execution_request ->
+    ( start_automation_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationDefinitionNotFoundException of automation_definition_not_found_exception
       | `AutomationDefinitionVersionNotFoundException of
@@ -3421,6 +4774,23 @@ module StartChangeRequestExecution : sig
         invalid_automation_execution_parameters_exception
       | `NoLongerSupportedException of no_longer_supported_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_change_request_execution_request ->
+    ( start_change_request_execution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationDefinitionNotApprovedException of automation_definition_not_approved_exception
+      | `AutomationDefinitionNotFoundException of automation_definition_not_found_exception
+      | `AutomationDefinitionVersionNotFoundException of
+        automation_definition_version_not_found_exception
+      | `AutomationExecutionLimitExceededException of automation_execution_limit_exceeded_exception
+      | `IdempotentParameterMismatch of idempotent_parameter_mismatch
+      | `InternalServerError of internal_server_error
+      | `InvalidAutomationExecutionParametersException of
+        invalid_automation_execution_parameters_exception
+      | `NoLongerSupportedException of no_longer_supported_exception ] )
+    result
 end
 [@@ocaml.doc
   " Amazon Web Services Systems Manager Change Manager is no longer open to new customers. \
@@ -3447,6 +4817,15 @@ module StartExecutionPreview : sig
       | `InternalServerError of internal_server_error
       | `ValidationException of validation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_execution_preview_request ->
+    ( start_execution_preview_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ValidationException of validation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Initiates the process of creating a preview showing the effects that running a specified \
@@ -3464,6 +4843,16 @@ module StartSession : sig
     'http_type Smaws_Lib.Context.t ->
     start_session_request ->
     ( start_session_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `TargetNotConnected of target_not_connected ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_session_request ->
+    ( start_session_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -3503,6 +4892,16 @@ module StopAutomationExecution : sig
       | `InternalServerError of internal_server_error
       | `InvalidAutomationStatusUpdateException of invalid_automation_status_update_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    stop_automation_execution_request ->
+    ( stop_automation_execution_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
+      | `InternalServerError of internal_server_error
+      | `InvalidAutomationStatusUpdateException of invalid_automation_status_update_exception ] )
+    result
 end
 [@@ocaml.doc "Stop an Automation that is currently running.\n"]
 
@@ -3514,6 +4913,13 @@ module TerminateSession : sig
     'http_type Smaws_Lib.Context.t ->
     terminate_session_request ->
     ( terminate_session_response,
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    terminate_session_request ->
+    ( terminate_session_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
     result
 end
@@ -3534,6 +4940,17 @@ module UnlabelParameterVersion : sig
     'http_type Smaws_Lib.Context.t ->
     unlabel_parameter_version_request ->
     ( unlabel_parameter_version_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ParameterNotFound of parameter_not_found
+      | `ParameterVersionNotFound of parameter_version_not_found
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    unlabel_parameter_version_request ->
+    ( unlabel_parameter_version_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ParameterNotFound of parameter_not_found
@@ -3570,6 +4987,26 @@ module UpdateAssociation : sig
     'http_type Smaws_Lib.Context.t ->
     update_association_request ->
     ( update_association_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `AssociationVersionLimitExceeded of association_version_limit_exceeded
+      | `InternalServerError of internal_server_error
+      | `InvalidAssociationVersion of invalid_association_version
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentVersion of invalid_document_version
+      | `InvalidOutputLocation of invalid_output_location
+      | `InvalidParameters of invalid_parameters
+      | `InvalidSchedule of invalid_schedule
+      | `InvalidTarget of invalid_target
+      | `InvalidTargetMaps of invalid_target_maps
+      | `InvalidUpdate of invalid_update
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_association_request ->
+    ( update_association_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `AssociationVersionLimitExceeded of association_version_limit_exceeded
@@ -3633,6 +5070,19 @@ module UpdateAssociationStatus : sig
       | `StatusUnchanged of status_unchanged
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_association_status_request ->
+    ( update_association_status_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `AssociationDoesNotExist of association_does_not_exist
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidInstanceId of invalid_instance_id
+      | `StatusUnchanged of status_unchanged
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   "Updates the status of the Amazon Web Services Systems Manager document (SSM document) \
@@ -3673,6 +5123,23 @@ module UpdateDocument : sig
       | `InvalidDocumentVersion of invalid_document_version
       | `MaxDocumentSizeExceeded of max_document_size_exceeded ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_document_request ->
+    ( update_document_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DocumentVersionLimitExceeded of document_version_limit_exceeded
+      | `DuplicateDocumentContent of duplicate_document_content
+      | `DuplicateDocumentVersionName of duplicate_document_version_name
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentContent of invalid_document_content
+      | `InvalidDocumentOperation of invalid_document_operation
+      | `InvalidDocumentSchemaVersion of invalid_document_schema_version
+      | `InvalidDocumentVersion of invalid_document_version
+      | `MaxDocumentSizeExceeded of max_document_size_exceeded ] )
+    result
 end
 [@@ocaml.doc "Updates one or more values for an SSM document.\n"]
 
@@ -3689,6 +5156,17 @@ module UpdateDocumentDefaultVersion : sig
     'http_type Smaws_Lib.Context.t ->
     update_document_default_version_request ->
     ( update_document_default_version_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentSchemaVersion of invalid_document_schema_version
+      | `InvalidDocumentVersion of invalid_document_version ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_document_default_version_request ->
+    ( update_document_default_version_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
@@ -3724,6 +5202,18 @@ module UpdateDocumentMetadata : sig
       | `InvalidDocumentVersion of invalid_document_version
       | `TooManyUpdates of too_many_updates ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_document_metadata_request ->
+    ( update_document_metadata_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidDocument of invalid_document
+      | `InvalidDocumentOperation of invalid_document_operation
+      | `InvalidDocumentVersion of invalid_document_version
+      | `TooManyUpdates of too_many_updates ] )
+    result
 end
 [@@ocaml.doc
   " Amazon Web Services Systems Manager Change Manager is no longer open to new customers. \
@@ -3750,6 +5240,15 @@ module UpdateMaintenanceWindow : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_maintenance_window_request ->
+    ( update_maintenance_window_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing maintenance window. Only specified parameters are modified.\n\n\
@@ -3772,6 +5271,15 @@ module UpdateMaintenanceWindowTarget : sig
     'http_type Smaws_Lib.Context.t ->
     update_maintenance_window_target_request ->
     ( update_maintenance_window_target_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_maintenance_window_target_request ->
+    ( update_maintenance_window_target_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -3815,6 +5323,15 @@ module UpdateMaintenanceWindowTask : sig
     'http_type Smaws_Lib.Context.t ->
     update_maintenance_window_task_request ->
     ( update_maintenance_window_task_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_maintenance_window_task_request ->
+    ( update_maintenance_window_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -3882,6 +5399,15 @@ module UpdateManagedInstanceRole : sig
       | `InternalServerError of internal_server_error
       | `InvalidInstanceId of invalid_instance_id ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_managed_instance_role_request ->
+    ( update_managed_instance_role_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `InvalidInstanceId of invalid_instance_id ] )
+    result
 end
 [@@ocaml.doc
   "Changes the Identity and Access Management (IAM) role that is assigned to the on-premises \
@@ -3904,6 +5430,20 @@ module UpdateOpsItem : sig
     'http_type Smaws_Lib.Context.t ->
     update_ops_item_request ->
     ( update_ops_item_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsItemAccessDeniedException of ops_item_access_denied_exception
+      | `OpsItemAlreadyExistsException of ops_item_already_exists_exception
+      | `OpsItemConflictException of ops_item_conflict_exception
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
+      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_ops_item_request ->
+    ( update_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
@@ -3947,6 +5487,18 @@ module UpdateOpsMetadata : sig
       | `OpsMetadataNotFoundException of ops_metadata_not_found_exception
       | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_ops_metadata_request ->
+    ( update_ops_metadata_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
+      | `OpsMetadataKeyLimitExceededException of ops_metadata_key_limit_exceeded_exception
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception
+      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
+    result
 end
 [@@ocaml.doc
   "Amazon Web Services Systems Manager calls this API operation when you edit OpsMetadata in \
@@ -3963,6 +5515,15 @@ module UpdatePatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     update_patch_baseline_request ->
     ( update_patch_baseline_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DoesNotExistException of does_not_exist_exception
+      | `InternalServerError of internal_server_error ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_patch_baseline_request ->
+    ( update_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error ] )
@@ -3996,6 +5557,18 @@ module UpdateResourceDataSync : sig
         resource_data_sync_invalid_configuration_exception
       | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_resource_data_sync_request ->
+    ( update_resource_data_sync_result Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ResourceDataSyncConflictException of resource_data_sync_conflict_exception
+      | `ResourceDataSyncInvalidConfigurationException of
+        resource_data_sync_invalid_configuration_exception
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Update a resource data sync. After you create a resource data sync for a Region, you can't \
@@ -4021,6 +5594,16 @@ module UpdateServiceSetting : sig
     'http_type Smaws_Lib.Context.t ->
     update_service_setting_request ->
     ( update_service_setting_result,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InternalServerError of internal_server_error
+      | `ServiceSettingNotFound of service_setting_not_found
+      | `TooManyUpdates of too_many_updates ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_service_setting_request ->
+    ( update_service_setting_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found

--- a/sdks/ssm/operations.mli
+++ b/sdks/ssm/operations.mli
@@ -31,7 +31,8 @@ module AddTagsToResource : sig
       | `InvalidResourceId of invalid_resource_id
       | `InvalidResourceType of invalid_resource_type
       | `TooManyTagsError of too_many_tags_error
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -110,7 +111,8 @@ module AssociateOpsItemRelatedItem : sig
       | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
       | `OpsItemNotFoundException of ops_item_not_found_exception
       | `OpsItemRelatedItemAlreadyExistsException of ops_item_related_item_already_exists_exception
-      ] )
+      ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -146,7 +148,8 @@ module CancelCommand : sig
       | `DuplicateInstanceId of duplicate_instance_id
       | `InternalServerError of internal_server_error
       | `InvalidCommandId of invalid_command_id
-      | `InvalidInstanceId of invalid_instance_id ] )
+      | `InvalidInstanceId of invalid_instance_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -175,7 +178,8 @@ module CancelMaintenanceWindowExecution : sig
     ( cancel_maintenance_window_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -205,7 +209,8 @@ module CreateActivation : sig
     ( create_activation_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidParameters of invalid_parameters ] )
+      | `InvalidParameters of invalid_parameters ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -278,7 +283,8 @@ module CreateAssociation : sig
       | `InvalidTag of invalid_tag
       | `InvalidTarget of invalid_target
       | `InvalidTargetMaps of invalid_target_maps
-      | `UnsupportedPlatformType of unsupported_platform_type ] )
+      | `UnsupportedPlatformType of unsupported_platform_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -346,7 +352,8 @@ module CreateAssociationBatch : sig
       | `InvalidSchedule of invalid_schedule
       | `InvalidTarget of invalid_target
       | `InvalidTargetMaps of invalid_target_maps
-      | `UnsupportedPlatformType of unsupported_platform_type ] )
+      | `UnsupportedPlatformType of unsupported_platform_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -400,7 +407,8 @@ module CreateDocument : sig
       | `InvalidDocumentSchemaVersion of invalid_document_schema_version
       | `MaxDocumentSizeExceeded of max_document_size_exceeded
       | `NoLongerSupportedException of no_longer_supported_exception
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -435,7 +443,8 @@ module CreateMaintenanceWindow : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -479,7 +488,8 @@ module CreateOpsItem : sig
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
       | `OpsItemAlreadyExistsException of ops_item_already_exists_exception
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
-      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception ] )
+      | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -525,7 +535,8 @@ module CreateOpsMetadata : sig
       | `OpsMetadataAlreadyExistsException of ops_metadata_already_exists_exception
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
       | `OpsMetadataLimitExceededException of ops_metadata_limit_exceeded_exception
-      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
+      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -558,7 +569,8 @@ module CreatePatchBaseline : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -599,7 +611,8 @@ module CreateResourceDataSync : sig
       | `ResourceDataSyncAlreadyExistsException of resource_data_sync_already_exists_exception
       | `ResourceDataSyncCountExceededException of resource_data_sync_count_exceeded_exception
       | `ResourceDataSyncInvalidConfigurationException of
-        resource_data_sync_invalid_configuration_exception ] )
+        resource_data_sync_invalid_configuration_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -659,7 +672,8 @@ module DeleteActivation : sig
       | `InternalServerError of internal_server_error
       | `InvalidActivation of invalid_activation
       | `InvalidActivationId of invalid_activation_id
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -698,7 +712,8 @@ module DeleteAssociation : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidInstanceId of invalid_instance_id
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -742,7 +757,8 @@ module DeleteDocument : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidDocumentOperation of invalid_document_operation
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -783,7 +799,8 @@ module DeleteInventory : sig
       | `InvalidDeleteInventoryParametersException of invalid_delete_inventory_parameters_exception
       | `InvalidInventoryRequestException of invalid_inventory_request_exception
       | `InvalidOptionException of invalid_option_exception
-      | `InvalidTypeNameException of invalid_type_name_exception ] )
+      | `InvalidTypeNameException of invalid_type_name_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -805,7 +822,8 @@ module DeleteMaintenanceWindow : sig
     'http_type Smaws_Lib.Context.t ->
     delete_maintenance_window_request ->
     ( delete_maintenance_window_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a maintenance window.\n"]
@@ -832,7 +850,8 @@ module DeleteOpsItem : sig
     ( delete_ops_item_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -890,7 +909,8 @@ module DeleteOpsMetadata : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
-      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Delete OpsMetadata related to an application.\n"]
@@ -917,7 +937,8 @@ module DeleteParameter : sig
     ( delete_parameter_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ParameterNotFound of parameter_not_found ] )
+      | `ParameterNotFound of parameter_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -939,7 +960,8 @@ module DeleteParameters : sig
     'http_type Smaws_Lib.Context.t ->
     delete_parameters_request ->
     ( delete_parameters_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -968,7 +990,8 @@ module DeletePatchBaseline : sig
     ( delete_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceInUseException of resource_in_use_exception ] )
+      | `ResourceInUseException of resource_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a patch baseline.\n"]
@@ -1001,7 +1024,8 @@ module DeleteResourceDataSync : sig
       | `InternalServerError of internal_server_error
       | `ResourceDataSyncInvalidConfigurationException of
         resource_data_sync_invalid_configuration_exception
-      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1043,7 +1067,8 @@ module DeleteResourcePolicy : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyConflictException of resource_policy_conflict_exception
       | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception
-      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ] )
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1087,7 +1112,8 @@ module DeregisterManagedInstance : sig
     ( deregister_managed_instance_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidInstanceId of invalid_instance_id ] )
+      | `InvalidInstanceId of invalid_instance_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1123,7 +1149,8 @@ module DeregisterPatchBaselineForPatchGroup : sig
     ( deregister_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidResourceId of invalid_resource_id ] )
+      | `InvalidResourceId of invalid_resource_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a patch group from a patch baseline.\n"]
@@ -1153,7 +1180,8 @@ module DeregisterTargetFromMaintenanceWindow : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
-      | `TargetInUseException of target_in_use_exception ] )
+      | `TargetInUseException of target_in_use_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a target from a maintenance window.\n"]
@@ -1180,7 +1208,8 @@ module DeregisterTaskFromMaintenanceWindow : sig
     ( deregister_task_from_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a task from a maintenance window.\n"]
@@ -1210,7 +1239,8 @@ module DescribeActivations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1249,7 +1279,8 @@ module DescribeAssociation : sig
       | `InternalServerError of internal_server_error
       | `InvalidAssociationVersion of invalid_association_version
       | `InvalidDocument of invalid_document
-      | `InvalidInstanceId of invalid_instance_id ] )
+      | `InvalidInstanceId of invalid_instance_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1285,7 +1316,8 @@ module DescribeAssociationExecutionTargets : sig
       | `AssociationDoesNotExist of association_does_not_exist
       | `AssociationExecutionDoesNotExist of association_execution_does_not_exist
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Views information about a specific execution of a specific association.\n"]
@@ -1315,7 +1347,8 @@ module DescribeAssociationExecutions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Views all executions for a specific association ID. \n"]
@@ -1348,7 +1381,8 @@ module DescribeAutomationExecutions : sig
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidFilterValue of invalid_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides details about all active and terminated Automation executions.\n"]
@@ -1384,7 +1418,8 @@ module DescribeAutomationStepExecutions : sig
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidFilterValue of invalid_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1405,7 +1440,8 @@ module DescribeAvailablePatches : sig
     'http_type Smaws_Lib.Context.t ->
     describe_available_patches_request ->
     ( describe_available_patches_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1440,7 +1476,8 @@ module DescribeDocument : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `InvalidDocumentVersion of invalid_document_version ] )
+      | `InvalidDocumentVersion of invalid_document_version ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1477,7 +1514,8 @@ module DescribeDocumentPermission : sig
       | `InvalidDocument of invalid_document
       | `InvalidDocumentOperation of invalid_document_operation
       | `InvalidNextToken of invalid_next_token
-      | `InvalidPermissionType of invalid_permission_type ] )
+      | `InvalidPermissionType of invalid_permission_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1510,7 +1548,8 @@ module DescribeEffectiveInstanceAssociations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "All associations for the managed nodes.\n"]
@@ -1543,7 +1582,8 @@ module DescribeEffectivePatchesForPatchBaseline : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id
-      | `UnsupportedOperatingSystem of unsupported_operating_system ] )
+      | `UnsupportedOperatingSystem of unsupported_operating_system ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1575,7 +1615,8 @@ module DescribeInstanceAssociationsStatus : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "The status of the associations for the managed nodes.\n"]
@@ -1611,7 +1652,8 @@ module DescribeInstanceInformation : sig
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidInstanceInformationFilterValue of invalid_instance_information_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1650,7 +1692,8 @@ module DescribeInstancePatchStates : sig
     ( describe_instance_patch_states_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the high-level patch state of one or more managed nodes.\n"]
@@ -1680,7 +1723,8 @@ module DescribeInstancePatchStatesForPatchGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1714,7 +1758,8 @@ module DescribeInstancePatches : sig
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1758,7 +1803,8 @@ module DescribeInstanceProperties : sig
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidInstancePropertyFilterValue of invalid_instance_property_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1790,7 +1836,8 @@ module DescribeInventoryDeletions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDeletionIdException of invalid_deletion_id_exception
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes a specific delete inventory operation.\n"]
@@ -1817,7 +1864,8 @@ module DescribeMaintenanceWindowExecutionTaskInvocations : sig
     ( describe_maintenance_window_execution_task_invocations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1846,7 +1894,8 @@ module DescribeMaintenanceWindowExecutionTasks : sig
     ( describe_maintenance_window_execution_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "For a given maintenance window execution, lists the tasks that were run.\n"]
@@ -1866,7 +1915,8 @@ module DescribeMaintenanceWindowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_window_executions_request ->
     ( describe_maintenance_window_executions_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1896,7 +1946,8 @@ module DescribeMaintenanceWindowSchedule : sig
     ( describe_maintenance_window_schedule_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves information about upcoming executions of a maintenance window.\n"]
@@ -1923,7 +1974,8 @@ module DescribeMaintenanceWindowTargets : sig
     ( describe_maintenance_window_targets_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the targets registered with the maintenance window.\n"]
@@ -1950,7 +2002,8 @@ module DescribeMaintenanceWindowTasks : sig
     ( describe_maintenance_window_tasks_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1977,7 +2030,8 @@ module DescribeMaintenanceWindows : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_windows_request ->
     ( describe_maintenance_windows_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the maintenance windows in an Amazon Web Services account.\n"]
@@ -1997,7 +2051,8 @@ module DescribeMaintenanceWindowsForTarget : sig
     'http_type Smaws_Lib.Context.t ->
     describe_maintenance_windows_for_target_request ->
     ( describe_maintenance_windows_for_target_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2019,7 +2074,8 @@ module DescribeOpsItems : sig
     'http_type Smaws_Lib.Context.t ->
     describe_ops_items_request ->
     ( describe_ops_items_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2065,7 +2121,8 @@ module DescribeParameters : sig
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidFilterOption of invalid_filter_option
       | `InvalidFilterValue of invalid_filter_value
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2105,7 +2162,8 @@ module DescribePatchBaselines : sig
     'http_type Smaws_Lib.Context.t ->
     describe_patch_baselines_request ->
     ( describe_patch_baselines_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the patch baselines in your Amazon Web Services account.\n"]
@@ -2132,7 +2190,8 @@ module DescribePatchGroupState : sig
     ( describe_patch_group_state_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2153,7 +2212,8 @@ module DescribePatchGroups : sig
     'http_type Smaws_Lib.Context.t ->
     describe_patch_groups_request ->
     ( describe_patch_groups_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all patch groups that have been registered with patch baselines.\n"]
@@ -2173,7 +2233,8 @@ module DescribePatchProperties : sig
     'http_type Smaws_Lib.Context.t ->
     describe_patch_properties_request ->
     ( describe_patch_properties_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2240,7 +2301,8 @@ module DescribeSessions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2281,7 +2343,8 @@ module DisassociateOpsItemRelatedItem : sig
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
       | `OpsItemNotFoundException of ops_item_not_found_exception
       | `OpsItemRelatedItemAssociationNotFoundException of
-        ops_item_related_item_association_not_found_exception ] )
+        ops_item_related_item_association_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2320,7 +2383,8 @@ module GetAccessToken : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a credentials set to be used with just-in-time node access.\n"]
@@ -2347,7 +2411,8 @@ module GetAutomationExecution : sig
     ( get_automation_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Get detailed information about a particular Automation execution.\n"]
@@ -2380,7 +2445,8 @@ module GetCalendarState : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidDocumentType of invalid_document_type
-      | `UnsupportedCalendarException of unsupported_calendar_exception ] )
+      | `UnsupportedCalendarException of unsupported_calendar_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2431,7 +2497,8 @@ module GetCommandInvocation : sig
       | `InvalidCommandId of invalid_command_id
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidPluginName of invalid_plugin_name
-      | `InvocationDoesNotExist of invocation_does_not_exist ] )
+      | `InvocationDoesNotExist of invocation_does_not_exist ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2461,7 +2528,8 @@ module GetConnectionStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_connection_status_request ->
     ( get_connection_status_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2483,7 +2551,8 @@ module GetDefaultPatchBaseline : sig
     'http_type Smaws_Lib.Context.t ->
     get_default_patch_baseline_request ->
     ( get_default_patch_baseline_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2519,7 +2588,8 @@ module GetDeployablePatchSnapshotForInstance : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `UnsupportedFeatureRequiredException of unsupported_feature_required_exception
-      | `UnsupportedOperatingSystem of unsupported_operating_system ] )
+      | `UnsupportedOperatingSystem of unsupported_operating_system ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2559,7 +2629,8 @@ module GetDocument : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `InvalidDocumentVersion of invalid_document_version ] )
+      | `InvalidDocumentVersion of invalid_document_version ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2587,7 +2658,8 @@ module GetExecutionPreview : sig
     ( get_execution_preview_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2631,7 +2703,8 @@ module GetInventory : sig
       | `InvalidInventoryGroupException of invalid_inventory_group_exception
       | `InvalidNextToken of invalid_next_token
       | `InvalidResultAttributeException of invalid_result_attribute_exception
-      | `InvalidTypeNameException of invalid_type_name_exception ] )
+      | `InvalidTypeNameException of invalid_type_name_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2663,7 +2736,8 @@ module GetInventorySchema : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token
-      | `InvalidTypeNameException of invalid_type_name_exception ] )
+      | `InvalidTypeNameException of invalid_type_name_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2692,7 +2766,8 @@ module GetMaintenanceWindow : sig
     ( get_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves a maintenance window.\n"]
@@ -2719,7 +2794,8 @@ module GetMaintenanceWindowExecution : sig
     ( get_maintenance_window_execution_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves details about a specific a maintenance window execution.\n"]
@@ -2746,7 +2822,8 @@ module GetMaintenanceWindowExecutionTask : sig
     ( get_maintenance_window_execution_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2774,7 +2851,8 @@ module GetMaintenanceWindowExecutionTaskInvocation : sig
     ( get_maintenance_window_execution_task_invocation_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves information about a specific task running on a specific target.\n"]
@@ -2801,7 +2879,8 @@ module GetMaintenanceWindowTask : sig
     ( get_maintenance_window_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2840,7 +2919,8 @@ module GetOpsItem : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsItemAccessDeniedException of ops_item_access_denied_exception
-      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+      | `OpsItemNotFoundException of ops_item_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2880,7 +2960,8 @@ module GetOpsMetadata : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
-      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ] )
+      | `OpsMetadataNotFoundException of ops_metadata_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "View operational metadata related to an application in Application Manager.\n"]
@@ -2919,7 +3000,8 @@ module GetOpsSummary : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token
       | `InvalidTypeNameException of invalid_type_name_exception
-      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2956,7 +3038,8 @@ module GetParameter : sig
       | `InternalServerError of internal_server_error
       | `InvalidKeyId of invalid_key_id
       | `ParameterNotFound of parameter_not_found
-      | `ParameterVersionNotFound of parameter_version_not_found ] )
+      | `ParameterVersionNotFound of parameter_version_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2997,7 +3080,8 @@ module GetParameterHistory : sig
       | `InternalServerError of internal_server_error
       | `InvalidKeyId of invalid_key_id
       | `InvalidNextToken of invalid_next_token
-      | `ParameterNotFound of parameter_not_found ] )
+      | `ParameterNotFound of parameter_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3034,7 +3118,8 @@ module GetParameters : sig
     ( get_parameters_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidKeyId of invalid_key_id ] )
+      | `InvalidKeyId of invalid_key_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3080,7 +3165,8 @@ module GetParametersByPath : sig
       | `InvalidFilterOption of invalid_filter_option
       | `InvalidFilterValue of invalid_filter_value
       | `InvalidKeyId of invalid_key_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3122,7 +3208,8 @@ module GetPatchBaseline : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
-      | `InvalidResourceId of invalid_resource_id ] )
+      | `InvalidResourceId of invalid_resource_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves information about a patch baseline.\n"]
@@ -3142,7 +3229,8 @@ module GetPatchBaselineForPatchGroup : sig
     'http_type Smaws_Lib.Context.t ->
     get_patch_baseline_for_patch_group_request ->
     ( get_patch_baseline_for_patch_group_result Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the patch baseline that should be used for the specified patch group.\n"]
@@ -3174,7 +3262,7 @@ module GetResourcePolicies : sig
       | `InternalServerError of internal_server_error
       | `ResourceNotFoundException of resource_not_found_exception
       | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns an array of the [Policy] object.\n"]
@@ -3201,7 +3289,8 @@ module GetServiceSetting : sig
     ( get_service_setting_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ServiceSettingNotFound of service_setting_not_found ] )
+      | `ServiceSettingNotFound of service_setting_not_found ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3252,7 +3341,8 @@ module LabelParameterVersion : sig
       | `ParameterNotFound of parameter_not_found
       | `ParameterVersionLabelLimitExceeded of parameter_version_label_limit_exceeded
       | `ParameterVersionNotFound of parameter_version_not_found
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3326,7 +3416,8 @@ module ListAssociationVersions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves all versions of an association for a specific association ID.\n"]
@@ -3353,7 +3444,8 @@ module ListAssociations : sig
     ( list_associations_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3393,7 +3485,8 @@ module ListCommandInvocations : sig
       | `InvalidCommandId of invalid_command_id
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3433,7 +3526,8 @@ module ListCommands : sig
       | `InvalidCommandId of invalid_command_id
       | `InvalidFilterKey of invalid_filter_key
       | `InvalidInstanceId of invalid_instance_id
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the commands requested by users of the Amazon Web Services account.\n"]
@@ -3469,7 +3563,8 @@ module ListComplianceItems : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token
       | `InvalidResourceId of invalid_resource_id
-      | `InvalidResourceType of invalid_resource_type ] )
+      | `InvalidResourceType of invalid_resource_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3502,7 +3597,8 @@ module ListComplianceSummaries : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3538,7 +3634,8 @@ module ListDocumentMetadataHistory : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidDocumentVersion of invalid_document_version
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3575,7 +3672,8 @@ module ListDocumentVersions : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List all versions for a document.\n"]
@@ -3605,7 +3703,8 @@ module ListDocuments : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilterKey of invalid_filter_key
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3643,7 +3742,8 @@ module ListInventoryEntries : sig
       | `InvalidFilter of invalid_filter
       | `InvalidInstanceId of invalid_instance_id
       | `InvalidNextToken of invalid_next_token
-      | `InvalidTypeNameException of invalid_type_name_exception ] )
+      | `InvalidTypeNameException of invalid_type_name_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "A list of inventory items returned by the request.\n"]
@@ -3679,7 +3779,8 @@ module ListNodes : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token
       | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Takes in filters and returns a list of managed nodes matching the filter criteria.\n"]
@@ -3718,7 +3819,8 @@ module ListNodesSummary : sig
       | `InvalidFilter of invalid_filter
       | `InvalidNextToken of invalid_next_token
       | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3753,7 +3855,8 @@ module ListOpsItemEvents : sig
       | `InternalServerError of internal_server_error
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
       | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
-      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+      | `OpsItemNotFoundException of ops_item_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3783,7 +3886,8 @@ module ListOpsItemRelatedItems : sig
     ( list_ops_item_related_items_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ] )
+      | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3812,7 +3916,8 @@ module ListOpsMetadata : sig
     ( list_ops_metadata_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception ] )
+      | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3844,7 +3949,8 @@ module ListResourceComplianceSummaries : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidFilter of invalid_filter
-      | `InvalidNextToken of invalid_next_token ] )
+      | `InvalidNextToken of invalid_next_token ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3880,7 +3986,8 @@ module ListResourceDataSync : sig
       | `InternalServerError of internal_server_error
       | `InvalidNextToken of invalid_next_token
       | `ResourceDataSyncInvalidConfigurationException of
-        resource_data_sync_invalid_configuration_exception ] )
+        resource_data_sync_invalid_configuration_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3919,7 +4026,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id
-      | `InvalidResourceType of invalid_resource_type ] )
+      | `InvalidResourceType of invalid_resource_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3958,7 +4066,8 @@ module ModifyDocumentPermission : sig
       | `DocumentPermissionLimit of document_permission_limit
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `InvalidPermissionType of invalid_permission_type ] )
+      | `InvalidPermissionType of invalid_permission_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4004,7 +4113,8 @@ module PutComplianceItems : sig
       | `InvalidResourceId of invalid_resource_id
       | `InvalidResourceType of invalid_resource_type
       | `ItemSizeLimitExceededException of item_size_limit_exceeded_exception
-      | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception ] )
+      | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4129,7 +4239,8 @@ module PutInventory : sig
       | `TotalSizeLimitExceededException of total_size_limit_exceeded_exception
       | `UnsupportedInventoryItemContextException of unsupported_inventory_item_context_exception
       | `UnsupportedInventorySchemaVersionException of
-        unsupported_inventory_schema_version_exception ] )
+        unsupported_inventory_schema_version_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4197,7 +4308,8 @@ module PutParameter : sig
       | `ParameterPatternMismatchException of parameter_pattern_mismatch_exception
       | `PoliciesLimitExceededException of policies_limit_exceeded_exception
       | `TooManyUpdates of too_many_updates
-      | `UnsupportedParameterType of unsupported_parameter_type ] )
+      | `UnsupportedParameterType of unsupported_parameter_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Create or update a parameter in Parameter Store.\n"]
@@ -4239,7 +4351,8 @@ module PutResourcePolicy : sig
       | `ResourcePolicyConflictException of resource_policy_conflict_exception
       | `ResourcePolicyInvalidParameterException of resource_policy_invalid_parameter_exception
       | `ResourcePolicyLimitExceededException of resource_policy_limit_exceeded_exception
-      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ] )
+      | `ResourcePolicyNotFoundException of resource_policy_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4311,7 +4424,8 @@ module RegisterDefaultPatchBaseline : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
-      | `InvalidResourceId of invalid_resource_id ] )
+      | `InvalidResourceId of invalid_resource_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4353,7 +4467,8 @@ module RegisterPatchBaselineForPatchGroup : sig
       | `DoesNotExistException of does_not_exist_exception
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Registers a patch baseline for a patch group.\n"]
@@ -4386,7 +4501,8 @@ module RegisterTargetWithMaintenanceWindow : sig
       | `DoesNotExistException of does_not_exist_exception
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Registers a target with a maintenance window.\n"]
@@ -4422,7 +4538,8 @@ module RegisterTaskWithMaintenanceWindow : sig
       | `FeatureNotAvailableException of feature_not_available_exception
       | `IdempotentParameterMismatch of idempotent_parameter_mismatch
       | `InternalServerError of internal_server_error
-      | `ResourceLimitExceededException of resource_limit_exceeded_exception ] )
+      | `ResourceLimitExceededException of resource_limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds a new task to a maintenance window.\n"]
@@ -4455,7 +4572,8 @@ module RemoveTagsFromResource : sig
       | `InternalServerError of internal_server_error
       | `InvalidResourceId of invalid_resource_id
       | `InvalidResourceType of invalid_resource_type
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes tag keys from the specified resource.\n"]
@@ -4485,7 +4603,8 @@ module ResetServiceSetting : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4527,7 +4646,8 @@ module ResumeSession : sig
     ( resume_session_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4566,7 +4686,8 @@ module SendAutomationSignal : sig
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
       | `AutomationStepNotFoundException of automation_step_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidAutomationSignalException of invalid_automation_signal_exception ] )
+      | `InvalidAutomationSignalException of invalid_automation_signal_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4622,7 +4743,8 @@ module SendCommand : sig
       | `InvalidParameters of invalid_parameters
       | `InvalidRole of invalid_role
       | `MaxDocumentSizeExceeded of max_document_size_exceeded
-      | `UnsupportedPlatformType of unsupported_platform_type ] )
+      | `UnsupportedPlatformType of unsupported_platform_type ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Runs commands on one or more managed nodes.\n"]
@@ -4661,7 +4783,8 @@ module StartAccessRequest : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `ServiceQuotaExceededException of service_quota_exceeded_exception
       | `ThrottlingException of throttling_exception
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Starts the workflow for just-in-time node access sessions.\n"]
@@ -4688,7 +4811,8 @@ module StartAssociationsOnce : sig
     ( start_associations_once_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AssociationDoesNotExist of association_does_not_exist
-      | `InvalidAssociation of invalid_association ] )
+      | `InvalidAssociation of invalid_association ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4738,7 +4862,8 @@ module StartAutomationExecution : sig
       | `InternalServerError of internal_server_error
       | `InvalidAutomationExecutionParametersException of
         invalid_automation_execution_parameters_exception
-      | `InvalidTarget of invalid_target ] )
+      | `InvalidTarget of invalid_target ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Initiates execution of an Automation runbook.\n"]
@@ -4789,7 +4914,8 @@ module StartChangeRequestExecution : sig
       | `InternalServerError of internal_server_error
       | `InvalidAutomationExecutionParametersException of
         invalid_automation_execution_parameters_exception
-      | `NoLongerSupportedException of no_longer_supported_exception ] )
+      | `NoLongerSupportedException of no_longer_supported_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4824,7 +4950,8 @@ module StartExecutionPreview : sig
     ( start_execution_preview_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `ValidationException of validation_exception ] )
+      | `ValidationException of validation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4856,7 +4983,8 @@ module StartSession : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
-      | `TargetNotConnected of target_not_connected ] )
+      | `TargetNotConnected of target_not_connected ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4900,7 +5028,8 @@ module StopAutomationExecution : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `AutomationExecutionNotFoundException of automation_execution_not_found_exception
       | `InternalServerError of internal_server_error
-      | `InvalidAutomationStatusUpdateException of invalid_automation_status_update_exception ] )
+      | `InvalidAutomationStatusUpdateException of invalid_automation_status_update_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Stop an Automation that is currently running.\n"]
@@ -4920,7 +5049,8 @@ module TerminateSession : sig
     'http_type Smaws_Lib.Context.t ->
     terminate_session_request ->
     ( terminate_session_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ] )
+      [> Smaws_Lib.Protocols.AwsJson.error | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4955,7 +5085,8 @@ module UnlabelParameterVersion : sig
       | `InternalServerError of internal_server_error
       | `ParameterNotFound of parameter_not_found
       | `ParameterVersionNotFound of parameter_version_not_found
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5020,7 +5151,8 @@ module UpdateAssociation : sig
       | `InvalidTarget of invalid_target
       | `InvalidTargetMaps of invalid_target_maps
       | `InvalidUpdate of invalid_update
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5081,7 +5213,8 @@ module UpdateAssociationStatus : sig
       | `InvalidDocument of invalid_document
       | `InvalidInstanceId of invalid_instance_id
       | `StatusUnchanged of status_unchanged
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5138,7 +5271,8 @@ module UpdateDocument : sig
       | `InvalidDocumentOperation of invalid_document_operation
       | `InvalidDocumentSchemaVersion of invalid_document_schema_version
       | `InvalidDocumentVersion of invalid_document_version
-      | `MaxDocumentSizeExceeded of max_document_size_exceeded ] )
+      | `MaxDocumentSizeExceeded of max_document_size_exceeded ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates one or more values for an SSM document.\n"]
@@ -5171,7 +5305,8 @@ module UpdateDocumentDefaultVersion : sig
       | `InternalServerError of internal_server_error
       | `InvalidDocument of invalid_document
       | `InvalidDocumentSchemaVersion of invalid_document_schema_version
-      | `InvalidDocumentVersion of invalid_document_version ] )
+      | `InvalidDocumentVersion of invalid_document_version ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5212,7 +5347,8 @@ module UpdateDocumentMetadata : sig
       | `InvalidDocument of invalid_document
       | `InvalidDocumentOperation of invalid_document_operation
       | `InvalidDocumentVersion of invalid_document_version
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5247,7 +5383,8 @@ module UpdateMaintenanceWindow : sig
     ( update_maintenance_window_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5282,7 +5419,8 @@ module UpdateMaintenanceWindowTarget : sig
     ( update_maintenance_window_target_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5334,7 +5472,8 @@ module UpdateMaintenanceWindowTask : sig
     ( update_maintenance_window_task_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5406,7 +5545,8 @@ module UpdateManagedInstanceRole : sig
     ( update_managed_instance_role_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
-      | `InvalidInstanceId of invalid_instance_id ] )
+      | `InvalidInstanceId of invalid_instance_id ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5451,7 +5591,8 @@ module UpdateOpsItem : sig
       | `OpsItemConflictException of ops_item_conflict_exception
       | `OpsItemInvalidParameterException of ops_item_invalid_parameter_exception
       | `OpsItemLimitExceededException of ops_item_limit_exceeded_exception
-      | `OpsItemNotFoundException of ops_item_not_found_exception ] )
+      | `OpsItemNotFoundException of ops_item_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5497,7 +5638,8 @@ module UpdateOpsMetadata : sig
       | `OpsMetadataInvalidArgumentException of ops_metadata_invalid_argument_exception
       | `OpsMetadataKeyLimitExceededException of ops_metadata_key_limit_exceeded_exception
       | `OpsMetadataNotFoundException of ops_metadata_not_found_exception
-      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ] )
+      | `OpsMetadataTooManyUpdatesException of ops_metadata_too_many_updates_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5526,7 +5668,8 @@ module UpdatePatchBaseline : sig
     ( update_patch_baseline_result Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DoesNotExistException of does_not_exist_exception
-      | `InternalServerError of internal_server_error ] )
+      | `InternalServerError of internal_server_error ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5567,7 +5710,8 @@ module UpdateResourceDataSync : sig
       | `ResourceDataSyncConflictException of resource_data_sync_conflict_exception
       | `ResourceDataSyncInvalidConfigurationException of
         resource_data_sync_invalid_configuration_exception
-      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ] )
+      | `ResourceDataSyncNotFoundException of resource_data_sync_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5607,7 +5751,8 @@ module UpdateServiceSetting : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InternalServerError of internal_server_error
       | `ServiceSettingNotFound of service_setting_not_found
-      | `TooManyUpdates of too_many_updates ] )
+      | `TooManyUpdates of too_many_updates ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/sts/Smaws_Client_STS.mli
+++ b/sdks/sts/Smaws_Client_STS.mli
@@ -206,7 +206,8 @@ module AssumeRole : sig
       | `ExpiredTokenException of expired_token_exception
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -344,7 +345,8 @@ module AssumeRoleWithSAML : sig
       | `InvalidIdentityTokenException of invalid_identity_token_exception
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -525,7 +527,8 @@ module AssumeRoleWithWebIdentity : sig
       | `InvalidIdentityTokenException of invalid_identity_token_exception
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -690,7 +693,8 @@ module AssumeRoot : sig
     ( assume_root_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `ExpiredTokenException of expired_token_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -741,7 +745,8 @@ module DecodeAuthorizationMessage : sig
     decode_authorization_message_request ->
     ( decode_authorization_message_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
-      | `InvalidAuthorizationMessageException of invalid_authorization_message_exception ] )
+      | `InvalidAuthorizationMessageException of invalid_authorization_message_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -798,7 +803,7 @@ module GetAccessKeyInfo : sig
     'http_type Smaws_Lib.Context.t ->
     get_access_key_info_request ->
     ( get_access_key_info_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -838,7 +843,7 @@ module GetCallerIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     get_caller_identity_request ->
     ( get_caller_identity_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -877,7 +882,8 @@ module GetDelegatedAccessToken : sig
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `ExpiredTradeInTokenException of expired_trade_in_token_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -911,7 +917,8 @@ module GetFederationToken : sig
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1035,7 +1042,7 @@ module GetSessionToken : sig
     get_session_token_request ->
     ( get_session_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error | `RegionDisabledException of region_disabled_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1127,7 +1134,8 @@ module GetWebIdentityToken : sig
       | `JWTPayloadSizeExceededException of jwt_payload_size_exceeded_exception
       | `OutboundWebIdentityFederationDisabledException of
         outbound_web_identity_federation_disabled_exception
-      | `SessionDurationEscalationException of session_duration_escalation_exception ] )
+      | `SessionDurationEscalationException of session_duration_escalation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/sts/Smaws_Client_STS.mli
+++ b/sdks/sts/Smaws_Client_STS.mli
@@ -197,6 +197,17 @@ module AssumeRole : sig
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
       | `RegionDisabledException of region_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_role_request ->
+    ( assume_role_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTokenException of expired_token_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a set of temporary security credentials that you can use to access Amazon Web Services \
@@ -314,6 +325,19 @@ module AssumeRoleWithSAML : sig
     'http_type Smaws_Lib.Context.t ->
     assume_role_with_saml_request ->
     ( assume_role_with_saml_response,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTokenException of expired_token_exception
+      | `IDPRejectedClaimException of idp_rejected_claim_exception
+      | `InvalidIdentityTokenException of invalid_identity_token_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_role_with_saml_request ->
+    ( assume_role_with_saml_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `ExpiredTokenException of expired_token_exception
       | `IDPRejectedClaimException of idp_rejected_claim_exception
@@ -489,6 +513,20 @@ module AssumeRoleWithWebIdentity : sig
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
       | `RegionDisabledException of region_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_role_with_web_identity_request ->
+    ( assume_role_with_web_identity_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTokenException of expired_token_exception
+      | `IDPCommunicationErrorException of idp_communication_error_exception
+      | `IDPRejectedClaimException of idp_rejected_claim_exception
+      | `InvalidIdentityTokenException of invalid_identity_token_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a set of temporary security credentials for users who have been authenticated in a \
@@ -645,6 +683,15 @@ module AssumeRoot : sig
       | `ExpiredTokenException of expired_token_exception
       | `RegionDisabledException of region_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_root_request ->
+    ( assume_root_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTokenException of expired_token_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a set of short term credentials you can use to perform privileged tasks on a member \
@@ -685,6 +732,14 @@ module DecodeAuthorizationMessage : sig
     'http_type Smaws_Lib.Context.t ->
     decode_authorization_message_request ->
     ( decode_authorization_message_response,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `InvalidAuthorizationMessageException of invalid_authorization_message_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    decode_authorization_message_request ->
+    ( decode_authorization_message_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `InvalidAuthorizationMessageException of invalid_authorization_message_exception ] )
     result
@@ -738,6 +793,13 @@ module GetAccessKeyInfo : sig
     'http_type Smaws_Lib.Context.t ->
     get_access_key_info_request ->
     (get_access_key_info_response, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_access_key_info_request ->
+    ( get_access_key_info_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "Returns the account identifier for the specified access key ID.\n\n\
@@ -771,6 +833,13 @@ module GetCallerIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     get_caller_identity_request ->
     (get_caller_identity_response, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_caller_identity_request ->
+    ( get_caller_identity_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "Returns details about the IAM user or role whose credentials are used to call the operation.\n\n\
@@ -800,6 +869,16 @@ module GetDelegatedAccessToken : sig
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
       | `RegionDisabledException of region_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_delegated_access_token_request ->
+    ( get_delegated_access_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTradeInTokenException of expired_trade_in_token_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Exchanges a trade-in token for temporary Amazon Web Services credentials with the permissions \
@@ -819,6 +898,16 @@ module GetFederationToken : sig
     'http_type Smaws_Lib.Context.t ->
     get_federation_token_request ->
     ( get_federation_token_response,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_federation_token_request ->
+    ( get_federation_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
@@ -940,6 +1029,14 @@ module GetSessionToken : sig
       [> Smaws_Lib.Protocols.AwsQuery.error | `RegionDisabledException of region_disabled_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_session_token_request ->
+    ( get_session_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error | `RegionDisabledException of region_disabled_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Returns a set of temporary credentials for an Amazon Web Services account or IAM user. The \
@@ -1015,6 +1112,17 @@ module GetWebIdentityToken : sig
     'http_type Smaws_Lib.Context.t ->
     get_web_identity_token_request ->
     ( get_web_identity_token_response,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `JWTPayloadSizeExceededException of jwt_payload_size_exceeded_exception
+      | `OutboundWebIdentityFederationDisabledException of
+        outbound_web_identity_federation_disabled_exception
+      | `SessionDurationEscalationException of session_duration_escalation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_web_identity_token_request ->
+    ( get_web_identity_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `JWTPayloadSizeExceededException of jwt_payload_size_exceeded_exception
       | `OutboundWebIdentityFederationDisabledException of

--- a/sdks/sts/operations.ml
+++ b/sdks/sts/operations.ml
@@ -48,6 +48,12 @@ module AssumeRole = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"AssumeRole"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:assume_role_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : assume_role_request) =
+    let fields = assume_role_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"AssumeRole"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:assume_role_response_of_xml ~error_deserializer
 end
 
 module AssumeRoleWithSAML = struct
@@ -109,6 +115,12 @@ module AssumeRoleWithSAML = struct
   let request context (request : assume_role_with_saml_request) =
     let fields = assume_role_with_saml_request_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"AssumeRoleWithSAML"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:assume_role_with_saml_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : assume_role_with_saml_request) =
+    let fields = assume_role_with_saml_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"AssumeRoleWithSAML"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:assume_role_with_saml_response_of_xml ~error_deserializer
 end
@@ -182,6 +194,12 @@ module AssumeRoleWithWebIdentity = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"AssumeRoleWithWebIdentity"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:assume_role_with_web_identity_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : assume_role_with_web_identity_request) =
+    let fields = assume_role_with_web_identity_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"AssumeRoleWithWebIdentity"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:assume_role_with_web_identity_response_of_xml ~error_deserializer
 end
 
 module AssumeRoot = struct
@@ -213,6 +231,12 @@ module AssumeRoot = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"AssumeRoot"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:assume_root_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : assume_root_request) =
+    let fields = assume_root_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"AssumeRoot"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:assume_root_response_of_xml ~error_deserializer
 end
 
 module DecodeAuthorizationMessage = struct
@@ -237,6 +261,12 @@ module DecodeAuthorizationMessage = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"DecodeAuthorizationMessage"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:decode_authorization_message_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : decode_authorization_message_request) =
+    let fields = decode_authorization_message_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"DecodeAuthorizationMessage"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:decode_authorization_message_response_of_xml ~error_deserializer
 end
 
 module GetAccessKeyInfo = struct
@@ -250,6 +280,12 @@ module GetAccessKeyInfo = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"GetAccessKeyInfo"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:get_access_key_info_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : get_access_key_info_request) =
+    let fields = get_access_key_info_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"GetAccessKeyInfo"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:get_access_key_info_response_of_xml ~error_deserializer
 end
 
 module GetCallerIdentity = struct
@@ -261,6 +297,12 @@ module GetCallerIdentity = struct
   let request context (request : get_caller_identity_request) =
     let fields = get_caller_identity_request_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"GetCallerIdentity"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:get_caller_identity_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : get_caller_identity_request) =
+    let fields = get_caller_identity_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"GetCallerIdentity"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:get_caller_identity_response_of_xml ~error_deserializer
 end
@@ -302,6 +344,12 @@ module GetDelegatedAccessToken = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"GetDelegatedAccessToken"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:get_delegated_access_token_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : get_delegated_access_token_request) =
+    let fields = get_delegated_access_token_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"GetDelegatedAccessToken"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:get_delegated_access_token_response_of_xml ~error_deserializer
 end
 
 module GetFederationToken = struct
@@ -341,6 +389,12 @@ module GetFederationToken = struct
     Smaws_Lib.Protocols.AwsQuery.request ~action:"GetFederationToken"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:get_federation_token_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : get_federation_token_request) =
+    let fields = get_federation_token_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"GetFederationToken"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:get_federation_token_response_of_xml ~error_deserializer
 end
 
 module GetSessionToken = struct
@@ -362,6 +416,12 @@ module GetSessionToken = struct
   let request context (request : get_session_token_request) =
     let fields = get_session_token_request_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"GetSessionToken"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:get_session_token_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : get_session_token_request) =
+    let fields = get_session_token_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"GetSessionToken"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:get_session_token_response_of_xml ~error_deserializer
 end
@@ -403,6 +463,12 @@ module GetWebIdentityToken = struct
   let request context (request : get_web_identity_token_request) =
     let fields = get_web_identity_token_request_to_query [] request in
     Smaws_Lib.Protocols.AwsQuery.request ~action:"GetWebIdentityToken"
+      ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
+      ~output_deserializer:get_web_identity_token_response_of_xml ~error_deserializer
+
+  let request_with_metadata context (request : get_web_identity_token_request) =
+    let fields = get_web_identity_token_request_to_query [] request in
+    Smaws_Lib.Protocols.AwsQuery.request_with_metadata ~action:"GetWebIdentityToken"
       ~xmlNamespace:"https://sts.amazonaws.com/doc/2011-06-15/" ~service ~context ~fields
       ~output_deserializer:get_web_identity_token_response_of_xml ~error_deserializer
 end

--- a/sdks/sts/operations.mli
+++ b/sdks/sts/operations.mli
@@ -19,6 +19,17 @@ module AssumeRole : sig
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
       | `RegionDisabledException of region_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_role_request ->
+    ( assume_role_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTokenException of expired_token_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a set of temporary security credentials that you can use to access Amazon Web Services \
@@ -136,6 +147,19 @@ module AssumeRoleWithSAML : sig
     'http_type Smaws_Lib.Context.t ->
     assume_role_with_saml_request ->
     ( assume_role_with_saml_response,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTokenException of expired_token_exception
+      | `IDPRejectedClaimException of idp_rejected_claim_exception
+      | `InvalidIdentityTokenException of invalid_identity_token_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_role_with_saml_request ->
+    ( assume_role_with_saml_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `ExpiredTokenException of expired_token_exception
       | `IDPRejectedClaimException of idp_rejected_claim_exception
@@ -311,6 +335,20 @@ module AssumeRoleWithWebIdentity : sig
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
       | `RegionDisabledException of region_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_role_with_web_identity_request ->
+    ( assume_role_with_web_identity_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTokenException of expired_token_exception
+      | `IDPCommunicationErrorException of idp_communication_error_exception
+      | `IDPRejectedClaimException of idp_rejected_claim_exception
+      | `InvalidIdentityTokenException of invalid_identity_token_exception
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a set of temporary security credentials for users who have been authenticated in a \
@@ -467,6 +505,15 @@ module AssumeRoot : sig
       | `ExpiredTokenException of expired_token_exception
       | `RegionDisabledException of region_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_root_request ->
+    ( assume_root_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTokenException of expired_token_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns a set of short term credentials you can use to perform privileged tasks on a member \
@@ -507,6 +554,14 @@ module DecodeAuthorizationMessage : sig
     'http_type Smaws_Lib.Context.t ->
     decode_authorization_message_request ->
     ( decode_authorization_message_response,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `InvalidAuthorizationMessageException of invalid_authorization_message_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    decode_authorization_message_request ->
+    ( decode_authorization_message_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `InvalidAuthorizationMessageException of invalid_authorization_message_exception ] )
     result
@@ -560,6 +615,13 @@ module GetAccessKeyInfo : sig
     'http_type Smaws_Lib.Context.t ->
     get_access_key_info_request ->
     (get_access_key_info_response, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_access_key_info_request ->
+    ( get_access_key_info_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "Returns the account identifier for the specified access key ID.\n\n\
@@ -593,6 +655,13 @@ module GetCallerIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     get_caller_identity_request ->
     (get_caller_identity_response, [> Smaws_Lib.Protocols.AwsQuery.error ]) result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_caller_identity_request ->
+    ( get_caller_identity_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+    result
 end
 [@@ocaml.doc
   "Returns details about the IAM user or role whose credentials are used to call the operation.\n\n\
@@ -622,6 +691,16 @@ module GetDelegatedAccessToken : sig
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
       | `RegionDisabledException of region_disabled_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_delegated_access_token_request ->
+    ( get_delegated_access_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `ExpiredTradeInTokenException of expired_trade_in_token_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
 end
 [@@ocaml.doc
   "Exchanges a trade-in token for temporary Amazon Web Services credentials with the permissions \
@@ -641,6 +720,16 @@ module GetFederationToken : sig
     'http_type Smaws_Lib.Context.t ->
     get_federation_token_request ->
     ( get_federation_token_response,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `MalformedPolicyDocumentException of malformed_policy_document_exception
+      | `PackedPolicyTooLargeException of packed_policy_too_large_exception
+      | `RegionDisabledException of region_disabled_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_federation_token_request ->
+    ( get_federation_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
@@ -762,6 +851,14 @@ module GetSessionToken : sig
       [> Smaws_Lib.Protocols.AwsQuery.error | `RegionDisabledException of region_disabled_exception ]
     )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_session_token_request ->
+    ( get_session_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsQuery.error | `RegionDisabledException of region_disabled_exception ]
+    )
+    result
 end
 [@@ocaml.doc
   "Returns a set of temporary credentials for an Amazon Web Services account or IAM user. The \
@@ -836,6 +933,17 @@ module GetWebIdentityToken : sig
     'http_type Smaws_Lib.Context.t ->
     get_web_identity_token_request ->
     ( get_web_identity_token_response,
+      [> Smaws_Lib.Protocols.AwsQuery.error
+      | `JWTPayloadSizeExceededException of jwt_payload_size_exceeded_exception
+      | `OutboundWebIdentityFederationDisabledException of
+        outbound_web_identity_federation_disabled_exception
+      | `SessionDurationEscalationException of session_duration_escalation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_web_identity_token_request ->
+    ( get_web_identity_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `JWTPayloadSizeExceededException of jwt_payload_size_exceeded_exception
       | `OutboundWebIdentityFederationDisabledException of

--- a/sdks/sts/operations.mli
+++ b/sdks/sts/operations.mli
@@ -28,7 +28,8 @@ module AssumeRole : sig
       | `ExpiredTokenException of expired_token_exception
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -166,7 +167,8 @@ module AssumeRoleWithSAML : sig
       | `InvalidIdentityTokenException of invalid_identity_token_exception
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -347,7 +349,8 @@ module AssumeRoleWithWebIdentity : sig
       | `InvalidIdentityTokenException of invalid_identity_token_exception
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -512,7 +515,8 @@ module AssumeRoot : sig
     ( assume_root_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `ExpiredTokenException of expired_token_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -563,7 +567,8 @@ module DecodeAuthorizationMessage : sig
     decode_authorization_message_request ->
     ( decode_authorization_message_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error
-      | `InvalidAuthorizationMessageException of invalid_authorization_message_exception ] )
+      | `InvalidAuthorizationMessageException of invalid_authorization_message_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -620,7 +625,7 @@ module GetAccessKeyInfo : sig
     'http_type Smaws_Lib.Context.t ->
     get_access_key_info_request ->
     ( get_access_key_info_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -660,7 +665,7 @@ module GetCallerIdentity : sig
     'http_type Smaws_Lib.Context.t ->
     get_caller_identity_request ->
     ( get_caller_identity_response Smaws_Lib.Response.t,
-      [> Smaws_Lib.Protocols.AwsQuery.error ] )
+      [> Smaws_Lib.Protocols.AwsQuery.error ] * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -699,7 +704,8 @@ module GetDelegatedAccessToken : sig
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `ExpiredTradeInTokenException of expired_trade_in_token_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -733,7 +739,8 @@ module GetFederationToken : sig
       [> Smaws_Lib.Protocols.AwsQuery.error
       | `MalformedPolicyDocumentException of malformed_policy_document_exception
       | `PackedPolicyTooLargeException of packed_policy_too_large_exception
-      | `RegionDisabledException of region_disabled_exception ] )
+      | `RegionDisabledException of region_disabled_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -857,7 +864,7 @@ module GetSessionToken : sig
     get_session_token_request ->
     ( get_session_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsQuery.error | `RegionDisabledException of region_disabled_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -948,7 +955,8 @@ module GetWebIdentityToken : sig
       | `JWTPayloadSizeExceededException of jwt_payload_size_exceeded_exception
       | `OutboundWebIdentityFederationDisabledException of
         outbound_web_identity_federation_disabled_exception
-      | `SessionDurationEscalationException of session_duration_escalation_exception ] )
+      | `SessionDurationEscalationException of session_duration_escalation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/swf/Smaws_Client_SWF.mli
+++ b/sdks/swf/Smaws_Client_SWF.mli
@@ -1082,7 +1082,8 @@ module CountClosedWorkflowExecutions : sig
     ( workflow_execution_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1152,7 +1153,8 @@ module CountOpenWorkflowExecutions : sig
     ( workflow_execution_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1222,7 +1224,8 @@ module CountPendingActivityTasks : sig
     ( pending_task_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1276,7 +1279,8 @@ module CountPendingDecisionTasks : sig
     ( pending_task_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1333,7 +1337,8 @@ module DeleteActivityType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeNotDeprecatedFault of type_not_deprecated_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1404,7 +1409,8 @@ module DeleteWorkflowType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeNotDeprecatedFault of type_not_deprecated_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1475,7 +1481,8 @@ module DeprecateActivityType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1543,7 +1550,8 @@ module DeprecateDomain : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DomainDeprecatedFault of domain_deprecated_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1603,7 +1611,8 @@ module DeprecateWorkflowType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1672,7 +1681,8 @@ module DescribeActivityType : sig
     ( activity_type_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1736,7 +1746,8 @@ module DescribeDomain : sig
     ( domain_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1787,7 +1798,8 @@ module DescribeWorkflowExecution : sig
     ( workflow_execution_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1842,7 +1854,8 @@ module DescribeWorkflowType : sig
     ( workflow_type_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1907,7 +1920,8 @@ module GetWorkflowExecutionHistory : sig
     ( history Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1963,7 +1977,8 @@ module ListActivityTypes : sig
     ( activity_type_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2017,7 +2032,8 @@ module ListClosedWorkflowExecutions : sig
     ( workflow_execution_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2085,7 +2101,8 @@ module ListDomains : sig
     list_domains_input ->
     ( domain_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `OperationNotPermittedFault of operation_not_permitted_fault ] )
+      | `OperationNotPermittedFault of operation_not_permitted_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2142,7 +2159,8 @@ module ListOpenWorkflowExecutions : sig
     ( workflow_execution_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2216,7 +2234,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List tags for a given domain.\n"]
@@ -2243,7 +2262,8 @@ module ListWorkflowTypes : sig
     ( workflow_type_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2298,7 +2318,8 @@ module PollForActivityTask : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2362,7 +2383,8 @@ module PollForDecisionTask : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2433,7 +2455,8 @@ module RecordActivityTaskHeartbeat : sig
     ( activity_task_status Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2514,7 +2537,8 @@ module RegisterActivityType : sig
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2590,7 +2614,8 @@ module RegisterDomain : sig
       | `DomainAlreadyExistsFault of domain_already_exists_fault
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `TooManyTagsFault of too_many_tags_fault ] )
+      | `TooManyTagsFault of too_many_tags_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2647,7 +2672,8 @@ module RegisterWorkflowType : sig
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2719,7 +2745,8 @@ module RequestCancelWorkflowExecution : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2780,7 +2807,8 @@ module RespondActivityTaskCanceled : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2846,7 +2874,8 @@ module RespondActivityTaskCompleted : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2912,7 +2941,8 @@ module RespondActivityTaskFailed : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2972,7 +3002,8 @@ module RespondDecisionTaskCompleted : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3015,7 +3046,8 @@ module SignalWorkflowExecution : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3086,7 +3118,8 @@ module StartWorkflowExecution : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
       | `UnknownResourceFault of unknown_resource_fault
-      | `WorkflowExecutionAlreadyStartedFault of workflow_execution_already_started_fault ] )
+      | `WorkflowExecutionAlreadyStartedFault of workflow_execution_already_started_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3176,7 +3209,8 @@ module TagResource : sig
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TooManyTagsFault of too_many_tags_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3207,7 +3241,8 @@ module TerminateWorkflowExecution : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3273,7 +3308,8 @@ module UndeprecateActivityType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3343,7 +3379,8 @@ module UndeprecateDomain : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DomainAlreadyExistsFault of domain_already_exists_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3401,7 +3438,8 @@ module UndeprecateWorkflowType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3472,7 +3510,8 @@ module UntagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Remove a tag from a Amazon SWF domain.\n"]

--- a/sdks/swf/Smaws_Client_SWF.mli
+++ b/sdks/swf/Smaws_Client_SWF.mli
@@ -1075,6 +1075,15 @@ module CountClosedWorkflowExecutions : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    count_closed_workflow_executions_input ->
+    ( workflow_execution_count Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns the number of closed workflow executions within the given domain that meet the \
@@ -1132,6 +1141,15 @@ module CountOpenWorkflowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     count_open_workflow_executions_input ->
     ( workflow_execution_count,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    count_open_workflow_executions_input ->
+    ( workflow_execution_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1197,6 +1215,15 @@ module CountPendingActivityTasks : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    count_pending_activity_tasks_input ->
+    ( pending_task_count Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns the estimated number of activity tasks in the specified task list. The count returned \
@@ -1238,6 +1265,15 @@ module CountPendingDecisionTasks : sig
     'http_type Smaws_Lib.Context.t ->
     count_pending_decision_tasks_input ->
     ( pending_task_count,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    count_pending_decision_tasks_input ->
+    ( pending_task_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1284,6 +1320,16 @@ module DeleteActivityType : sig
     'http_type Smaws_Lib.Context.t ->
     delete_activity_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeNotDeprecatedFault of type_not_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_activity_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeNotDeprecatedFault of type_not_deprecated_fault
@@ -1350,6 +1396,16 @@ module DeleteWorkflowType : sig
       | `TypeNotDeprecatedFault of type_not_deprecated_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_workflow_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeNotDeprecatedFault of type_not_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified {i workflow type}.\n\n\
@@ -1406,6 +1462,16 @@ module DeprecateActivityType : sig
     'http_type Smaws_Lib.Context.t ->
     deprecate_activity_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeDeprecatedFault of type_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deprecate_activity_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
@@ -1469,6 +1535,16 @@ module DeprecateDomain : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deprecate_domain_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DomainDeprecatedFault of domain_deprecated_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Deprecates the specified domain. After a domain has been deprecated it cannot be used to create \
@@ -1514,6 +1590,16 @@ module DeprecateWorkflowType : sig
     'http_type Smaws_Lib.Context.t ->
     deprecate_workflow_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeDeprecatedFault of type_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deprecate_workflow_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
@@ -1579,6 +1665,15 @@ module DescribeActivityType : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_activity_type_input ->
+    ( activity_type_detail Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the specified activity type. This includes configuration settings \
@@ -1634,6 +1729,15 @@ module DescribeDomain : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_domain_input ->
+    ( domain_detail Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the specified domain, including description and status.\n\n\
@@ -1672,6 +1776,15 @@ module DescribeWorkflowExecution : sig
     'http_type Smaws_Lib.Context.t ->
     describe_workflow_execution_input ->
     ( workflow_execution_detail,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_workflow_execution_input ->
+    ( workflow_execution_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1718,6 +1831,15 @@ module DescribeWorkflowType : sig
     'http_type Smaws_Lib.Context.t ->
     describe_workflow_type_input ->
     ( workflow_type_detail,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_workflow_type_input ->
+    ( workflow_type_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1778,6 +1900,15 @@ module GetWorkflowExecutionHistory : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_workflow_execution_history_input ->
+    ( history Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns the history of the specified workflow execution. The results may be split into multiple \
@@ -1825,6 +1956,15 @@ module ListActivityTypes : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_activity_types_input ->
+    ( activity_type_infos Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about all activities registered in the specified domain that match the \
@@ -1866,6 +2006,15 @@ module ListClosedWorkflowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     list_closed_workflow_executions_input ->
     ( workflow_execution_infos,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_closed_workflow_executions_input ->
+    ( workflow_execution_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1930,6 +2079,14 @@ module ListDomains : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_domains_input ->
+    ( domain_infos Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns the list of domains registered in the account. The results may be split into multiple \
@@ -1974,6 +2131,15 @@ module ListOpenWorkflowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     list_open_workflow_executions_input ->
     ( workflow_execution_infos,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_open_workflow_executions_input ->
+    ( workflow_execution_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -2042,6 +2208,16 @@ module ListTagsForResource : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc "List tags for a given domain.\n"]
 
@@ -2056,6 +2232,15 @@ module ListWorkflowTypes : sig
     'http_type Smaws_Lib.Context.t ->
     list_workflow_types_input ->
     ( workflow_type_infos,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_workflow_types_input ->
+    ( workflow_type_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -2100,6 +2285,16 @@ module PollForActivityTask : sig
     'http_type Smaws_Lib.Context.t ->
     poll_for_activity_task_input ->
     ( activity_task,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    poll_for_activity_task_input ->
+    ( activity_task Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
@@ -2154,6 +2349,16 @@ module PollForDecisionTask : sig
     'http_type Smaws_Lib.Context.t ->
     poll_for_decision_task_input ->
     ( decision_task,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    poll_for_decision_task_input ->
+    ( decision_task Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
@@ -2217,6 +2422,15 @@ module RecordActivityTaskHeartbeat : sig
     'http_type Smaws_Lib.Context.t ->
     record_activity_task_heartbeat_input ->
     ( activity_task_status,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    record_activity_task_heartbeat_input ->
+    ( activity_task_status Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -2291,6 +2505,17 @@ module RegisterActivityType : sig
       | `TypeAlreadyExistsFault of type_already_exists_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_activity_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeAlreadyExistsFault of type_already_exists_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Registers a new {i activity type} along with its configuration settings in the specified \
@@ -2356,6 +2581,17 @@ module RegisterDomain : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TooManyTagsFault of too_many_tags_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_domain_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DomainAlreadyExistsFault of domain_already_exists_fault
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TooManyTagsFault of too_many_tags_fault ] )
+    result
 end
 [@@ocaml.doc
   "Registers a new domain.\n\n\
@@ -2396,6 +2632,17 @@ module RegisterWorkflowType : sig
     'http_type Smaws_Lib.Context.t ->
     register_workflow_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeAlreadyExistsFault of type_already_exists_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_workflow_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
@@ -2465,6 +2712,15 @@ module RequestCancelWorkflowExecution : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    request_cancel_workflow_execution_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Records a [WorkflowExecutionCancelRequested] event in the currently running workflow execution \
@@ -2513,6 +2769,15 @@ module RespondActivityTaskCanceled : sig
     'http_type Smaws_Lib.Context.t ->
     respond_activity_task_canceled_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    respond_activity_task_canceled_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -2574,6 +2839,15 @@ module RespondActivityTaskCompleted : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    respond_activity_task_completed_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Used by workers to tell the service that the [ActivityTask] identified by the [taskToken] \
@@ -2631,6 +2905,15 @@ module RespondActivityTaskFailed : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    respond_activity_task_failed_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Used by workers to tell the service that the [ActivityTask] identified by the [taskToken] has \
@@ -2682,6 +2965,15 @@ module RespondDecisionTaskCompleted : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    respond_decision_task_completed_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Used by deciders to tell the service that the [DecisionTask] identified by the [taskToken] has \
@@ -2712,6 +3004,15 @@ module SignalWorkflowExecution : sig
     'http_type Smaws_Lib.Context.t ->
     signal_workflow_execution_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    signal_workflow_execution_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -2766,6 +3067,19 @@ module StartWorkflowExecution : sig
     'http_type Smaws_Lib.Context.t ->
     start_workflow_execution_input ->
     ( run,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DefaultUndefinedFault of default_undefined_fault
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeDeprecatedFault of type_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault
+      | `WorkflowExecutionAlreadyStartedFault of workflow_execution_already_started_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_workflow_execution_input ->
+    ( run Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DefaultUndefinedFault of default_undefined_fault
       | `LimitExceededFault of limit_exceeded_fault
@@ -2853,6 +3167,17 @@ module TagResource : sig
       | `TooManyTagsFault of too_many_tags_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TooManyTagsFault of too_many_tags_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Add a tag to a Amazon SWF domain.\n\n\
@@ -2871,6 +3196,15 @@ module TerminateWorkflowExecution : sig
     'http_type Smaws_Lib.Context.t ->
     terminate_workflow_execution_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    terminate_workflow_execution_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -2926,6 +3260,16 @@ module UndeprecateActivityType : sig
     'http_type Smaws_Lib.Context.t ->
     undeprecate_activity_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeAlreadyExistsFault of type_already_exists_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    undeprecate_activity_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
@@ -2991,6 +3335,16 @@ module UndeprecateDomain : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    undeprecate_domain_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DomainAlreadyExistsFault of domain_already_exists_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Undeprecates a previously deprecated domain. After a domain has been undeprecated it can be \
@@ -3034,6 +3388,16 @@ module UndeprecateWorkflowType : sig
     'http_type Smaws_Lib.Context.t ->
     undeprecate_workflow_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeAlreadyExistsFault of type_already_exists_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    undeprecate_workflow_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
@@ -3095,6 +3459,16 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault

--- a/sdks/swf/operations.ml
+++ b/sdks/swf/operations.ml
@@ -24,6 +24,12 @@ module CountClosedWorkflowExecutions = struct
     Smaws_Lib.Protocols.AwsJson.request
       ~shape_name:"SimpleWorkflowService.CountClosedWorkflowExecutions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.workflow_execution_count_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : count_closed_workflow_executions_input) =
+    let input = Json_serializers.count_closed_workflow_executions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.CountClosedWorkflowExecutions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.workflow_execution_count_of_yojson ~error_deserializer
 end
 
 module CountOpenWorkflowExecutions = struct
@@ -47,6 +53,12 @@ module CountOpenWorkflowExecutions = struct
   let request context (request : count_open_workflow_executions_input) =
     let input = Json_serializers.count_open_workflow_executions_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.CountOpenWorkflowExecutions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.workflow_execution_count_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : count_open_workflow_executions_input) =
+    let input = Json_serializers.count_open_workflow_executions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.CountOpenWorkflowExecutions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.workflow_execution_count_of_yojson ~error_deserializer
 end
@@ -74,6 +86,12 @@ module CountPendingActivityTasks = struct
     Smaws_Lib.Protocols.AwsJson.request
       ~shape_name:"SimpleWorkflowService.CountPendingActivityTasks" ~service ~context ~input
       ~output_deserializer:Json_deserializers.pending_task_count_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : count_pending_activity_tasks_input) =
+    let input = Json_serializers.count_pending_activity_tasks_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.CountPendingActivityTasks" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.pending_task_count_of_yojson ~error_deserializer
 end
 
 module CountPendingDecisionTasks = struct
@@ -97,6 +115,12 @@ module CountPendingDecisionTasks = struct
   let request context (request : count_pending_decision_tasks_input) =
     let input = Json_serializers.count_pending_decision_tasks_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.CountPendingDecisionTasks" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.pending_task_count_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : count_pending_decision_tasks_input) =
+    let input = Json_serializers.count_pending_decision_tasks_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.CountPendingDecisionTasks" ~service ~context ~input
       ~output_deserializer:Json_deserializers.pending_task_count_of_yojson ~error_deserializer
 end
@@ -128,6 +152,13 @@ module DeleteActivityType = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_activity_type_input) =
+    let input = Json_serializers.delete_activity_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.DeleteActivityType" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteWorkflowType = struct
@@ -155,6 +186,13 @@ module DeleteWorkflowType = struct
     let input = Json_serializers.delete_workflow_type_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.DeleteWorkflowType"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_workflow_type_input) =
+    let input = Json_serializers.delete_workflow_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.DeleteWorkflowType" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -186,6 +224,13 @@ module DeprecateActivityType = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deprecate_activity_type_input) =
+    let input = Json_serializers.deprecate_activity_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.DeprecateActivityType" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeprecateDomain = struct
@@ -213,6 +258,13 @@ module DeprecateDomain = struct
     let input = Json_serializers.deprecate_domain_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.DeprecateDomain" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : deprecate_domain_input) =
+    let input = Json_serializers.deprecate_domain_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.DeprecateDomain" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -243,6 +295,13 @@ module DeprecateWorkflowType = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deprecate_workflow_type_input) =
+    let input = Json_serializers.deprecate_workflow_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.DeprecateWorkflowType" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DescribeActivityType = struct
@@ -267,6 +326,12 @@ module DescribeActivityType = struct
     let input = Json_serializers.describe_activity_type_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.DescribeActivityType"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.activity_type_detail_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_activity_type_input) =
+    let input = Json_serializers.describe_activity_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.DescribeActivityType" ~service ~context ~input
       ~output_deserializer:Json_deserializers.activity_type_detail_of_yojson ~error_deserializer
 end
 
@@ -293,6 +358,12 @@ module DescribeDomain = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.DescribeDomain" ~service
       ~context ~input ~output_deserializer:Json_deserializers.domain_detail_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_domain_input) =
+    let input = Json_serializers.describe_domain_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.DescribeDomain" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.domain_detail_of_yojson ~error_deserializer
 end
 
 module DescribeWorkflowExecution = struct
@@ -316,6 +387,13 @@ module DescribeWorkflowExecution = struct
   let request context (request : describe_workflow_execution_input) =
     let input = Json_serializers.describe_workflow_execution_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.DescribeWorkflowExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.workflow_execution_detail_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_workflow_execution_input) =
+    let input = Json_serializers.describe_workflow_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.DescribeWorkflowExecution" ~service ~context ~input
       ~output_deserializer:Json_deserializers.workflow_execution_detail_of_yojson
       ~error_deserializer
@@ -344,6 +422,12 @@ module DescribeWorkflowType = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.DescribeWorkflowType"
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.workflow_type_detail_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : describe_workflow_type_input) =
+    let input = Json_serializers.describe_workflow_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.DescribeWorkflowType" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.workflow_type_detail_of_yojson ~error_deserializer
 end
 
 module GetWorkflowExecutionHistory = struct
@@ -367,6 +451,12 @@ module GetWorkflowExecutionHistory = struct
   let request context (request : get_workflow_execution_history_input) =
     let input = Json_serializers.get_workflow_execution_history_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.GetWorkflowExecutionHistory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.history_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_workflow_execution_history_input) =
+    let input = Json_serializers.get_workflow_execution_history_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.GetWorkflowExecutionHistory" ~service ~context ~input
       ~output_deserializer:Json_deserializers.history_of_yojson ~error_deserializer
 end
@@ -394,6 +484,12 @@ module ListActivityTypes = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.ListActivityTypes"
       ~service ~context ~input ~output_deserializer:Json_deserializers.activity_type_infos_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_activity_types_input) =
+    let input = Json_serializers.list_activity_types_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.ListActivityTypes" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.activity_type_infos_of_yojson ~error_deserializer
 end
 
 module ListClosedWorkflowExecutions = struct
@@ -419,6 +515,12 @@ module ListClosedWorkflowExecutions = struct
     Smaws_Lib.Protocols.AwsJson.request
       ~shape_name:"SimpleWorkflowService.ListClosedWorkflowExecutions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.workflow_execution_infos_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_closed_workflow_executions_input) =
+    let input = Json_serializers.list_closed_workflow_executions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.ListClosedWorkflowExecutions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.workflow_execution_infos_of_yojson ~error_deserializer
 end
 
 module ListDomains = struct
@@ -441,6 +543,12 @@ module ListDomains = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.ListDomains" ~service
       ~context ~input ~output_deserializer:Json_deserializers.domain_infos_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_domains_input) =
+    let input = Json_serializers.list_domains_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.ListDomains" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.domain_infos_of_yojson ~error_deserializer
 end
 
 module ListOpenWorkflowExecutions = struct
@@ -464,6 +572,12 @@ module ListOpenWorkflowExecutions = struct
   let request context (request : list_open_workflow_executions_input) =
     let input = Json_serializers.list_open_workflow_executions_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.ListOpenWorkflowExecutions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.workflow_execution_infos_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : list_open_workflow_executions_input) =
+    let input = Json_serializers.list_open_workflow_executions_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.ListOpenWorkflowExecutions" ~service ~context ~input
       ~output_deserializer:Json_deserializers.workflow_execution_infos_of_yojson ~error_deserializer
 end
@@ -495,6 +609,13 @@ module ListTagsForResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_input) =
+    let input = Json_serializers.list_tags_for_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_output_of_yojson
+      ~error_deserializer
 end
 
 module ListWorkflowTypes = struct
@@ -520,6 +641,12 @@ module ListWorkflowTypes = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.ListWorkflowTypes"
       ~service ~context ~input ~output_deserializer:Json_deserializers.workflow_type_infos_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_workflow_types_input) =
+    let input = Json_serializers.list_workflow_types_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.ListWorkflowTypes" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.workflow_type_infos_of_yojson ~error_deserializer
 end
 
 module PollForActivityTask = struct
@@ -548,6 +675,12 @@ module PollForActivityTask = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.PollForActivityTask"
       ~service ~context ~input ~output_deserializer:Json_deserializers.activity_task_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : poll_for_activity_task_input) =
+    let input = Json_serializers.poll_for_activity_task_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.PollForActivityTask" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.activity_task_of_yojson ~error_deserializer
 end
 
 module PollForDecisionTask = struct
@@ -576,6 +709,12 @@ module PollForDecisionTask = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.PollForDecisionTask"
       ~service ~context ~input ~output_deserializer:Json_deserializers.decision_task_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : poll_for_decision_task_input) =
+    let input = Json_serializers.poll_for_decision_task_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.PollForDecisionTask" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.decision_task_of_yojson ~error_deserializer
 end
 
 module RecordActivityTaskHeartbeat = struct
@@ -599,6 +738,12 @@ module RecordActivityTaskHeartbeat = struct
   let request context (request : record_activity_task_heartbeat_input) =
     let input = Json_serializers.record_activity_task_heartbeat_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.RecordActivityTaskHeartbeat" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.activity_task_status_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : record_activity_task_heartbeat_input) =
+    let input = Json_serializers.record_activity_task_heartbeat_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.RecordActivityTaskHeartbeat" ~service ~context ~input
       ~output_deserializer:Json_deserializers.activity_task_status_of_yojson ~error_deserializer
 end
@@ -633,6 +778,13 @@ module RegisterActivityType = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : register_activity_type_input) =
+    let input = Json_serializers.register_activity_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.RegisterActivityType" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module RegisterDomain = struct
@@ -664,6 +816,13 @@ module RegisterDomain = struct
     let input = Json_serializers.register_domain_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.RegisterDomain" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : register_domain_input) =
+    let input = Json_serializers.register_domain_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.RegisterDomain" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -697,6 +856,13 @@ module RegisterWorkflowType = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : register_workflow_type_input) =
+    let input = Json_serializers.register_workflow_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.RegisterWorkflowType" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module RequestCancelWorkflowExecution = struct
@@ -720,6 +886,13 @@ module RequestCancelWorkflowExecution = struct
   let request context (request : request_cancel_workflow_execution_input) =
     let input = Json_serializers.request_cancel_workflow_execution_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.RequestCancelWorkflowExecution" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : request_cancel_workflow_execution_input) =
+    let input = Json_serializers.request_cancel_workflow_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.RequestCancelWorkflowExecution" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -749,6 +922,13 @@ module RespondActivityTaskCanceled = struct
       ~shape_name:"SimpleWorkflowService.RespondActivityTaskCanceled" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : respond_activity_task_canceled_input) =
+    let input = Json_serializers.respond_activity_task_canceled_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.RespondActivityTaskCanceled" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module RespondActivityTaskCompleted = struct
@@ -772,6 +952,13 @@ module RespondActivityTaskCompleted = struct
   let request context (request : respond_activity_task_completed_input) =
     let input = Json_serializers.respond_activity_task_completed_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.RespondActivityTaskCompleted" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : respond_activity_task_completed_input) =
+    let input = Json_serializers.respond_activity_task_completed_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.RespondActivityTaskCompleted" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -801,6 +988,13 @@ module RespondActivityTaskFailed = struct
       ~shape_name:"SimpleWorkflowService.RespondActivityTaskFailed" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : respond_activity_task_failed_input) =
+    let input = Json_serializers.respond_activity_task_failed_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.RespondActivityTaskFailed" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module RespondDecisionTaskCompleted = struct
@@ -824,6 +1018,13 @@ module RespondDecisionTaskCompleted = struct
   let request context (request : respond_decision_task_completed_input) =
     let input = Json_serializers.respond_decision_task_completed_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.RespondDecisionTaskCompleted" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : respond_decision_task_completed_input) =
+    let input = Json_serializers.respond_decision_task_completed_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.RespondDecisionTaskCompleted" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -851,6 +1052,13 @@ module SignalWorkflowExecution = struct
     let input = Json_serializers.signal_workflow_execution_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.SignalWorkflowExecution"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : signal_workflow_execution_input) =
+    let input = Json_serializers.signal_workflow_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.SignalWorkflowExecution" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -892,6 +1100,12 @@ module StartWorkflowExecution = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.StartWorkflowExecution"
       ~service ~context ~input ~output_deserializer:Json_deserializers.run_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_workflow_execution_input) =
+    let input = Json_serializers.start_workflow_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.StartWorkflowExecution" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.run_of_yojson ~error_deserializer
 end
 
 module TagResource = struct
@@ -923,6 +1137,13 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.TagResource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_input) =
+    let input = Json_serializers.tag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.TagResource" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module TerminateWorkflowExecution = struct
@@ -946,6 +1167,13 @@ module TerminateWorkflowExecution = struct
   let request context (request : terminate_workflow_execution_input) =
     let input = Json_serializers.terminate_workflow_execution_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"SimpleWorkflowService.TerminateWorkflowExecution" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : terminate_workflow_execution_input) =
+    let input = Json_serializers.terminate_workflow_execution_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"SimpleWorkflowService.TerminateWorkflowExecution" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
@@ -978,6 +1206,13 @@ module UndeprecateActivityType = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : undeprecate_activity_type_input) =
+    let input = Json_serializers.undeprecate_activity_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.UndeprecateActivityType" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UndeprecateDomain = struct
@@ -1006,6 +1241,13 @@ module UndeprecateDomain = struct
     let input = Json_serializers.undeprecate_domain_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.UndeprecateDomain"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : undeprecate_domain_input) =
+    let input = Json_serializers.undeprecate_domain_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.UndeprecateDomain" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -1037,6 +1279,13 @@ module UndeprecateWorkflowType = struct
       ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : undeprecate_workflow_type_input) =
+    let input = Json_serializers.undeprecate_workflow_type_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.UndeprecateWorkflowType" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1064,5 +1313,12 @@ module UntagResource = struct
     let input = Json_serializers.untag_resource_input_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"SimpleWorkflowService.UntagResource" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_input) =
+    let input = Json_serializers.untag_resource_input_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"SimpleWorkflowService.UntagResource" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end

--- a/sdks/swf/operations.mli
+++ b/sdks/swf/operations.mli
@@ -15,6 +15,15 @@ module CountClosedWorkflowExecutions : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    count_closed_workflow_executions_input ->
+    ( workflow_execution_count Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns the number of closed workflow executions within the given domain that meet the \
@@ -72,6 +81,15 @@ module CountOpenWorkflowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     count_open_workflow_executions_input ->
     ( workflow_execution_count,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    count_open_workflow_executions_input ->
+    ( workflow_execution_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -137,6 +155,15 @@ module CountPendingActivityTasks : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    count_pending_activity_tasks_input ->
+    ( pending_task_count Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns the estimated number of activity tasks in the specified task list. The count returned \
@@ -178,6 +205,15 @@ module CountPendingDecisionTasks : sig
     'http_type Smaws_Lib.Context.t ->
     count_pending_decision_tasks_input ->
     ( pending_task_count,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    count_pending_decision_tasks_input ->
+    ( pending_task_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -224,6 +260,16 @@ module DeleteActivityType : sig
     'http_type Smaws_Lib.Context.t ->
     delete_activity_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeNotDeprecatedFault of type_not_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_activity_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeNotDeprecatedFault of type_not_deprecated_fault
@@ -290,6 +336,16 @@ module DeleteWorkflowType : sig
       | `TypeNotDeprecatedFault of type_not_deprecated_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_workflow_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeNotDeprecatedFault of type_not_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified {i workflow type}.\n\n\
@@ -346,6 +402,16 @@ module DeprecateActivityType : sig
     'http_type Smaws_Lib.Context.t ->
     deprecate_activity_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeDeprecatedFault of type_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deprecate_activity_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
@@ -409,6 +475,16 @@ module DeprecateDomain : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deprecate_domain_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DomainDeprecatedFault of domain_deprecated_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Deprecates the specified domain. After a domain has been deprecated it cannot be used to create \
@@ -454,6 +530,16 @@ module DeprecateWorkflowType : sig
     'http_type Smaws_Lib.Context.t ->
     deprecate_workflow_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeDeprecatedFault of type_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deprecate_workflow_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
@@ -519,6 +605,15 @@ module DescribeActivityType : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_activity_type_input ->
+    ( activity_type_detail Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the specified activity type. This includes configuration settings \
@@ -574,6 +669,15 @@ module DescribeDomain : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_domain_input ->
+    ( domain_detail Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about the specified domain, including description and status.\n\n\
@@ -612,6 +716,15 @@ module DescribeWorkflowExecution : sig
     'http_type Smaws_Lib.Context.t ->
     describe_workflow_execution_input ->
     ( workflow_execution_detail,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_workflow_execution_input ->
+    ( workflow_execution_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -658,6 +771,15 @@ module DescribeWorkflowType : sig
     'http_type Smaws_Lib.Context.t ->
     describe_workflow_type_input ->
     ( workflow_type_detail,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_workflow_type_input ->
+    ( workflow_type_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -718,6 +840,15 @@ module GetWorkflowExecutionHistory : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_workflow_execution_history_input ->
+    ( history Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns the history of the specified workflow execution. The results may be split into multiple \
@@ -765,6 +896,15 @@ module ListActivityTypes : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_activity_types_input ->
+    ( activity_type_infos Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns information about all activities registered in the specified domain that match the \
@@ -806,6 +946,15 @@ module ListClosedWorkflowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     list_closed_workflow_executions_input ->
     ( workflow_execution_infos,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_closed_workflow_executions_input ->
+    ( workflow_execution_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -870,6 +1019,14 @@ module ListDomains : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_domains_input ->
+    ( domain_infos Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault ] )
+    result
 end
 [@@ocaml.doc
   "Returns the list of domains registered in the account. The results may be split into multiple \
@@ -914,6 +1071,15 @@ module ListOpenWorkflowExecutions : sig
     'http_type Smaws_Lib.Context.t ->
     list_open_workflow_executions_input ->
     ( workflow_execution_infos,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_open_workflow_executions_input ->
+    ( workflow_execution_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -982,6 +1148,16 @@ module ListTagsForResource : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_input ->
+    ( list_tags_for_resource_output Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc "List tags for a given domain.\n"]
 
@@ -996,6 +1172,15 @@ module ListWorkflowTypes : sig
     'http_type Smaws_Lib.Context.t ->
     list_workflow_types_input ->
     ( workflow_type_infos,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_workflow_types_input ->
+    ( workflow_type_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1040,6 +1225,16 @@ module PollForActivityTask : sig
     'http_type Smaws_Lib.Context.t ->
     poll_for_activity_task_input ->
     ( activity_task,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    poll_for_activity_task_input ->
+    ( activity_task Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
@@ -1094,6 +1289,16 @@ module PollForDecisionTask : sig
     'http_type Smaws_Lib.Context.t ->
     poll_for_decision_task_input ->
     ( decision_task,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    poll_for_decision_task_input ->
+    ( decision_task Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
@@ -1157,6 +1362,15 @@ module RecordActivityTaskHeartbeat : sig
     'http_type Smaws_Lib.Context.t ->
     record_activity_task_heartbeat_input ->
     ( activity_task_status,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    record_activity_task_heartbeat_input ->
+    ( activity_task_status Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1231,6 +1445,17 @@ module RegisterActivityType : sig
       | `TypeAlreadyExistsFault of type_already_exists_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_activity_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeAlreadyExistsFault of type_already_exists_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Registers a new {i activity type} along with its configuration settings in the specified \
@@ -1296,6 +1521,17 @@ module RegisterDomain : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TooManyTagsFault of too_many_tags_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_domain_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DomainAlreadyExistsFault of domain_already_exists_fault
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TooManyTagsFault of too_many_tags_fault ] )
+    result
 end
 [@@ocaml.doc
   "Registers a new domain.\n\n\
@@ -1336,6 +1572,17 @@ module RegisterWorkflowType : sig
     'http_type Smaws_Lib.Context.t ->
     register_workflow_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeAlreadyExistsFault of type_already_exists_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_workflow_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
@@ -1405,6 +1652,15 @@ module RequestCancelWorkflowExecution : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    request_cancel_workflow_execution_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Records a [WorkflowExecutionCancelRequested] event in the currently running workflow execution \
@@ -1453,6 +1709,15 @@ module RespondActivityTaskCanceled : sig
     'http_type Smaws_Lib.Context.t ->
     respond_activity_task_canceled_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    respond_activity_task_canceled_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1514,6 +1779,15 @@ module RespondActivityTaskCompleted : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    respond_activity_task_completed_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Used by workers to tell the service that the [ActivityTask] identified by the [taskToken] \
@@ -1571,6 +1845,15 @@ module RespondActivityTaskFailed : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    respond_activity_task_failed_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Used by workers to tell the service that the [ActivityTask] identified by the [taskToken] has \
@@ -1622,6 +1905,15 @@ module RespondDecisionTaskCompleted : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    respond_decision_task_completed_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Used by deciders to tell the service that the [DecisionTask] identified by the [taskToken] has \
@@ -1652,6 +1944,15 @@ module SignalWorkflowExecution : sig
     'http_type Smaws_Lib.Context.t ->
     signal_workflow_execution_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    signal_workflow_execution_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1706,6 +2007,19 @@ module StartWorkflowExecution : sig
     'http_type Smaws_Lib.Context.t ->
     start_workflow_execution_input ->
     ( run,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DefaultUndefinedFault of default_undefined_fault
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeDeprecatedFault of type_deprecated_fault
+      | `UnknownResourceFault of unknown_resource_fault
+      | `WorkflowExecutionAlreadyStartedFault of workflow_execution_already_started_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_workflow_execution_input ->
+    ( run Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DefaultUndefinedFault of default_undefined_fault
       | `LimitExceededFault of limit_exceeded_fault
@@ -1793,6 +2107,17 @@ module TagResource : sig
       | `TooManyTagsFault of too_many_tags_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TooManyTagsFault of too_many_tags_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Add a tag to a Amazon SWF domain.\n\n\
@@ -1811,6 +2136,15 @@ module TerminateWorkflowExecution : sig
     'http_type Smaws_Lib.Context.t ->
     terminate_workflow_execution_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    terminate_workflow_execution_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
@@ -1866,6 +2200,16 @@ module UndeprecateActivityType : sig
     'http_type Smaws_Lib.Context.t ->
     undeprecate_activity_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeAlreadyExistsFault of type_already_exists_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    undeprecate_activity_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
@@ -1931,6 +2275,16 @@ module UndeprecateDomain : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `UnknownResourceFault of unknown_resource_fault ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    undeprecate_domain_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DomainAlreadyExistsFault of domain_already_exists_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
 end
 [@@ocaml.doc
   "Undeprecates a previously deprecated domain. After a domain has been undeprecated it can be \
@@ -1974,6 +2328,16 @@ module UndeprecateWorkflowType : sig
     'http_type Smaws_Lib.Context.t ->
     undeprecate_workflow_type_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `TypeAlreadyExistsFault of type_already_exists_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    undeprecate_workflow_type_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
@@ -2034,6 +2398,16 @@ module UntagResource : sig
     'http_type Smaws_Lib.Context.t ->
     untag_resource_input ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `LimitExceededFault of limit_exceeded_fault
+      | `OperationNotPermittedFault of operation_not_permitted_fault
+      | `UnknownResourceFault of unknown_resource_fault ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_input ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault

--- a/sdks/swf/operations.mli
+++ b/sdks/swf/operations.mli
@@ -22,7 +22,8 @@ module CountClosedWorkflowExecutions : sig
     ( workflow_execution_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -92,7 +93,8 @@ module CountOpenWorkflowExecutions : sig
     ( workflow_execution_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -162,7 +164,8 @@ module CountPendingActivityTasks : sig
     ( pending_task_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -216,7 +219,8 @@ module CountPendingDecisionTasks : sig
     ( pending_task_count Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -273,7 +277,8 @@ module DeleteActivityType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeNotDeprecatedFault of type_not_deprecated_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -344,7 +349,8 @@ module DeleteWorkflowType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeNotDeprecatedFault of type_not_deprecated_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -415,7 +421,8 @@ module DeprecateActivityType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -483,7 +490,8 @@ module DeprecateDomain : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DomainDeprecatedFault of domain_deprecated_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -543,7 +551,8 @@ module DeprecateWorkflowType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -612,7 +621,8 @@ module DescribeActivityType : sig
     ( activity_type_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -676,7 +686,8 @@ module DescribeDomain : sig
     ( domain_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -727,7 +738,8 @@ module DescribeWorkflowExecution : sig
     ( workflow_execution_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -782,7 +794,8 @@ module DescribeWorkflowType : sig
     ( workflow_type_detail Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -847,7 +860,8 @@ module GetWorkflowExecutionHistory : sig
     ( history Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -903,7 +917,8 @@ module ListActivityTypes : sig
     ( activity_type_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -957,7 +972,8 @@ module ListClosedWorkflowExecutions : sig
     ( workflow_execution_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1025,7 +1041,8 @@ module ListDomains : sig
     list_domains_input ->
     ( domain_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `OperationNotPermittedFault of operation_not_permitted_fault ] )
+      | `OperationNotPermittedFault of operation_not_permitted_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1082,7 +1099,8 @@ module ListOpenWorkflowExecutions : sig
     ( workflow_execution_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1156,7 +1174,8 @@ module ListTagsForResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List tags for a given domain.\n"]
@@ -1183,7 +1202,8 @@ module ListWorkflowTypes : sig
     ( workflow_type_infos Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1238,7 +1258,8 @@ module PollForActivityTask : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1302,7 +1323,8 @@ module PollForDecisionTask : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1373,7 +1395,8 @@ module RecordActivityTaskHeartbeat : sig
     ( activity_task_status Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1454,7 +1477,8 @@ module RegisterActivityType : sig
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1530,7 +1554,8 @@ module RegisterDomain : sig
       | `DomainAlreadyExistsFault of domain_already_exists_fault
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `TooManyTagsFault of too_many_tags_fault ] )
+      | `TooManyTagsFault of too_many_tags_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1587,7 +1612,8 @@ module RegisterWorkflowType : sig
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1659,7 +1685,8 @@ module RequestCancelWorkflowExecution : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1720,7 +1747,8 @@ module RespondActivityTaskCanceled : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1786,7 +1814,8 @@ module RespondActivityTaskCompleted : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1852,7 +1881,8 @@ module RespondActivityTaskFailed : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1912,7 +1942,8 @@ module RespondDecisionTaskCompleted : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1955,7 +1986,8 @@ module SignalWorkflowExecution : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2026,7 +2058,8 @@ module StartWorkflowExecution : sig
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeDeprecatedFault of type_deprecated_fault
       | `UnknownResourceFault of unknown_resource_fault
-      | `WorkflowExecutionAlreadyStartedFault of workflow_execution_already_started_fault ] )
+      | `WorkflowExecutionAlreadyStartedFault of workflow_execution_already_started_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2116,7 +2149,8 @@ module TagResource : sig
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TooManyTagsFault of too_many_tags_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2147,7 +2181,8 @@ module TerminateWorkflowExecution : sig
     ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2213,7 +2248,8 @@ module UndeprecateActivityType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2283,7 +2319,8 @@ module UndeprecateDomain : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DomainAlreadyExistsFault of domain_already_exists_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2341,7 +2378,8 @@ module UndeprecateWorkflowType : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OperationNotPermittedFault of operation_not_permitted_fault
       | `TypeAlreadyExistsFault of type_already_exists_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2411,7 +2449,8 @@ module UntagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `LimitExceededFault of limit_exceeded_fault
       | `OperationNotPermittedFault of operation_not_permitted_fault
-      | `UnknownResourceFault of unknown_resource_fault ] )
+      | `UnknownResourceFault of unknown_resource_fault ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Remove a tag from a Amazon SWF domain.\n"]

--- a/sdks/transcribe/Smaws_Client_Transcribe.mli
+++ b/sdks/transcribe/Smaws_Client_Transcribe.mli
@@ -878,7 +878,8 @@ module CreateCallAnalyticsCategory : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -933,7 +934,8 @@ module CreateLanguageModel : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -985,7 +987,8 @@ module CreateMedicalVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1033,7 +1036,8 @@ module CreateVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1079,7 +1083,8 @@ module CreateVocabularyFilter : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1125,7 +1130,8 @@ module DeleteCallAnalyticsCategory : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1157,7 +1163,8 @@ module DeleteCallAnalyticsJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1189,7 +1196,8 @@ module DeleteLanguageModel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1221,7 +1229,8 @@ module DeleteMedicalScribeJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1253,7 +1262,8 @@ module DeleteMedicalTranscriptionJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1288,7 +1298,8 @@ module DeleteMedicalVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1321,7 +1332,8 @@ module DeleteTranscriptionJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1356,7 +1368,8 @@ module DeleteVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1391,7 +1404,8 @@ module DeleteVocabularyFilter : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1427,7 +1441,8 @@ module DescribeLanguageModel : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1468,7 +1483,8 @@ module GetCallAnalyticsCategory : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1504,7 +1520,8 @@ module GetCallAnalyticsJob : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1551,7 +1568,8 @@ module GetMedicalScribeJob : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1592,7 +1610,8 @@ module GetMedicalTranscriptionJob : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1633,7 +1652,8 @@ module GetMedicalVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1673,7 +1693,8 @@ module GetTranscriptionJob : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1717,7 +1738,8 @@ module GetVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1757,7 +1779,8 @@ module GetVocabularyFilter : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1790,7 +1813,8 @@ module ListCallAnalyticsCategories : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1823,7 +1847,8 @@ module ListCallAnalyticsJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1857,7 +1882,8 @@ module ListLanguageModels : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1891,7 +1917,8 @@ module ListMedicalScribeJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1925,7 +1952,8 @@ module ListMedicalTranscriptionJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1959,7 +1987,8 @@ module ListMedicalVocabularies : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1996,7 +2025,8 @@ module ListTagsForResource : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2030,7 +2060,8 @@ module ListTranscriptionJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2064,7 +2095,8 @@ module ListVocabularies : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2098,7 +2130,8 @@ module ListVocabularyFilters : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2135,7 +2168,8 @@ module StartCallAnalyticsJob : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2217,7 +2251,8 @@ module StartMedicalScribeJob : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2292,7 +2327,8 @@ module StartMedicalTranscriptionJob : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2369,7 +2405,8 @@ module StartTranscriptionJob : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2438,7 +2475,8 @@ module TagResource : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2478,7 +2516,8 @@ module UntagResource : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2518,7 +2557,8 @@ module UpdateCallAnalyticsCategory : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2559,7 +2599,8 @@ module UpdateMedicalVocabulary : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2598,7 +2639,8 @@ module UpdateVocabulary : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2635,7 +2677,8 @@ module UpdateVocabularyFilter : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/transcribe/Smaws_Client_Transcribe.mli
+++ b/sdks/transcribe/Smaws_Client_Transcribe.mli
@@ -869,6 +869,17 @@ module CreateCallAnalyticsCategory : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_call_analytics_category_request ->
+    ( create_call_analytics_category_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new Call Analytics category.\n\n\
@@ -907,6 +918,17 @@ module CreateLanguageModel : sig
     'http_type Smaws_Lib.Context.t ->
     create_language_model_request ->
     ( create_language_model_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_language_model_request ->
+    ( create_language_model_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -954,6 +976,17 @@ module CreateMedicalVocabulary : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_medical_vocabulary_request ->
+    ( create_medical_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new custom medical vocabulary.\n\n\
@@ -985,6 +1018,17 @@ module CreateVocabulary : sig
     'http_type Smaws_Lib.Context.t ->
     create_vocabulary_request ->
     ( create_vocabulary_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vocabulary_request ->
+    ( create_vocabulary_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -1026,6 +1070,17 @@ module CreateVocabularyFilter : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vocabulary_filter_request ->
+    ( create_vocabulary_filter_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new custom vocabulary filter.\n\n\
@@ -1061,6 +1116,17 @@ module DeleteCallAnalyticsCategory : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_call_analytics_category_request ->
+    ( delete_call_analytics_category_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a Call Analytics category. To use this operation, specify the name of the category you \
@@ -1078,6 +1144,16 @@ module DeleteCallAnalyticsJob : sig
     'http_type Smaws_Lib.Context.t ->
     delete_call_analytics_job_request ->
     ( delete_call_analytics_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_call_analytics_job_request ->
+    ( delete_call_analytics_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1105,6 +1181,16 @@ module DeleteLanguageModel : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_language_model_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a custom language model. To use this operation, specify the name of the language model \
@@ -1127,6 +1213,16 @@ module DeleteMedicalScribeJob : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_medical_scribe_job_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a Medical Scribe job. To use this operation, specify the name of the job you want to \
@@ -1144,6 +1240,16 @@ module DeleteMedicalTranscriptionJob : sig
     'http_type Smaws_Lib.Context.t ->
     delete_medical_transcription_job_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_medical_transcription_job_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1173,6 +1279,17 @@ module DeleteMedicalVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_medical_vocabulary_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a custom medical vocabulary. To use this operation, specify the name of the custom \
@@ -1196,6 +1313,16 @@ module DeleteTranscriptionJob : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_transcription_job_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a transcription job. To use this operation, specify the name of the job you want to \
@@ -1214,6 +1341,17 @@ module DeleteVocabulary : sig
     'http_type Smaws_Lib.Context.t ->
     delete_vocabulary_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vocabulary_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1244,6 +1382,17 @@ module DeleteVocabularyFilter : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vocabulary_filter_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a custom vocabulary filter. To use this operation, specify the name of the custom \
@@ -1263,6 +1412,17 @@ module DescribeLanguageModel : sig
     'http_type Smaws_Lib.Context.t ->
     describe_language_model_request ->
     ( describe_language_model_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_language_model_request ->
+    ( describe_language_model_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1299,6 +1459,17 @@ module GetCallAnalyticsCategory : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_call_analytics_category_request ->
+    ( get_call_analytics_category_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified Call Analytics category.\n\n\
@@ -1318,6 +1489,17 @@ module GetCallAnalyticsJob : sig
     'http_type Smaws_Lib.Context.t ->
     get_call_analytics_job_request ->
     ( get_call_analytics_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_call_analytics_job_request ->
+    ( get_call_analytics_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1360,6 +1542,17 @@ module GetMedicalScribeJob : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_medical_scribe_job_request ->
+    ( get_medical_scribe_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified Medical Scribe job.\n\n\
@@ -1384,6 +1577,17 @@ module GetMedicalTranscriptionJob : sig
     'http_type Smaws_Lib.Context.t ->
     get_medical_transcription_job_request ->
     ( get_medical_transcription_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_medical_transcription_job_request ->
+    ( get_medical_transcription_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1420,6 +1624,17 @@ module GetMedicalVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_medical_vocabulary_request ->
+    ( get_medical_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified custom medical vocabulary.\n\n\
@@ -1443,6 +1658,17 @@ module GetTranscriptionJob : sig
     'http_type Smaws_Lib.Context.t ->
     get_transcription_job_request ->
     ( get_transcription_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_transcription_job_request ->
+    ( get_transcription_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1482,6 +1708,17 @@ module GetVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_vocabulary_request ->
+    ( get_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified custom vocabulary.\n\n\
@@ -1511,6 +1748,17 @@ module GetVocabularyFilter : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_vocabulary_filter_request ->
+    ( get_vocabulary_filter_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified custom vocabulary filter.\n\n\
@@ -1534,6 +1782,16 @@ module ListCallAnalyticsCategories : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_call_analytics_categories_request ->
+    ( list_call_analytics_categories_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of Call Analytics categories, including all rules that make up each category.\n\n\
@@ -1552,6 +1810,16 @@ module ListCallAnalyticsJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_call_analytics_jobs_request ->
     ( list_call_analytics_jobs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_call_analytics_jobs_request ->
+    ( list_call_analytics_jobs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1581,6 +1849,16 @@ module ListLanguageModels : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_language_models_request ->
+    ( list_language_models_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of custom language models that match the specified criteria. If no criteria are \
@@ -1600,6 +1878,16 @@ module ListMedicalScribeJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_medical_scribe_jobs_request ->
     ( list_medical_scribe_jobs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_medical_scribe_jobs_request ->
+    ( list_medical_scribe_jobs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1629,6 +1917,16 @@ module ListMedicalTranscriptionJobs : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_medical_transcription_jobs_request ->
+    ( list_medical_transcription_jobs_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of medical transcription jobs that match the specified criteria. If no criteria \
@@ -1648,6 +1946,16 @@ module ListMedicalVocabularies : sig
     'http_type Smaws_Lib.Context.t ->
     list_medical_vocabularies_request ->
     ( list_medical_vocabularies_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_medical_vocabularies_request ->
+    ( list_medical_vocabularies_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1679,6 +1987,17 @@ module ListTagsForResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all tags associated with the specified transcription job, vocabulary, model, or resource.\n\n\
@@ -1698,6 +2017,16 @@ module ListTranscriptionJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_transcription_jobs_request ->
     ( list_transcription_jobs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_transcription_jobs_request ->
+    ( list_transcription_jobs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1727,6 +2056,16 @@ module ListVocabularies : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vocabularies_request ->
+    ( list_vocabularies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of custom vocabularies that match the specified criteria. If no criteria are \
@@ -1746,6 +2085,16 @@ module ListVocabularyFilters : sig
     'http_type Smaws_Lib.Context.t ->
     list_vocabulary_filters_request ->
     ( list_vocabulary_filters_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vocabulary_filters_request ->
+    ( list_vocabulary_filters_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -1771,6 +2120,17 @@ module StartCallAnalyticsJob : sig
     'http_type Smaws_Lib.Context.t ->
     start_call_analytics_job_request ->
     ( start_call_analytics_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_call_analytics_job_request ->
+    ( start_call_analytics_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -1848,6 +2208,17 @@ module StartMedicalScribeJob : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_medical_scribe_job_request ->
+    ( start_medical_scribe_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Transcribes patient-clinician conversations and generates clinical notes. \n\n\
@@ -1906,6 +2277,17 @@ module StartMedicalTranscriptionJob : sig
     'http_type Smaws_Lib.Context.t ->
     start_medical_transcription_job_request ->
     ( start_medical_transcription_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_medical_transcription_job_request ->
+    ( start_medical_transcription_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -1978,6 +2360,17 @@ module StartTranscriptionJob : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_transcription_job_request ->
+    ( start_transcription_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Transcribes the audio from a media file and applies any additional Request Parameters you \
@@ -2035,6 +2428,18 @@ module TagResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more custom tags, each in the form of a key:value pair, to the specified resource.\n\n\
@@ -2063,6 +2468,18 @@ module UntagResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the specified tags from the specified Amazon Transcribe resource.\n\n\
@@ -2084,6 +2501,18 @@ module UpdateCallAnalyticsCategory : sig
     'http_type Smaws_Lib.Context.t ->
     update_call_analytics_category_request ->
     ( update_call_analytics_category_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_call_analytics_category_request ->
+    ( update_call_analytics_category_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -2120,6 +2549,18 @@ module UpdateMedicalVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_medical_vocabulary_request ->
+    ( update_medical_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing custom medical vocabulary with new values. This operation overwrites all \
@@ -2147,6 +2588,18 @@ module UpdateVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_vocabulary_request ->
+    ( update_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing custom vocabulary with new values. This operation overwrites all existing \
@@ -2167,6 +2620,17 @@ module UpdateVocabularyFilter : sig
     'http_type Smaws_Lib.Context.t ->
     update_vocabulary_filter_request ->
     ( update_vocabulary_filter_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_vocabulary_filter_request ->
+    ( update_vocabulary_filter_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception

--- a/sdks/transcribe/operations.ml
+++ b/sdks/transcribe/operations.ml
@@ -31,6 +31,13 @@ module CreateCallAnalyticsCategory = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_call_analytics_category_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_call_analytics_category_request) =
+    let input = Json_serializers.create_call_analytics_category_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.CreateCallAnalyticsCategory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_call_analytics_category_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateLanguageModel = struct
@@ -61,6 +68,13 @@ module CreateLanguageModel = struct
     let input = Json_serializers.create_language_model_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.CreateLanguageModel" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.create_language_model_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_language_model_request) =
+    let input = Json_serializers.create_language_model_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.CreateLanguageModel"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_language_model_response_of_yojson
       ~error_deserializer
 end
@@ -95,6 +109,13 @@ module CreateMedicalVocabulary = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_medical_vocabulary_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_medical_vocabulary_request) =
+    let input = Json_serializers.create_medical_vocabulary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.CreateMedicalVocabulary" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_medical_vocabulary_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateVocabulary = struct
@@ -126,6 +147,13 @@ module CreateVocabulary = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.CreateVocabulary" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_vocabulary_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_vocabulary_request) =
+    let input = Json_serializers.create_vocabulary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.CreateVocabulary"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_vocabulary_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateVocabularyFilter = struct
@@ -156,6 +184,13 @@ module CreateVocabularyFilter = struct
     let input = Json_serializers.create_vocabulary_filter_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.CreateVocabularyFilter" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.create_vocabulary_filter_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_vocabulary_filter_request) =
+    let input = Json_serializers.create_vocabulary_filter_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.CreateVocabularyFilter" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_vocabulary_filter_response_of_yojson
       ~error_deserializer
 end
@@ -190,6 +225,13 @@ module DeleteCallAnalyticsCategory = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_call_analytics_category_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_call_analytics_category_request) =
+    let input = Json_serializers.delete_call_analytics_category_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.DeleteCallAnalyticsCategory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_call_analytics_category_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteCallAnalyticsJob = struct
@@ -217,6 +259,13 @@ module DeleteCallAnalyticsJob = struct
     let input = Json_serializers.delete_call_analytics_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.DeleteCallAnalyticsJob" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.delete_call_analytics_job_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_call_analytics_job_request) =
+    let input = Json_serializers.delete_call_analytics_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.DeleteCallAnalyticsJob" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_call_analytics_job_response_of_yojson
       ~error_deserializer
 end
@@ -247,6 +296,13 @@ module DeleteLanguageModel = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.DeleteLanguageModel" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_language_model_request) =
+    let input = Json_serializers.delete_language_model_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.DeleteLanguageModel"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteMedicalScribeJob = struct
@@ -275,6 +331,13 @@ module DeleteMedicalScribeJob = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.DeleteMedicalScribeJob" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_medical_scribe_job_request) =
+    let input = Json_serializers.delete_medical_scribe_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.DeleteMedicalScribeJob" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteMedicalTranscriptionJob = struct
@@ -302,6 +365,13 @@ module DeleteMedicalTranscriptionJob = struct
     let input = Json_serializers.delete_medical_transcription_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.DeleteMedicalTranscriptionJob"
       ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_medical_transcription_job_request) =
+    let input = Json_serializers.delete_medical_transcription_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.DeleteMedicalTranscriptionJob" ~service ~context ~input
       ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
@@ -335,6 +405,13 @@ module DeleteMedicalVocabulary = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.DeleteMedicalVocabulary" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_medical_vocabulary_request) =
+    let input = Json_serializers.delete_medical_vocabulary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.DeleteMedicalVocabulary" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteTranscriptionJob = struct
@@ -362,6 +439,13 @@ module DeleteTranscriptionJob = struct
     let input = Json_serializers.delete_transcription_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.DeleteTranscriptionJob" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_transcription_job_request) =
+    let input = Json_serializers.delete_transcription_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.DeleteTranscriptionJob" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
 end
 
@@ -394,6 +478,13 @@ module DeleteVocabulary = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.DeleteVocabulary" ~service ~context
       ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_vocabulary_request) =
+    let input = Json_serializers.delete_vocabulary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.DeleteVocabulary"
+      ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DeleteVocabularyFilter = struct
@@ -425,6 +516,13 @@ module DeleteVocabularyFilter = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.DeleteVocabularyFilter" ~service
       ~context ~input ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_vocabulary_filter_request) =
+    let input = Json_serializers.delete_vocabulary_filter_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.DeleteVocabularyFilter" ~service ~context ~input
+      ~output_deserializer:Smaws_Lib.Smithy_api.Json_deserializers.unit__of_yojson
+      ~error_deserializer
 end
 
 module DescribeLanguageModel = struct
@@ -455,6 +553,13 @@ module DescribeLanguageModel = struct
     let input = Json_serializers.describe_language_model_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.DescribeLanguageModel" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_language_model_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_language_model_request) =
+    let input = Json_serializers.describe_language_model_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.DescribeLanguageModel"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_language_model_response_of_yojson
       ~error_deserializer
 end
@@ -489,6 +594,13 @@ module GetCallAnalyticsCategory = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_call_analytics_category_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_call_analytics_category_request) =
+    let input = Json_serializers.get_call_analytics_category_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.GetCallAnalyticsCategory" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_call_analytics_category_response_of_yojson
+      ~error_deserializer
 end
 
 module GetCallAnalyticsJob = struct
@@ -519,6 +631,13 @@ module GetCallAnalyticsJob = struct
     let input = Json_serializers.get_call_analytics_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.GetCallAnalyticsJob" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_call_analytics_job_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_call_analytics_job_request) =
+    let input = Json_serializers.get_call_analytics_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.GetCallAnalyticsJob"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_call_analytics_job_response_of_yojson
       ~error_deserializer
 end
@@ -553,6 +672,13 @@ module GetMedicalScribeJob = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_medical_scribe_job_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_medical_scribe_job_request) =
+    let input = Json_serializers.get_medical_scribe_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.GetMedicalScribeJob"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_medical_scribe_job_response_of_yojson
+      ~error_deserializer
 end
 
 module GetMedicalTranscriptionJob = struct
@@ -583,6 +709,13 @@ module GetMedicalTranscriptionJob = struct
     let input = Json_serializers.get_medical_transcription_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.GetMedicalTranscriptionJob" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_medical_transcription_job_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_medical_transcription_job_request) =
+    let input = Json_serializers.get_medical_transcription_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.GetMedicalTranscriptionJob" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_medical_transcription_job_response_of_yojson
       ~error_deserializer
 end
@@ -617,6 +750,13 @@ module GetMedicalVocabulary = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_medical_vocabulary_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_medical_vocabulary_request) =
+    let input = Json_serializers.get_medical_vocabulary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.GetMedicalVocabulary"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_medical_vocabulary_response_of_yojson
+      ~error_deserializer
 end
 
 module GetTranscriptionJob = struct
@@ -647,6 +787,13 @@ module GetTranscriptionJob = struct
     let input = Json_serializers.get_transcription_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.GetTranscriptionJob" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_transcription_job_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_transcription_job_request) =
+    let input = Json_serializers.get_transcription_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.GetTranscriptionJob"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_transcription_job_response_of_yojson
       ~error_deserializer
 end
@@ -680,6 +827,12 @@ module GetVocabulary = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.GetVocabulary" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_vocabulary_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_vocabulary_request) =
+    let input = Json_serializers.get_vocabulary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.GetVocabulary"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_vocabulary_response_of_yojson ~error_deserializer
 end
 
 module GetVocabularyFilter = struct
@@ -712,6 +865,13 @@ module GetVocabularyFilter = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_vocabulary_filter_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_vocabulary_filter_request) =
+    let input = Json_serializers.get_vocabulary_filter_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.GetVocabularyFilter"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_vocabulary_filter_response_of_yojson
+      ~error_deserializer
 end
 
 module ListCallAnalyticsCategories = struct
@@ -739,6 +899,13 @@ module ListCallAnalyticsCategories = struct
     let input = Json_serializers.list_call_analytics_categories_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.ListCallAnalyticsCategories"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_call_analytics_categories_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_call_analytics_categories_request) =
+    let input = Json_serializers.list_call_analytics_categories_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.ListCallAnalyticsCategories" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_call_analytics_categories_response_of_yojson
       ~error_deserializer
 end
@@ -770,6 +937,13 @@ module ListCallAnalyticsJobs = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_call_analytics_jobs_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_call_analytics_jobs_request) =
+    let input = Json_serializers.list_call_analytics_jobs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.ListCallAnalyticsJobs"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_call_analytics_jobs_response_of_yojson
+      ~error_deserializer
 end
 
 module ListLanguageModels = struct
@@ -797,6 +971,13 @@ module ListLanguageModels = struct
     let input = Json_serializers.list_language_models_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.ListLanguageModels" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_language_models_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_language_models_request) =
+    let input = Json_serializers.list_language_models_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.ListLanguageModels"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_language_models_response_of_yojson
       ~error_deserializer
 end
@@ -828,6 +1009,13 @@ module ListMedicalScribeJobs = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_medical_scribe_jobs_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_medical_scribe_jobs_request) =
+    let input = Json_serializers.list_medical_scribe_jobs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.ListMedicalScribeJobs"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_medical_scribe_jobs_response_of_yojson
+      ~error_deserializer
 end
 
 module ListMedicalTranscriptionJobs = struct
@@ -857,6 +1045,13 @@ module ListMedicalTranscriptionJobs = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_medical_transcription_jobs_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_medical_transcription_jobs_request) =
+    let input = Json_serializers.list_medical_transcription_jobs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.ListMedicalTranscriptionJobs" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_medical_transcription_jobs_response_of_yojson
+      ~error_deserializer
 end
 
 module ListMedicalVocabularies = struct
@@ -884,6 +1079,13 @@ module ListMedicalVocabularies = struct
     let input = Json_serializers.list_medical_vocabularies_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.ListMedicalVocabularies" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_medical_vocabularies_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_medical_vocabularies_request) =
+    let input = Json_serializers.list_medical_vocabularies_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.ListMedicalVocabularies" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_medical_vocabularies_response_of_yojson
       ~error_deserializer
 end
@@ -918,6 +1120,13 @@ module ListTagsForResource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.ListTagsForResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module ListTranscriptionJobs = struct
@@ -945,6 +1154,13 @@ module ListTranscriptionJobs = struct
     let input = Json_serializers.list_transcription_jobs_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.ListTranscriptionJobs" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_transcription_jobs_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_transcription_jobs_request) =
+    let input = Json_serializers.list_transcription_jobs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.ListTranscriptionJobs"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_transcription_jobs_response_of_yojson
       ~error_deserializer
 end
@@ -975,6 +1191,13 @@ module ListVocabularies = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.ListVocabularies" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_vocabularies_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_vocabularies_request) =
+    let input = Json_serializers.list_vocabularies_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.ListVocabularies"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_vocabularies_response_of_yojson
+      ~error_deserializer
 end
 
 module ListVocabularyFilters = struct
@@ -1002,6 +1225,13 @@ module ListVocabularyFilters = struct
     let input = Json_serializers.list_vocabulary_filters_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.ListVocabularyFilters" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_vocabulary_filters_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_vocabulary_filters_request) =
+    let input = Json_serializers.list_vocabulary_filters_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.ListVocabularyFilters"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_vocabulary_filters_response_of_yojson
       ~error_deserializer
 end
@@ -1036,6 +1266,13 @@ module StartCallAnalyticsJob = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.start_call_analytics_job_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_call_analytics_job_request) =
+    let input = Json_serializers.start_call_analytics_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.StartCallAnalyticsJob"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_call_analytics_job_response_of_yojson
+      ~error_deserializer
 end
 
 module StartMedicalScribeJob = struct
@@ -1066,6 +1303,13 @@ module StartMedicalScribeJob = struct
     let input = Json_serializers.start_medical_scribe_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.StartMedicalScribeJob" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.start_medical_scribe_job_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_medical_scribe_job_request) =
+    let input = Json_serializers.start_medical_scribe_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.StartMedicalScribeJob"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_medical_scribe_job_response_of_yojson
       ~error_deserializer
 end
@@ -1100,6 +1344,13 @@ module StartMedicalTranscriptionJob = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_medical_transcription_job_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_medical_transcription_job_request) =
+    let input = Json_serializers.start_medical_transcription_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.StartMedicalTranscriptionJob" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_medical_transcription_job_response_of_yojson
+      ~error_deserializer
 end
 
 module StartTranscriptionJob = struct
@@ -1130,6 +1381,13 @@ module StartTranscriptionJob = struct
     let input = Json_serializers.start_transcription_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.StartTranscriptionJob" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.start_transcription_job_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : start_transcription_job_request) =
+    let input = Json_serializers.start_transcription_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.StartTranscriptionJob"
+      ~service ~context ~input
       ~output_deserializer:Json_deserializers.start_transcription_job_response_of_yojson
       ~error_deserializer
 end
@@ -1166,6 +1424,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.TagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.TagResource" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -1200,6 +1464,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.UntagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
 module UpdateCallAnalyticsCategory = struct
@@ -1233,6 +1503,13 @@ module UpdateCallAnalyticsCategory = struct
     let input = Json_serializers.update_call_analytics_category_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.UpdateCallAnalyticsCategory"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_call_analytics_category_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_call_analytics_category_request) =
+    let input = Json_serializers.update_call_analytics_category_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.UpdateCallAnalyticsCategory" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_call_analytics_category_response_of_yojson
       ~error_deserializer
 end
@@ -1270,6 +1547,13 @@ module UpdateMedicalVocabulary = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_medical_vocabulary_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_medical_vocabulary_request) =
+    let input = Json_serializers.update_medical_vocabulary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.UpdateMedicalVocabulary" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_medical_vocabulary_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateVocabulary = struct
@@ -1304,6 +1588,13 @@ module UpdateVocabulary = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.UpdateVocabulary" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_vocabulary_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_vocabulary_request) =
+    let input = Json_serializers.update_vocabulary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"Transcribe.UpdateVocabulary"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_vocabulary_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateVocabularyFilter = struct
@@ -1334,6 +1625,13 @@ module UpdateVocabularyFilter = struct
     let input = Json_serializers.update_vocabulary_filter_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"Transcribe.UpdateVocabularyFilter" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_vocabulary_filter_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_vocabulary_filter_request) =
+    let input = Json_serializers.update_vocabulary_filter_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"Transcribe.UpdateVocabularyFilter" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_vocabulary_filter_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/transcribe/operations.mli
+++ b/sdks/transcribe/operations.mli
@@ -28,7 +28,8 @@ module CreateCallAnalyticsCategory : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -83,7 +84,8 @@ module CreateLanguageModel : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -135,7 +137,8 @@ module CreateMedicalVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -183,7 +186,8 @@ module CreateVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -229,7 +233,8 @@ module CreateVocabularyFilter : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -275,7 +280,8 @@ module DeleteCallAnalyticsCategory : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -307,7 +313,8 @@ module DeleteCallAnalyticsJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -339,7 +346,8 @@ module DeleteLanguageModel : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -371,7 +379,8 @@ module DeleteMedicalScribeJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -403,7 +412,8 @@ module DeleteMedicalTranscriptionJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -438,7 +448,8 @@ module DeleteMedicalVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -471,7 +482,8 @@ module DeleteTranscriptionJob : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -506,7 +518,8 @@ module DeleteVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -541,7 +554,8 @@ module DeleteVocabularyFilter : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -577,7 +591,8 @@ module DescribeLanguageModel : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -618,7 +633,8 @@ module GetCallAnalyticsCategory : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -654,7 +670,8 @@ module GetCallAnalyticsJob : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -701,7 +718,8 @@ module GetMedicalScribeJob : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -742,7 +760,8 @@ module GetMedicalTranscriptionJob : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -783,7 +802,8 @@ module GetMedicalVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -823,7 +843,8 @@ module GetTranscriptionJob : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -867,7 +888,8 @@ module GetVocabulary : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -907,7 +929,8 @@ module GetVocabularyFilter : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -940,7 +963,8 @@ module ListCallAnalyticsCategories : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -973,7 +997,8 @@ module ListCallAnalyticsJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1007,7 +1032,8 @@ module ListLanguageModels : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1041,7 +1067,8 @@ module ListMedicalScribeJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1075,7 +1102,8 @@ module ListMedicalTranscriptionJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1109,7 +1137,8 @@ module ListMedicalVocabularies : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1146,7 +1175,8 @@ module ListTagsForResource : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1180,7 +1210,8 @@ module ListTranscriptionJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1214,7 +1245,8 @@ module ListVocabularies : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1248,7 +1280,8 @@ module ListVocabularyFilters : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1285,7 +1318,8 @@ module StartCallAnalyticsJob : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1367,7 +1401,8 @@ module StartMedicalScribeJob : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1442,7 +1477,8 @@ module StartMedicalTranscriptionJob : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1519,7 +1555,8 @@ module StartTranscriptionJob : sig
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
-      | `LimitExceededException of limit_exceeded_exception ] )
+      | `LimitExceededException of limit_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1588,7 +1625,8 @@ module TagResource : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1628,7 +1666,8 @@ module UntagResource : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1668,7 +1707,8 @@ module UpdateCallAnalyticsCategory : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1709,7 +1749,8 @@ module UpdateMedicalVocabulary : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1748,7 +1789,8 @@ module UpdateVocabulary : sig
       | `ConflictException of conflict_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1784,7 +1826,8 @@ module UpdateVocabularyFilter : sig
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NotFoundException of not_found_exception ] )
+      | `NotFoundException of not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/transcribe/operations.mli
+++ b/sdks/transcribe/operations.mli
@@ -19,6 +19,17 @@ module CreateCallAnalyticsCategory : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_call_analytics_category_request ->
+    ( create_call_analytics_category_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new Call Analytics category.\n\n\
@@ -57,6 +68,17 @@ module CreateLanguageModel : sig
     'http_type Smaws_Lib.Context.t ->
     create_language_model_request ->
     ( create_language_model_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_language_model_request ->
+    ( create_language_model_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -104,6 +126,17 @@ module CreateMedicalVocabulary : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_medical_vocabulary_request ->
+    ( create_medical_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new custom medical vocabulary.\n\n\
@@ -135,6 +168,17 @@ module CreateVocabulary : sig
     'http_type Smaws_Lib.Context.t ->
     create_vocabulary_request ->
     ( create_vocabulary_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vocabulary_request ->
+    ( create_vocabulary_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -176,6 +220,17 @@ module CreateVocabularyFilter : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_vocabulary_filter_request ->
+    ( create_vocabulary_filter_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a new custom vocabulary filter.\n\n\
@@ -211,6 +266,17 @@ module DeleteCallAnalyticsCategory : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_call_analytics_category_request ->
+    ( delete_call_analytics_category_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a Call Analytics category. To use this operation, specify the name of the category you \
@@ -228,6 +294,16 @@ module DeleteCallAnalyticsJob : sig
     'http_type Smaws_Lib.Context.t ->
     delete_call_analytics_job_request ->
     ( delete_call_analytics_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_call_analytics_job_request ->
+    ( delete_call_analytics_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -255,6 +331,16 @@ module DeleteLanguageModel : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_language_model_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a custom language model. To use this operation, specify the name of the language model \
@@ -277,6 +363,16 @@ module DeleteMedicalScribeJob : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_medical_scribe_job_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a Medical Scribe job. To use this operation, specify the name of the job you want to \
@@ -294,6 +390,16 @@ module DeleteMedicalTranscriptionJob : sig
     'http_type Smaws_Lib.Context.t ->
     delete_medical_transcription_job_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_medical_transcription_job_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -323,6 +429,17 @@ module DeleteMedicalVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_medical_vocabulary_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a custom medical vocabulary. To use this operation, specify the name of the custom \
@@ -346,6 +463,16 @@ module DeleteTranscriptionJob : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_transcription_job_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a transcription job. To use this operation, specify the name of the job you want to \
@@ -364,6 +491,17 @@ module DeleteVocabulary : sig
     'http_type Smaws_Lib.Context.t ->
     delete_vocabulary_request ->
     ( Smaws_Lib.Smithy_api.Types.unit_,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vocabulary_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -394,6 +532,17 @@ module DeleteVocabularyFilter : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_vocabulary_filter_request ->
+    ( Smaws_Lib.Smithy_api.Types.unit_ Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a custom vocabulary filter. To use this operation, specify the name of the custom \
@@ -413,6 +562,17 @@ module DescribeLanguageModel : sig
     'http_type Smaws_Lib.Context.t ->
     describe_language_model_request ->
     ( describe_language_model_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_language_model_request ->
+    ( describe_language_model_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -449,6 +609,17 @@ module GetCallAnalyticsCategory : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_call_analytics_category_request ->
+    ( get_call_analytics_category_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified Call Analytics category.\n\n\
@@ -468,6 +639,17 @@ module GetCallAnalyticsJob : sig
     'http_type Smaws_Lib.Context.t ->
     get_call_analytics_job_request ->
     ( get_call_analytics_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_call_analytics_job_request ->
+    ( get_call_analytics_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -510,6 +692,17 @@ module GetMedicalScribeJob : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_medical_scribe_job_request ->
+    ( get_medical_scribe_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified Medical Scribe job.\n\n\
@@ -534,6 +727,17 @@ module GetMedicalTranscriptionJob : sig
     'http_type Smaws_Lib.Context.t ->
     get_medical_transcription_job_request ->
     ( get_medical_transcription_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_medical_transcription_job_request ->
+    ( get_medical_transcription_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -570,6 +774,17 @@ module GetMedicalVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_medical_vocabulary_request ->
+    ( get_medical_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified custom medical vocabulary.\n\n\
@@ -593,6 +808,17 @@ module GetTranscriptionJob : sig
     'http_type Smaws_Lib.Context.t ->
     get_transcription_job_request ->
     ( get_transcription_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_transcription_job_request ->
+    ( get_transcription_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -632,6 +858,17 @@ module GetVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_vocabulary_request ->
+    ( get_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified custom vocabulary.\n\n\
@@ -661,6 +898,17 @@ module GetVocabularyFilter : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_vocabulary_filter_request ->
+    ( get_vocabulary_filter_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides information about the specified custom vocabulary filter.\n\n\
@@ -684,6 +932,16 @@ module ListCallAnalyticsCategories : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_call_analytics_categories_request ->
+    ( list_call_analytics_categories_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of Call Analytics categories, including all rules that make up each category.\n\n\
@@ -702,6 +960,16 @@ module ListCallAnalyticsJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_call_analytics_jobs_request ->
     ( list_call_analytics_jobs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_call_analytics_jobs_request ->
+    ( list_call_analytics_jobs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -731,6 +999,16 @@ module ListLanguageModels : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_language_models_request ->
+    ( list_language_models_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of custom language models that match the specified criteria. If no criteria are \
@@ -750,6 +1028,16 @@ module ListMedicalScribeJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_medical_scribe_jobs_request ->
     ( list_medical_scribe_jobs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_medical_scribe_jobs_request ->
+    ( list_medical_scribe_jobs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -779,6 +1067,16 @@ module ListMedicalTranscriptionJobs : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_medical_transcription_jobs_request ->
+    ( list_medical_transcription_jobs_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of medical transcription jobs that match the specified criteria. If no criteria \
@@ -798,6 +1096,16 @@ module ListMedicalVocabularies : sig
     'http_type Smaws_Lib.Context.t ->
     list_medical_vocabularies_request ->
     ( list_medical_vocabularies_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_medical_vocabularies_request ->
+    ( list_medical_vocabularies_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -829,6 +1137,17 @@ module ListTagsForResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists all tags associated with the specified transcription job, vocabulary, model, or resource.\n\n\
@@ -848,6 +1167,16 @@ module ListTranscriptionJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_transcription_jobs_request ->
     ( list_transcription_jobs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_transcription_jobs_request ->
+    ( list_transcription_jobs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -877,6 +1206,16 @@ module ListVocabularies : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vocabularies_request ->
+    ( list_vocabularies_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides a list of custom vocabularies that match the specified criteria. If no criteria are \
@@ -896,6 +1235,16 @@ module ListVocabularyFilters : sig
     'http_type Smaws_Lib.Context.t ->
     list_vocabulary_filters_request ->
     ( list_vocabulary_filters_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_vocabulary_filters_request ->
+    ( list_vocabulary_filters_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception
@@ -921,6 +1270,17 @@ module StartCallAnalyticsJob : sig
     'http_type Smaws_Lib.Context.t ->
     start_call_analytics_job_request ->
     ( start_call_analytics_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_call_analytics_job_request ->
+    ( start_call_analytics_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -998,6 +1358,17 @@ module StartMedicalScribeJob : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_medical_scribe_job_request ->
+    ( start_medical_scribe_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Transcribes patient-clinician conversations and generates clinical notes. \n\n\
@@ -1056,6 +1427,17 @@ module StartMedicalTranscriptionJob : sig
     'http_type Smaws_Lib.Context.t ->
     start_medical_transcription_job_request ->
     ( start_medical_transcription_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_medical_transcription_job_request ->
+    ( start_medical_transcription_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -1128,6 +1510,17 @@ module StartTranscriptionJob : sig
       | `InternalFailureException of internal_failure_exception
       | `LimitExceededException of limit_exceeded_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_transcription_job_request ->
+    ( start_transcription_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception ] )
+    result
 end
 [@@ocaml.doc
   "Transcribes the audio from a media file and applies any additional Request Parameters you \
@@ -1185,6 +1578,18 @@ module TagResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Adds one or more custom tags, each in the form of a key:value pair, to the specified resource.\n\n\
@@ -1213,6 +1618,18 @@ module UntagResource : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Removes the specified tags from the specified Amazon Transcribe resource.\n\n\
@@ -1234,6 +1651,18 @@ module UpdateCallAnalyticsCategory : sig
     'http_type Smaws_Lib.Context.t ->
     update_call_analytics_category_request ->
     ( update_call_analytics_category_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_call_analytics_category_request ->
+    ( update_call_analytics_category_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `ConflictException of conflict_exception
@@ -1270,6 +1699,18 @@ module UpdateMedicalVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_medical_vocabulary_request ->
+    ( update_medical_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing custom medical vocabulary with new values. This operation overwrites all \
@@ -1297,6 +1738,18 @@ module UpdateVocabulary : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NotFoundException of not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_vocabulary_request ->
+    ( update_vocabulary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `ConflictException of conflict_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates an existing custom vocabulary with new values. This operation overwrites all existing \
@@ -1316,6 +1769,17 @@ module UpdateVocabularyFilter : sig
     'http_type Smaws_Lib.Context.t ->
     update_vocabulary_filter_request ->
     ( update_vocabulary_filter_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `BadRequestException of bad_request_exception
+      | `InternalFailureException of internal_failure_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NotFoundException of not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_vocabulary_filter_request ->
+    ( update_vocabulary_filter_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `BadRequestException of bad_request_exception
       | `InternalFailureException of internal_failure_exception

--- a/sdks/waf/Smaws_Client_WAF.mli
+++ b/sdks/waf/Smaws_Client_WAF.mli
@@ -910,7 +910,8 @@ module CreateByteMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -987,7 +988,8 @@ module CreateGeoMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1063,7 +1065,8 @@ module CreateIPSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1145,7 +1148,8 @@ module CreateRateBasedRule : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1264,7 +1268,8 @@ module CreateRegexMatchSet : sig
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1335,7 +1340,8 @@ module CreateRegexPatternSet : sig
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1415,7 +1421,8 @@ module CreateRule : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1513,7 +1520,8 @@ module CreateRuleGroup : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1581,7 +1589,8 @@ module CreateSizeConstraintSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1658,7 +1667,8 @@ module CreateSqlInjectionMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1741,7 +1751,8 @@ module CreateWebACL : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1827,7 +1838,8 @@ module CreateWebACLMigrationStack : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1878,7 +1890,8 @@ module CreateXssMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1952,7 +1965,8 @@ module DeleteByteMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2021,7 +2035,8 @@ module DeleteGeoMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2090,7 +2105,8 @@ module DeleteIPSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2150,7 +2166,8 @@ module DeleteLoggingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2191,7 +2208,8 @@ module DeletePermissionPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2249,7 +2267,8 @@ module DeleteRateBasedRule : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2318,7 +2337,8 @@ module DeleteRegexMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2387,7 +2407,8 @@ module DeleteRegexPatternSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2444,7 +2465,8 @@ module DeleteRule : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2519,7 +2541,8 @@ module DeleteRuleGroup : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2588,7 +2611,8 @@ module DeleteSizeConstraintSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2657,7 +2681,8 @@ module DeleteSqlInjectionMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2732,7 +2757,8 @@ module DeleteWebACL : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2798,7 +2824,8 @@ module DeleteXssMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2858,7 +2885,8 @@ module GetByteMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2893,7 +2921,8 @@ module GetChangeToken : sig
     get_change_token_request ->
     ( get_change_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `WAFInternalErrorException of waf_internal_error_exception ] )
+      | `WAFInternalErrorException of waf_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2942,7 +2971,8 @@ module GetChangeTokenStatus : sig
     ( get_change_token_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2998,7 +3028,8 @@ module GetGeoMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3039,7 +3070,8 @@ module GetIPSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3077,7 +3109,8 @@ module GetLoggingConfiguration : sig
     ( get_logging_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3115,7 +3148,8 @@ module GetPermissionPolicy : sig
     ( get_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3156,7 +3190,8 @@ module GetRateBasedRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3201,7 +3236,8 @@ module GetRateBasedRuleManagedKeys : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3245,7 +3281,8 @@ module GetRegexMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3286,7 +3323,8 @@ module GetRegexPatternSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3327,7 +3365,8 @@ module GetRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3366,7 +3405,8 @@ module GetRuleGroup : sig
     ( get_rule_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3407,7 +3447,8 @@ module GetSampledRequests : sig
     ( get_sampled_requests_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3457,7 +3498,8 @@ module GetSizeConstraintSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3498,7 +3540,8 @@ module GetSqlInjectionMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3539,7 +3582,8 @@ module GetWebACL : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3580,7 +3624,8 @@ module GetXssMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3621,7 +3666,8 @@ module ListActivatedRulesInRuleGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3659,7 +3705,8 @@ module ListByteMatchSets : sig
     ( list_byte_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3697,7 +3744,8 @@ module ListGeoMatchSets : sig
     ( list_geo_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3735,7 +3783,8 @@ module ListIPSets : sig
     ( list_ip_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3776,7 +3825,8 @@ module ListLoggingConfigurations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3814,7 +3864,8 @@ module ListRateBasedRules : sig
     ( list_rate_based_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3852,7 +3903,8 @@ module ListRegexMatchSets : sig
     ( list_regex_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3890,7 +3942,8 @@ module ListRegexPatternSets : sig
     ( list_regex_pattern_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3925,7 +3978,8 @@ module ListRuleGroups : sig
     list_rule_groups_request ->
     ( list_rule_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `WAFInternalErrorException of waf_internal_error_exception ] )
+      | `WAFInternalErrorException of waf_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3963,7 +4017,8 @@ module ListRules : sig
     ( list_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4001,7 +4056,8 @@ module ListSizeConstraintSets : sig
     ( list_size_constraint_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4039,7 +4095,8 @@ module ListSqlInjectionMatchSets : sig
     ( list_sql_injection_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4077,7 +4134,8 @@ module ListSubscribedRuleGroups : sig
     ( list_subscribed_rule_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4127,7 +4185,8 @@ module ListTagsForResource : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4172,7 +4231,8 @@ module ListWebACLs : sig
     ( list_web_ac_ls_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4210,7 +4270,8 @@ module ListXssMatchSets : sig
     ( list_xss_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4254,7 +4315,8 @@ module PutLoggingConfiguration : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4322,7 +4384,8 @@ module PutPermissionPolicy : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4412,7 +4475,8 @@ module TagResource : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4469,7 +4533,8 @@ module UntagResource : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4525,7 +4590,8 @@ module UpdateByteMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4630,7 +4696,8 @@ module UpdateGeoMatchSet : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4725,7 +4792,8 @@ module UpdateIPSet : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4849,7 +4917,8 @@ module UpdateRateBasedRule : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4948,7 +5017,8 @@ module UpdateRegexMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5046,7 +5116,8 @@ module UpdateRegexPatternSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5150,7 +5221,8 @@ module UpdateRule : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5245,7 +5317,8 @@ module UpdateRuleGroup : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5332,7 +5405,8 @@ module UpdateSizeConstraintSet : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5438,7 +5512,8 @@ module UpdateSqlInjectionMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5542,7 +5617,8 @@ module UpdateWebACL : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
-      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception ] )
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -5663,7 +5739,8 @@ module UpdateXssMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/waf/Smaws_Client_WAF.mli
+++ b/sdks/waf/Smaws_Client_WAF.mli
@@ -899,6 +899,19 @@ module CreateByteMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_byte_match_set_request ->
+    ( create_byte_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -955,6 +968,19 @@ module CreateGeoMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_geo_match_set_request ->
     ( create_geo_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_geo_match_set_request ->
+    ( create_geo_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -1026,6 +1052,19 @@ module CreateIPSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_ip_set_request ->
+    ( create_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1083,6 +1122,21 @@ module CreateRateBasedRule : sig
     'http_type Smaws_Lib.Context.t ->
     create_rate_based_rule_request ->
     ( create_rate_based_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_rate_based_rule_request ->
+    ( create_rate_based_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFBadRequestException of waf_bad_request_exception
       | `WAFDisallowedNameException of waf_disallowed_name_exception
@@ -1201,6 +1255,17 @@ module CreateRegexMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_regex_match_set_request ->
+    ( create_regex_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1255,6 +1320,17 @@ module CreateRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_regex_pattern_set_request ->
     ( create_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_regex_pattern_set_request ->
+    ( create_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -1316,6 +1392,21 @@ module CreateRule : sig
     'http_type Smaws_Lib.Context.t ->
     create_rule_request ->
     ( create_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_rule_request ->
+    ( create_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFBadRequestException of waf_bad_request_exception
       | `WAFDisallowedNameException of waf_disallowed_name_exception
@@ -1410,6 +1501,20 @@ module CreateRuleGroup : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_rule_group_request ->
+    ( create_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1457,6 +1562,19 @@ module CreateSizeConstraintSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_size_constraint_set_request ->
     ( create_size_constraint_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_size_constraint_set_request ->
+    ( create_size_constraint_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -1529,6 +1647,19 @@ module CreateSqlInjectionMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_sql_injection_match_set_request ->
+    ( create_sql_injection_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1585,6 +1716,22 @@ module CreateWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     create_web_acl_request ->
     ( create_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_web_acl_request ->
+    ( create_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFBadRequestException of waf_bad_request_exception
       | `WAFDisallowedNameException of waf_disallowed_name_exception
@@ -1670,6 +1817,18 @@ module CreateWebACLMigrationStack : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_web_acl_migration_stack_request ->
+    ( create_web_acl_migration_stack_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFEntityMigrationException of waf_entity_migration_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an AWS CloudFormation WAFV2 template for the specified web ACL in the specified Amazon \
@@ -1700,6 +1859,19 @@ module CreateXssMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_xss_match_set_request ->
     ( create_xss_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_xss_match_set_request ->
+    ( create_xss_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -1769,6 +1941,19 @@ module DeleteByteMatchSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_byte_match_set_request ->
+    ( delete_byte_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1817,6 +2002,19 @@ module DeleteGeoMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     delete_geo_match_set_request ->
     ( delete_geo_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_geo_match_set_request ->
+    ( delete_geo_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -1881,6 +2079,19 @@ module DeleteIPSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ip_set_request ->
+    ( delete_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1931,6 +2142,16 @@ module DeleteLoggingConfiguration : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_logging_configuration_request ->
+    ( delete_logging_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1957,6 +2178,16 @@ module DeletePermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_permission_policy_request ->
     ( delete_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_permission_policy_request ->
+    ( delete_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
@@ -1995,6 +2226,21 @@ module DeleteRateBasedRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_rate_based_rule_request ->
     ( delete_rate_based_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rate_based_rule_request ->
+    ( delete_rate_based_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2061,6 +2307,19 @@ module DeleteRegexMatchSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_regex_match_set_request ->
+    ( delete_regex_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2117,6 +2376,19 @@ module DeleteRegexPatternSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_regex_pattern_set_request ->
+    ( delete_regex_pattern_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2149,6 +2421,21 @@ module DeleteRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_rule_request ->
     ( delete_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rule_request ->
+    ( delete_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2219,6 +2506,21 @@ module DeleteRuleGroup : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rule_group_request ->
+    ( delete_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2275,6 +2577,19 @@ module DeleteSizeConstraintSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_size_constraint_set_request ->
+    ( delete_size_constraint_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2323,6 +2638,19 @@ module DeleteSqlInjectionMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     delete_sql_injection_match_set_request ->
     ( delete_sql_injection_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_sql_injection_match_set_request ->
+    ( delete_sql_injection_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2391,6 +2719,21 @@ module DeleteWebACL : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_web_acl_request ->
+    ( delete_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2436,6 +2779,19 @@ module DeleteXssMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     delete_xss_match_set_request ->
     ( delete_xss_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_xss_match_set_request ->
+    ( delete_xss_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2494,6 +2850,16 @@ module GetByteMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_byte_match_set_request ->
+    ( get_byte_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2518,6 +2884,14 @@ module GetChangeToken : sig
     'http_type Smaws_Lib.Context.t ->
     get_change_token_request ->
     ( get_change_token_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_change_token_request ->
+    ( get_change_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception ] )
     result
@@ -2557,6 +2931,15 @@ module GetChangeTokenStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_change_token_status_request ->
     ( get_change_token_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_change_token_status_request ->
+    ( get_change_token_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
@@ -2607,6 +2990,16 @@ module GetGeoMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_geo_match_set_request ->
+    ( get_geo_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2633,6 +3026,16 @@ module GetIPSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_ip_set_request ->
     ( get_ip_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ip_set_request ->
+    ( get_ip_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2667,6 +3070,15 @@ module GetLoggingConfiguration : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_logging_configuration_request ->
+    ( get_logging_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2692,6 +3104,15 @@ module GetPermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     get_permission_policy_request ->
     ( get_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_permission_policy_request ->
+    ( get_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
@@ -2727,6 +3148,16 @@ module GetRateBasedRule : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rate_based_rule_request ->
+    ( get_rate_based_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2755,6 +3186,17 @@ module GetRateBasedRuleManagedKeys : sig
     'http_type Smaws_Lib.Context.t ->
     get_rate_based_rule_managed_keys_request ->
     ( get_rate_based_rule_managed_keys_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rate_based_rule_managed_keys_request ->
+    ( get_rate_based_rule_managed_keys_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2795,6 +3237,16 @@ module GetRegexMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_regex_match_set_request ->
+    ( get_regex_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2821,6 +3273,16 @@ module GetRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_regex_pattern_set_request ->
     ( get_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_regex_pattern_set_request ->
+    ( get_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2857,6 +3319,16 @@ module GetRule : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rule_request ->
+    ( get_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2883,6 +3355,15 @@ module GetRuleGroup : sig
     'http_type Smaws_Lib.Context.t ->
     get_rule_group_request ->
     ( get_rule_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rule_group_request ->
+    ( get_rule_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
@@ -2915,6 +3396,15 @@ module GetSampledRequests : sig
     'http_type Smaws_Lib.Context.t ->
     get_sampled_requests_request ->
     ( get_sampled_requests_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sampled_requests_request ->
+    ( get_sampled_requests_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
@@ -2959,6 +3449,16 @@ module GetSizeConstraintSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_size_constraint_set_request ->
+    ( get_size_constraint_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2985,6 +3485,16 @@ module GetSqlInjectionMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_sql_injection_match_set_request ->
     ( get_sql_injection_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sql_injection_match_set_request ->
+    ( get_sql_injection_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -3021,6 +3531,16 @@ module GetWebACL : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_web_acl_request ->
+    ( get_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3047,6 +3567,16 @@ module GetXssMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_xss_match_set_request ->
     ( get_xss_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_xss_match_set_request ->
+    ( get_xss_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -3083,6 +3613,16 @@ module ListActivatedRulesInRuleGroup : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_activated_rules_in_rule_group_request ->
+    ( list_activated_rules_in_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3108,6 +3648,15 @@ module ListByteMatchSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_byte_match_sets_request ->
     ( list_byte_match_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_byte_match_sets_request ->
+    ( list_byte_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -3141,6 +3690,15 @@ module ListGeoMatchSets : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_geo_match_sets_request ->
+    ( list_geo_match_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3166,6 +3724,15 @@ module ListIPSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_ip_sets_request ->
     ( list_ip_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ip_sets_request ->
+    ( list_ip_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -3201,6 +3768,16 @@ module ListLoggingConfigurations : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_logging_configurations_request ->
+    ( list_logging_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3226,6 +3803,15 @@ module ListRateBasedRules : sig
     'http_type Smaws_Lib.Context.t ->
     list_rate_based_rules_request ->
     ( list_rate_based_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rate_based_rules_request ->
+    ( list_rate_based_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -3259,6 +3845,15 @@ module ListRegexMatchSets : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_regex_match_sets_request ->
+    ( list_regex_match_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3284,6 +3879,15 @@ module ListRegexPatternSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_regex_pattern_sets_request ->
     ( list_regex_pattern_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_regex_pattern_sets_request ->
+    ( list_regex_pattern_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -3315,6 +3919,14 @@ module ListRuleGroups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rule_groups_request ->
+    ( list_rule_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3340,6 +3952,15 @@ module ListRules : sig
     'http_type Smaws_Lib.Context.t ->
     list_rules_request ->
     ( list_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rules_request ->
+    ( list_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -3373,6 +3994,15 @@ module ListSizeConstraintSets : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_size_constraint_sets_request ->
+    ( list_size_constraint_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3398,6 +4028,15 @@ module ListSqlInjectionMatchSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_sql_injection_match_sets_request ->
     ( list_sql_injection_match_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_sql_injection_match_sets_request ->
+    ( list_sql_injection_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -3431,6 +4070,15 @@ module ListSubscribedRuleGroups : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_subscribed_rule_groups_request ->
+    ( list_subscribed_rule_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3460,6 +4108,19 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFBadRequestException of waf_bad_request_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -3504,6 +4165,15 @@ module ListWebACLs : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_web_ac_ls_request ->
+    ( list_web_ac_ls_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3529,6 +4199,15 @@ module ListXssMatchSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_xss_match_sets_request ->
     ( list_xss_match_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_xss_match_sets_request ->
+    ( list_xss_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -3560,6 +4239,17 @@ module PutLoggingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     put_logging_configuration_request ->
     ( put_logging_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_logging_configuration_request ->
+    ( put_logging_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
@@ -3617,6 +4307,17 @@ module PutPermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     put_permission_policy_request ->
     ( put_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_permission_policy_request ->
+    ( put_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
@@ -3699,6 +4400,20 @@ module TagResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3743,6 +4458,19 @@ module UntagResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3774,6 +4502,21 @@ module UpdateByteMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_byte_match_set_request ->
     ( update_byte_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_byte_match_set_request ->
+    ( update_byte_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -3873,6 +4616,22 @@ module UpdateGeoMatchSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_geo_match_set_request ->
+    ( update_geo_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3941,6 +4700,22 @@ module UpdateIPSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_ip_set_request ->
     ( update_ip_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_ip_set_request ->
+    ( update_ip_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -4060,6 +4835,22 @@ module UpdateRateBasedRule : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_rate_based_rule_request ->
+    ( update_rate_based_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -4144,6 +4935,21 @@ module UpdateRegexMatchSet : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_regex_match_set_request ->
+    ( update_regex_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -4217,6 +5023,21 @@ module UpdateRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_regex_pattern_set_request ->
     ( update_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidRegexPatternException of waf_invalid_regex_pattern_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_regex_pattern_set_request ->
+    ( update_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -4315,6 +5136,22 @@ module UpdateRule : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_rule_request ->
+    ( update_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -4396,6 +5233,20 @@ module UpdateRuleGroup : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_rule_group_request ->
+    ( update_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -4456,6 +5307,22 @@ module UpdateSizeConstraintSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_size_constraint_set_request ->
     ( update_size_constraint_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_size_constraint_set_request ->
+    ( update_size_constraint_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -4558,6 +5425,21 @@ module UpdateSqlInjectionMatchSet : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_sql_injection_match_set_request ->
+    ( update_sql_injection_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -4633,6 +5515,23 @@ module UpdateWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     update_web_acl_request ->
     ( update_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_web_acl_request ->
+    ( update_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -4741,6 +5640,21 @@ module UpdateXssMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_xss_match_set_request ->
     ( update_xss_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_xss_match_set_request ->
+    ( update_xss_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception

--- a/sdks/waf/operations.ml
+++ b/sdks/waf/operations.ml
@@ -41,6 +41,13 @@ module CreateByteMatchSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_byte_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_byte_match_set_request) =
+    let input = Json_serializers.create_byte_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.CreateByteMatchSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_byte_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateGeoMatchSet = struct
@@ -81,6 +88,13 @@ module CreateGeoMatchSet = struct
     let input = Json_serializers.create_geo_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.CreateGeoMatchSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.create_geo_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_geo_match_set_request) =
+    let input = Json_serializers.create_geo_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.CreateGeoMatchSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_geo_match_set_response_of_yojson
       ~error_deserializer
 end
@@ -124,6 +138,12 @@ module CreateIPSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.CreateIPSet" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_ip_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_ip_set_request) =
+    let input = Json_serializers.create_ip_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.CreateIPSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_ip_set_response_of_yojson ~error_deserializer
 end
 
 module CreateRateBasedRule = struct
@@ -174,6 +194,13 @@ module CreateRateBasedRule = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_rate_based_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_rate_based_rule_request) =
+    let input = Json_serializers.create_rate_based_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.CreateRateBasedRule" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_rate_based_rule_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateRegexMatchSet = struct
@@ -208,6 +235,13 @@ module CreateRegexMatchSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_regex_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_regex_match_set_request) =
+    let input = Json_serializers.create_regex_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.CreateRegexMatchSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_regex_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateRegexPatternSet = struct
@@ -240,6 +274,13 @@ module CreateRegexPatternSet = struct
     let input = Json_serializers.create_regex_pattern_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.CreateRegexPatternSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.create_regex_pattern_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_regex_pattern_set_request) =
+    let input = Json_serializers.create_regex_pattern_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.CreateRegexPatternSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_regex_pattern_set_response_of_yojson
       ~error_deserializer
 end
@@ -291,6 +332,12 @@ module CreateRule = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.CreateRule" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_rule_request) =
+    let input = Json_serializers.create_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.CreateRule"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_rule_response_of_yojson ~error_deserializer
 end
 
 module CreateRuleGroup = struct
@@ -336,6 +383,13 @@ module CreateRuleGroup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.CreateRuleGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_rule_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_rule_group_request) =
+    let input = Json_serializers.create_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.CreateRuleGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_rule_group_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateSizeConstraintSet = struct
@@ -378,6 +432,13 @@ module CreateSizeConstraintSet = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_size_constraint_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_size_constraint_set_request) =
+    let input = Json_serializers.create_size_constraint_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.CreateSizeConstraintSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_size_constraint_set_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateSqlInjectionMatchSet = struct
@@ -418,6 +479,13 @@ module CreateSqlInjectionMatchSet = struct
     let input = Json_serializers.create_sql_injection_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.CreateSqlInjectionMatchSet"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_sql_injection_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_sql_injection_match_set_request) =
+    let input = Json_serializers.create_sql_injection_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.CreateSqlInjectionMatchSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_sql_injection_match_set_response_of_yojson
       ~error_deserializer
 end
@@ -473,6 +541,12 @@ module CreateWebACL = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.CreateWebACL" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_web_acl_request) =
+    let input = Json_serializers.create_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.CreateWebACL"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_web_acl_response_of_yojson ~error_deserializer
 end
 
 module CreateWebACLMigrationStack = struct
@@ -510,6 +584,13 @@ module CreateWebACLMigrationStack = struct
     let input = Json_serializers.create_web_acl_migration_stack_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.CreateWebACLMigrationStack"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_web_acl_migration_stack_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_web_acl_migration_stack_request) =
+    let input = Json_serializers.create_web_acl_migration_stack_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.CreateWebACLMigrationStack" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_web_acl_migration_stack_response_of_yojson
       ~error_deserializer
 end
@@ -554,6 +635,13 @@ module CreateXssMatchSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.create_xss_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_xss_match_set_request) =
+    let input = Json_serializers.create_xss_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.CreateXssMatchSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_xss_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteByteMatchSet = struct
@@ -594,6 +682,13 @@ module DeleteByteMatchSet = struct
     let input = Json_serializers.delete_byte_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.DeleteByteMatchSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.delete_byte_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_byte_match_set_request) =
+    let input = Json_serializers.delete_byte_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeleteByteMatchSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_byte_match_set_response_of_yojson
       ~error_deserializer
 end
@@ -638,6 +733,13 @@ module DeleteGeoMatchSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.delete_geo_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_geo_match_set_request) =
+    let input = Json_serializers.delete_geo_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeleteGeoMatchSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_geo_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteIPSet = struct
@@ -679,6 +781,12 @@ module DeleteIPSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.DeleteIPSet" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_ip_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_ip_set_request) =
+    let input = Json_serializers.delete_ip_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.DeleteIPSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_ip_set_response_of_yojson ~error_deserializer
 end
 
 module DeleteLoggingConfiguration = struct
@@ -709,6 +817,13 @@ module DeleteLoggingConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_logging_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_logging_configuration_request) =
+    let input = Json_serializers.delete_logging_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeleteLoggingConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_logging_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DeletePermissionPolicy = struct
@@ -737,6 +852,13 @@ module DeletePermissionPolicy = struct
     let input = Json_serializers.delete_permission_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.DeletePermissionPolicy"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_permission_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_permission_policy_request) =
+    let input = Json_serializers.delete_permission_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeletePermissionPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_permission_policy_response_of_yojson
       ~error_deserializer
 end
@@ -790,6 +912,13 @@ module DeleteRateBasedRule = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.delete_rate_based_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_rate_based_rule_request) =
+    let input = Json_serializers.delete_rate_based_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeleteRateBasedRule" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_rate_based_rule_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteRegexMatchSet = struct
@@ -832,6 +961,13 @@ module DeleteRegexMatchSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.delete_regex_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_regex_match_set_request) =
+    let input = Json_serializers.delete_regex_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeleteRegexMatchSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_regex_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteRegexPatternSet = struct
@@ -872,6 +1008,13 @@ module DeleteRegexPatternSet = struct
     let input = Json_serializers.delete_regex_pattern_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.DeleteRegexPatternSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.delete_regex_pattern_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_regex_pattern_set_request) =
+    let input = Json_serializers.delete_regex_pattern_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeleteRegexPatternSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_regex_pattern_set_response_of_yojson
       ~error_deserializer
 end
@@ -924,6 +1067,12 @@ module DeleteRule = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.DeleteRule" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_rule_request) =
+    let input = Json_serializers.delete_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.DeleteRule"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_rule_response_of_yojson ~error_deserializer
 end
 
 module DeleteRuleGroup = struct
@@ -974,6 +1123,13 @@ module DeleteRuleGroup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.DeleteRuleGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_rule_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_rule_group_request) =
+    let input = Json_serializers.delete_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.DeleteRuleGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_rule_group_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteSizeConstraintSet = struct
@@ -1016,6 +1172,13 @@ module DeleteSizeConstraintSet = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_size_constraint_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_size_constraint_set_request) =
+    let input = Json_serializers.delete_size_constraint_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeleteSizeConstraintSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_size_constraint_set_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteSqlInjectionMatchSet = struct
@@ -1056,6 +1219,13 @@ module DeleteSqlInjectionMatchSet = struct
     let input = Json_serializers.delete_sql_injection_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.DeleteSqlInjectionMatchSet"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_sql_injection_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_sql_injection_match_set_request) =
+    let input = Json_serializers.delete_sql_injection_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeleteSqlInjectionMatchSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_sql_injection_match_set_response_of_yojson
       ~error_deserializer
 end
@@ -1108,6 +1278,12 @@ module DeleteWebACL = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.DeleteWebACL" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_web_acl_request) =
+    let input = Json_serializers.delete_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.DeleteWebACL"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_web_acl_response_of_yojson ~error_deserializer
 end
 
 module DeleteXssMatchSet = struct
@@ -1150,6 +1326,13 @@ module DeleteXssMatchSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.delete_xss_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_xss_match_set_request) =
+    let input = Json_serializers.delete_xss_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.DeleteXssMatchSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_xss_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module GetByteMatchSet = struct
@@ -1180,6 +1363,13 @@ module GetByteMatchSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetByteMatchSet" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_byte_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_byte_match_set_request) =
+    let input = Json_serializers.get_byte_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetByteMatchSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_byte_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module GetChangeToken = struct
@@ -1201,6 +1391,13 @@ module GetChangeToken = struct
     let input = Json_serializers.get_change_token_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetChangeToken" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_change_token_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_change_token_request) =
+    let input = Json_serializers.get_change_token_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetChangeToken"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_change_token_response_of_yojson
       ~error_deserializer
 end
 
@@ -1227,6 +1424,13 @@ module GetChangeTokenStatus = struct
     let input = Json_serializers.get_change_token_status_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetChangeTokenStatus" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_change_token_status_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_change_token_status_request) =
+    let input = Json_serializers.get_change_token_status_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.GetChangeTokenStatus" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_change_token_status_response_of_yojson
       ~error_deserializer
 end
@@ -1259,6 +1463,13 @@ module GetGeoMatchSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetGeoMatchSet" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_geo_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_geo_match_set_request) =
+    let input = Json_serializers.get_geo_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetGeoMatchSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_geo_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module GetIPSet = struct
@@ -1289,6 +1500,12 @@ module GetIPSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetIPSet" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_ip_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_ip_set_request) =
+    let input = Json_serializers.get_ip_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetIPSet"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_ip_set_response_of_yojson
+      ~error_deserializer
 end
 
 module GetLoggingConfiguration = struct
@@ -1316,6 +1533,13 @@ module GetLoggingConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_logging_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_logging_configuration_request) =
+    let input = Json_serializers.get_logging_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.GetLoggingConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_logging_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module GetPermissionPolicy = struct
@@ -1341,6 +1565,13 @@ module GetPermissionPolicy = struct
     let input = Json_serializers.get_permission_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetPermissionPolicy" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_permission_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_permission_policy_request) =
+    let input = Json_serializers.get_permission_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.GetPermissionPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_permission_policy_response_of_yojson
       ~error_deserializer
 end
@@ -1372,6 +1603,13 @@ module GetRateBasedRule = struct
     let input = Json_serializers.get_rate_based_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetRateBasedRule" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_rate_based_rule_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_rate_based_rule_request) =
+    let input = Json_serializers.get_rate_based_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetRateBasedRule"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_rate_based_rule_response_of_yojson
       ~error_deserializer
 end
 
@@ -1408,6 +1646,13 @@ module GetRateBasedRuleManagedKeys = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_rate_based_rule_managed_keys_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_rate_based_rule_managed_keys_request) =
+    let input = Json_serializers.get_rate_based_rule_managed_keys_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.GetRateBasedRuleManagedKeys" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_rate_based_rule_managed_keys_response_of_yojson
+      ~error_deserializer
 end
 
 module GetRegexMatchSet = struct
@@ -1437,6 +1682,13 @@ module GetRegexMatchSet = struct
     let input = Json_serializers.get_regex_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetRegexMatchSet" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_regex_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_regex_match_set_request) =
+    let input = Json_serializers.get_regex_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetRegexMatchSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_regex_match_set_response_of_yojson
       ~error_deserializer
 end
 
@@ -1469,6 +1721,13 @@ module GetRegexPatternSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_regex_pattern_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_regex_pattern_set_request) =
+    let input = Json_serializers.get_regex_pattern_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.GetRegexPatternSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_regex_pattern_set_response_of_yojson
+      ~error_deserializer
 end
 
 module GetRule = struct
@@ -1498,6 +1757,12 @@ module GetRule = struct
     let input = Json_serializers.get_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetRule" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_rule_response_of_yojson ~error_deserializer
+
+  let request_with_metadata context (request : get_rule_request) =
+    let input = Json_serializers.get_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetRule" ~service
+      ~context ~input ~output_deserializer:Json_deserializers.get_rule_response_of_yojson
+      ~error_deserializer
 end
 
 module GetRuleGroup = struct
@@ -1524,6 +1789,12 @@ module GetRuleGroup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetRuleGroup" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_rule_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_rule_group_request) =
+    let input = Json_serializers.get_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetRuleGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_rule_group_response_of_yojson ~error_deserializer
 end
 
 module GetSampledRequests = struct
@@ -1549,6 +1820,13 @@ module GetSampledRequests = struct
     let input = Json_serializers.get_sampled_requests_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetSampledRequests" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_sampled_requests_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_sampled_requests_request) =
+    let input = Json_serializers.get_sampled_requests_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.GetSampledRequests" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_sampled_requests_response_of_yojson
       ~error_deserializer
 end
@@ -1582,6 +1860,13 @@ module GetSizeConstraintSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_size_constraint_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_size_constraint_set_request) =
+    let input = Json_serializers.get_size_constraint_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.GetSizeConstraintSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_size_constraint_set_response_of_yojson
+      ~error_deserializer
 end
 
 module GetSqlInjectionMatchSet = struct
@@ -1611,6 +1896,13 @@ module GetSqlInjectionMatchSet = struct
     let input = Json_serializers.get_sql_injection_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetSqlInjectionMatchSet"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_sql_injection_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_sql_injection_match_set_request) =
+    let input = Json_serializers.get_sql_injection_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.GetSqlInjectionMatchSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_sql_injection_match_set_response_of_yojson
       ~error_deserializer
 end
@@ -1643,6 +1935,12 @@ module GetWebACL = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetWebACL" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_web_acl_request) =
+    let input = Json_serializers.get_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetWebACL"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_web_acl_response_of_yojson ~error_deserializer
 end
 
 module GetXssMatchSet = struct
@@ -1672,6 +1970,13 @@ module GetXssMatchSet = struct
     let input = Json_serializers.get_xss_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.GetXssMatchSet" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_xss_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_xss_match_set_request) =
+    let input = Json_serializers.get_xss_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.GetXssMatchSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_xss_match_set_response_of_yojson
       ~error_deserializer
 end
 
@@ -1704,6 +2009,13 @@ module ListActivatedRulesInRuleGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_activated_rules_in_rule_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_activated_rules_in_rule_group_request) =
+    let input = Json_serializers.list_activated_rules_in_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListActivatedRulesInRuleGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_activated_rules_in_rule_group_response_of_yojson
+      ~error_deserializer
 end
 
 module ListByteMatchSets = struct
@@ -1729,6 +2041,13 @@ module ListByteMatchSets = struct
     let input = Json_serializers.list_byte_match_sets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListByteMatchSets" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_byte_match_sets_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_byte_match_sets_request) =
+    let input = Json_serializers.list_byte_match_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListByteMatchSets" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_byte_match_sets_response_of_yojson
       ~error_deserializer
 end
@@ -1757,6 +2076,13 @@ module ListGeoMatchSets = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListGeoMatchSets" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_geo_match_sets_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_geo_match_sets_request) =
+    let input = Json_serializers.list_geo_match_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.ListGeoMatchSets"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_geo_match_sets_response_of_yojson
+      ~error_deserializer
 end
 
 module ListIPSets = struct
@@ -1783,6 +2109,12 @@ module ListIPSets = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListIPSets" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_ip_sets_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_ip_sets_request) =
+    let input = Json_serializers.list_ip_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.ListIPSets"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_ip_sets_response_of_yojson ~error_deserializer
 end
 
 module ListLoggingConfigurations = struct
@@ -1814,6 +2146,13 @@ module ListLoggingConfigurations = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_logging_configurations_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_logging_configurations_request) =
+    let input = Json_serializers.list_logging_configurations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListLoggingConfigurations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_logging_configurations_response_of_yojson
+      ~error_deserializer
 end
 
 module ListRateBasedRules = struct
@@ -1839,6 +2178,13 @@ module ListRateBasedRules = struct
     let input = Json_serializers.list_rate_based_rules_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListRateBasedRules" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_rate_based_rules_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_rate_based_rules_request) =
+    let input = Json_serializers.list_rate_based_rules_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListRateBasedRules" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_rate_based_rules_response_of_yojson
       ~error_deserializer
 end
@@ -1868,6 +2214,13 @@ module ListRegexMatchSets = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_regex_match_sets_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_regex_match_sets_request) =
+    let input = Json_serializers.list_regex_match_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListRegexMatchSets" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_regex_match_sets_response_of_yojson
+      ~error_deserializer
 end
 
 module ListRegexPatternSets = struct
@@ -1895,6 +2248,13 @@ module ListRegexPatternSets = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_regex_pattern_sets_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_regex_pattern_sets_request) =
+    let input = Json_serializers.list_regex_pattern_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListRegexPatternSets" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_regex_pattern_sets_response_of_yojson
+      ~error_deserializer
 end
 
 module ListRuleGroups = struct
@@ -1916,6 +2276,13 @@ module ListRuleGroups = struct
     let input = Json_serializers.list_rule_groups_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListRuleGroups" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_rule_groups_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_rule_groups_request) =
+    let input = Json_serializers.list_rule_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.ListRuleGroups"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_rule_groups_response_of_yojson
       ~error_deserializer
 end
 
@@ -1943,6 +2310,12 @@ module ListRules = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListRules" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_rules_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_rules_request) =
+    let input = Json_serializers.list_rules_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.ListRules"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_rules_response_of_yojson
+      ~error_deserializer
 end
 
 module ListSizeConstraintSets = struct
@@ -1968,6 +2341,13 @@ module ListSizeConstraintSets = struct
     let input = Json_serializers.list_size_constraint_sets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListSizeConstraintSets"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_size_constraint_sets_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_size_constraint_sets_request) =
+    let input = Json_serializers.list_size_constraint_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListSizeConstraintSets" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_size_constraint_sets_response_of_yojson
       ~error_deserializer
 end
@@ -1997,6 +2377,13 @@ module ListSqlInjectionMatchSets = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_sql_injection_match_sets_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_sql_injection_match_sets_request) =
+    let input = Json_serializers.list_sql_injection_match_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListSqlInjectionMatchSets" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_sql_injection_match_sets_response_of_yojson
+      ~error_deserializer
 end
 
 module ListSubscribedRuleGroups = struct
@@ -2022,6 +2409,13 @@ module ListSubscribedRuleGroups = struct
     let input = Json_serializers.list_subscribed_rule_groups_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListSubscribedRuleGroups"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_subscribed_rule_groups_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_subscribed_rule_groups_request) =
+    let input = Json_serializers.list_subscribed_rule_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListSubscribedRuleGroups" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_subscribed_rule_groups_response_of_yojson
       ~error_deserializer
 end
@@ -2067,6 +2461,13 @@ module ListTagsForResource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module ListWebACLs = struct
@@ -2093,6 +2494,12 @@ module ListWebACLs = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListWebACLs" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_web_ac_ls_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_web_ac_ls_request) =
+    let input = Json_serializers.list_web_ac_ls_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.ListWebACLs"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_web_ac_ls_response_of_yojson ~error_deserializer
 end
 
 module ListXssMatchSets = struct
@@ -2118,6 +2525,13 @@ module ListXssMatchSets = struct
     let input = Json_serializers.list_xss_match_sets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.ListXssMatchSets" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_xss_match_sets_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_xss_match_sets_request) =
+    let input = Json_serializers.list_xss_match_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.ListXssMatchSets"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_xss_match_sets_response_of_yojson
       ~error_deserializer
 end
 
@@ -2154,6 +2568,13 @@ module PutLoggingConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_logging_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_logging_configuration_request) =
+    let input = Json_serializers.put_logging_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.PutLoggingConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_logging_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module PutPermissionPolicy = struct
@@ -2187,6 +2608,13 @@ module PutPermissionPolicy = struct
     let input = Json_serializers.put_permission_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.PutPermissionPolicy" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.put_permission_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_permission_policy_request) =
+    let input = Json_serializers.put_permission_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.PutPermissionPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_permission_policy_response_of_yojson
       ~error_deserializer
 end
@@ -2235,6 +2663,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.TagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -2277,6 +2711,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
 module UpdateByteMatchSet = struct
@@ -2325,6 +2765,13 @@ module UpdateByteMatchSet = struct
     let input = Json_serializers.update_byte_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.UpdateByteMatchSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_byte_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_byte_match_set_request) =
+    let input = Json_serializers.update_byte_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.UpdateByteMatchSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_byte_match_set_response_of_yojson
       ~error_deserializer
 end
@@ -2381,6 +2828,13 @@ module UpdateGeoMatchSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_geo_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_geo_match_set_request) =
+    let input = Json_serializers.update_geo_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.UpdateGeoMatchSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_geo_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateIPSet = struct
@@ -2434,6 +2888,12 @@ module UpdateIPSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.UpdateIPSet" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_ip_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_ip_set_request) =
+    let input = Json_serializers.update_ip_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.UpdateIPSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_ip_set_response_of_yojson ~error_deserializer
 end
 
 module UpdateRateBasedRule = struct
@@ -2488,6 +2948,13 @@ module UpdateRateBasedRule = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_rate_based_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_rate_based_rule_request) =
+    let input = Json_serializers.update_rate_based_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.UpdateRateBasedRule" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_rate_based_rule_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateRegexMatchSet = struct
@@ -2538,6 +3005,13 @@ module UpdateRegexMatchSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_regex_match_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_regex_match_set_request) =
+    let input = Json_serializers.update_regex_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.UpdateRegexMatchSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_regex_match_set_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateRegexPatternSet = struct
@@ -2586,6 +3060,13 @@ module UpdateRegexPatternSet = struct
     let input = Json_serializers.update_regex_pattern_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.UpdateRegexPatternSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_regex_pattern_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_regex_pattern_set_request) =
+    let input = Json_serializers.update_regex_pattern_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.UpdateRegexPatternSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_regex_pattern_set_response_of_yojson
       ~error_deserializer
 end
@@ -2641,6 +3122,12 @@ module UpdateRule = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.UpdateRule" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_rule_request) =
+    let input = Json_serializers.update_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.UpdateRule"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_rule_response_of_yojson ~error_deserializer
 end
 
 module UpdateRuleGroup = struct
@@ -2685,6 +3172,13 @@ module UpdateRuleGroup = struct
     let input = Json_serializers.update_rule_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.UpdateRuleGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_rule_group_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_rule_group_request) =
+    let input = Json_serializers.update_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.UpdateRuleGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_rule_group_response_of_yojson
       ~error_deserializer
 end
 
@@ -2740,6 +3234,13 @@ module UpdateSizeConstraintSet = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_size_constraint_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_size_constraint_set_request) =
+    let input = Json_serializers.update_size_constraint_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.UpdateSizeConstraintSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_size_constraint_set_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateSqlInjectionMatchSet = struct
@@ -2788,6 +3289,13 @@ module UpdateSqlInjectionMatchSet = struct
     let input = Json_serializers.update_sql_injection_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.UpdateSqlInjectionMatchSet"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_sql_injection_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_sql_injection_match_set_request) =
+    let input = Json_serializers.update_sql_injection_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.UpdateSqlInjectionMatchSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_sql_injection_match_set_response_of_yojson
       ~error_deserializer
 end
@@ -2847,6 +3355,12 @@ module UpdateWebACL = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.UpdateWebACL" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_web_acl_request) =
+    let input = Json_serializers.update_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20150824.UpdateWebACL"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_web_acl_response_of_yojson ~error_deserializer
 end
 
 module UpdateXssMatchSet = struct
@@ -2895,6 +3409,13 @@ module UpdateXssMatchSet = struct
     let input = Json_serializers.update_xss_match_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20150824.UpdateXssMatchSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_xss_match_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_xss_match_set_request) =
+    let input = Json_serializers.update_xss_match_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20150824.UpdateXssMatchSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_xss_match_set_response_of_yojson
       ~error_deserializer
 end

--- a/sdks/waf/operations.mli
+++ b/sdks/waf/operations.mli
@@ -34,7 +34,8 @@ module CreateByteMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -111,7 +112,8 @@ module CreateGeoMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -187,7 +189,8 @@ module CreateIPSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -269,7 +272,8 @@ module CreateRateBasedRule : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -388,7 +392,8 @@ module CreateRegexMatchSet : sig
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -459,7 +464,8 @@ module CreateRegexPatternSet : sig
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -539,7 +545,8 @@ module CreateRule : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -637,7 +644,8 @@ module CreateRuleGroup : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -705,7 +713,8 @@ module CreateSizeConstraintSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -782,7 +791,8 @@ module CreateSqlInjectionMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -865,7 +875,8 @@ module CreateWebACL : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -951,7 +962,8 @@ module CreateWebACLMigrationStack : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1002,7 +1014,8 @@ module CreateXssMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1076,7 +1089,8 @@ module DeleteByteMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1145,7 +1159,8 @@ module DeleteGeoMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1214,7 +1229,8 @@ module DeleteIPSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1274,7 +1290,8 @@ module DeleteLoggingConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1315,7 +1332,8 @@ module DeletePermissionPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1373,7 +1391,8 @@ module DeleteRateBasedRule : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1442,7 +1461,8 @@ module DeleteRegexMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1511,7 +1531,8 @@ module DeleteRegexPatternSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1568,7 +1589,8 @@ module DeleteRule : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1643,7 +1665,8 @@ module DeleteRuleGroup : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1712,7 +1735,8 @@ module DeleteSizeConstraintSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1781,7 +1805,8 @@ module DeleteSqlInjectionMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1856,7 +1881,8 @@ module DeleteWebACL : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1922,7 +1948,8 @@ module DeleteXssMatchSet : sig
       | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1982,7 +2009,8 @@ module GetByteMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2017,7 +2045,8 @@ module GetChangeToken : sig
     get_change_token_request ->
     ( get_change_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `WAFInternalErrorException of waf_internal_error_exception ] )
+      | `WAFInternalErrorException of waf_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2066,7 +2095,8 @@ module GetChangeTokenStatus : sig
     ( get_change_token_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2122,7 +2152,8 @@ module GetGeoMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2163,7 +2194,8 @@ module GetIPSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2201,7 +2233,8 @@ module GetLoggingConfiguration : sig
     ( get_logging_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2239,7 +2272,8 @@ module GetPermissionPolicy : sig
     ( get_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2280,7 +2314,8 @@ module GetRateBasedRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2325,7 +2360,8 @@ module GetRateBasedRuleManagedKeys : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2369,7 +2405,8 @@ module GetRegexMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2410,7 +2447,8 @@ module GetRegexPatternSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2451,7 +2489,8 @@ module GetRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2490,7 +2529,8 @@ module GetRuleGroup : sig
     ( get_rule_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2531,7 +2571,8 @@ module GetSampledRequests : sig
     ( get_sampled_requests_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2581,7 +2622,8 @@ module GetSizeConstraintSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2622,7 +2664,8 @@ module GetSqlInjectionMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2663,7 +2706,8 @@ module GetWebACL : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2704,7 +2748,8 @@ module GetXssMatchSet : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2745,7 +2790,8 @@ module ListActivatedRulesInRuleGroup : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2783,7 +2829,8 @@ module ListByteMatchSets : sig
     ( list_byte_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2821,7 +2868,8 @@ module ListGeoMatchSets : sig
     ( list_geo_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2859,7 +2907,8 @@ module ListIPSets : sig
     ( list_ip_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2900,7 +2949,8 @@ module ListLoggingConfigurations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2938,7 +2988,8 @@ module ListRateBasedRules : sig
     ( list_rate_based_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2976,7 +3027,8 @@ module ListRegexMatchSets : sig
     ( list_regex_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3014,7 +3066,8 @@ module ListRegexPatternSets : sig
     ( list_regex_pattern_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3049,7 +3102,8 @@ module ListRuleGroups : sig
     list_rule_groups_request ->
     ( list_rule_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `WAFInternalErrorException of waf_internal_error_exception ] )
+      | `WAFInternalErrorException of waf_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3087,7 +3141,8 @@ module ListRules : sig
     ( list_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3125,7 +3180,8 @@ module ListSizeConstraintSets : sig
     ( list_size_constraint_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3163,7 +3219,8 @@ module ListSqlInjectionMatchSets : sig
     ( list_sql_injection_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3201,7 +3258,8 @@ module ListSubscribedRuleGroups : sig
     ( list_subscribed_rule_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3251,7 +3309,8 @@ module ListTagsForResource : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3296,7 +3355,8 @@ module ListWebACLs : sig
     ( list_web_ac_ls_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3334,7 +3394,8 @@ module ListXssMatchSets : sig
     ( list_xss_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
-      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+      | `WAFInvalidAccountException of waf_invalid_account_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3378,7 +3439,8 @@ module PutLoggingConfiguration : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3446,7 +3508,8 @@ module PutPermissionPolicy : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3536,7 +3599,8 @@ module TagResource : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3593,7 +3657,8 @@ module UntagResource : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3649,7 +3714,8 @@ module UpdateByteMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3754,7 +3820,8 @@ module UpdateGeoMatchSet : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3849,7 +3916,8 @@ module UpdateIPSet : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3973,7 +4041,8 @@ module UpdateRateBasedRule : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4072,7 +4141,8 @@ module UpdateRegexMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4170,7 +4240,8 @@ module UpdateRegexPatternSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4274,7 +4345,8 @@ module UpdateRule : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4369,7 +4441,8 @@ module UpdateRuleGroup : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4456,7 +4529,8 @@ module UpdateSizeConstraintSet : sig
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4562,7 +4636,8 @@ module UpdateSqlInjectionMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4666,7 +4741,8 @@ module UpdateWebACL : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception
-      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception ] )
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4786,7 +4862,8 @@ module UpdateXssMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentContainerException of waf_nonexistent_container_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFStaleDataException of waf_stale_data_exception ] )
+      | `WAFStaleDataException of waf_stale_data_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/waf/operations.mli
+++ b/sdks/waf/operations.mli
@@ -23,6 +23,19 @@ module CreateByteMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_byte_match_set_request ->
+    ( create_byte_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -79,6 +92,19 @@ module CreateGeoMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_geo_match_set_request ->
     ( create_geo_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_geo_match_set_request ->
+    ( create_geo_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -150,6 +176,19 @@ module CreateIPSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_ip_set_request ->
+    ( create_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -207,6 +246,21 @@ module CreateRateBasedRule : sig
     'http_type Smaws_Lib.Context.t ->
     create_rate_based_rule_request ->
     ( create_rate_based_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_rate_based_rule_request ->
+    ( create_rate_based_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFBadRequestException of waf_bad_request_exception
       | `WAFDisallowedNameException of waf_disallowed_name_exception
@@ -325,6 +379,17 @@ module CreateRegexMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_regex_match_set_request ->
+    ( create_regex_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -379,6 +444,17 @@ module CreateRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_regex_pattern_set_request ->
     ( create_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_regex_pattern_set_request ->
+    ( create_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -440,6 +516,21 @@ module CreateRule : sig
     'http_type Smaws_Lib.Context.t ->
     create_rule_request ->
     ( create_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_rule_request ->
+    ( create_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFBadRequestException of waf_bad_request_exception
       | `WAFDisallowedNameException of waf_disallowed_name_exception
@@ -534,6 +625,20 @@ module CreateRuleGroup : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_rule_group_request ->
+    ( create_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -581,6 +686,19 @@ module CreateSizeConstraintSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_size_constraint_set_request ->
     ( create_size_constraint_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_size_constraint_set_request ->
+    ( create_size_constraint_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -653,6 +771,19 @@ module CreateSqlInjectionMatchSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_sql_injection_match_set_request ->
+    ( create_sql_injection_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -709,6 +840,22 @@ module CreateWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     create_web_acl_request ->
     ( create_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_web_acl_request ->
+    ( create_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFBadRequestException of waf_bad_request_exception
       | `WAFDisallowedNameException of waf_disallowed_name_exception
@@ -794,6 +941,18 @@ module CreateWebACLMigrationStack : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_web_acl_migration_stack_request ->
+    ( create_web_acl_migration_stack_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFEntityMigrationException of waf_entity_migration_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an AWS CloudFormation WAFV2 template for the specified web ACL in the specified Amazon \
@@ -824,6 +983,19 @@ module CreateXssMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_xss_match_set_request ->
     ( create_xss_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_xss_match_set_request ->
+    ( create_xss_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDisallowedNameException of waf_disallowed_name_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -893,6 +1065,19 @@ module DeleteByteMatchSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_byte_match_set_request ->
+    ( delete_byte_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -941,6 +1126,19 @@ module DeleteGeoMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     delete_geo_match_set_request ->
     ( delete_geo_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_geo_match_set_request ->
+    ( delete_geo_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -1005,6 +1203,19 @@ module DeleteIPSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ip_set_request ->
+    ( delete_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1055,6 +1266,16 @@ module DeleteLoggingConfiguration : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_logging_configuration_request ->
+    ( delete_logging_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1081,6 +1302,16 @@ module DeletePermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_permission_policy_request ->
     ( delete_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_permission_policy_request ->
+    ( delete_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
@@ -1119,6 +1350,21 @@ module DeleteRateBasedRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_rate_based_rule_request ->
     ( delete_rate_based_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rate_based_rule_request ->
+    ( delete_rate_based_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -1185,6 +1431,19 @@ module DeleteRegexMatchSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_regex_match_set_request ->
+    ( delete_regex_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1241,6 +1500,19 @@ module DeleteRegexPatternSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_regex_pattern_set_request ->
+    ( delete_regex_pattern_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1273,6 +1545,21 @@ module DeleteRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_rule_request ->
     ( delete_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rule_request ->
+    ( delete_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -1343,6 +1630,21 @@ module DeleteRuleGroup : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rule_group_request ->
+    ( delete_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1399,6 +1701,19 @@ module DeleteSizeConstraintSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_size_constraint_set_request ->
+    ( delete_size_constraint_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1447,6 +1762,19 @@ module DeleteSqlInjectionMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     delete_sql_injection_match_set_request ->
     ( delete_sql_injection_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_sql_injection_match_set_request ->
+    ( delete_sql_injection_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -1515,6 +1843,21 @@ module DeleteWebACL : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_web_acl_request ->
+    ( delete_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1560,6 +1903,19 @@ module DeleteXssMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     delete_xss_match_set_request ->
     ( delete_xss_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonEmptyEntityException of waf_non_empty_entity_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_xss_match_set_request ->
+    ( delete_xss_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -1618,6 +1974,16 @@ module GetByteMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_byte_match_set_request ->
+    ( get_byte_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1642,6 +2008,14 @@ module GetChangeToken : sig
     'http_type Smaws_Lib.Context.t ->
     get_change_token_request ->
     ( get_change_token_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_change_token_request ->
+    ( get_change_token_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception ] )
     result
@@ -1681,6 +2055,15 @@ module GetChangeTokenStatus : sig
     'http_type Smaws_Lib.Context.t ->
     get_change_token_status_request ->
     ( get_change_token_status_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_change_token_status_request ->
+    ( get_change_token_status_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
@@ -1731,6 +2114,16 @@ module GetGeoMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_geo_match_set_request ->
+    ( get_geo_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1757,6 +2150,16 @@ module GetIPSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_ip_set_request ->
     ( get_ip_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ip_set_request ->
+    ( get_ip_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -1791,6 +2194,15 @@ module GetLoggingConfiguration : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_logging_configuration_request ->
+    ( get_logging_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1816,6 +2228,15 @@ module GetPermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     get_permission_policy_request ->
     ( get_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_permission_policy_request ->
+    ( get_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
@@ -1851,6 +2272,16 @@ module GetRateBasedRule : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rate_based_rule_request ->
+    ( get_rate_based_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1879,6 +2310,17 @@ module GetRateBasedRuleManagedKeys : sig
     'http_type Smaws_Lib.Context.t ->
     get_rate_based_rule_managed_keys_request ->
     ( get_rate_based_rule_managed_keys_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rate_based_rule_managed_keys_request ->
+    ( get_rate_based_rule_managed_keys_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -1919,6 +2361,16 @@ module GetRegexMatchSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_regex_match_set_request ->
+    ( get_regex_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -1945,6 +2397,16 @@ module GetRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_regex_pattern_set_request ->
     ( get_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_regex_pattern_set_request ->
+    ( get_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -1981,6 +2443,16 @@ module GetRule : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rule_request ->
+    ( get_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2007,6 +2479,15 @@ module GetRuleGroup : sig
     'http_type Smaws_Lib.Context.t ->
     get_rule_group_request ->
     ( get_rule_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rule_group_request ->
+    ( get_rule_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
@@ -2039,6 +2520,15 @@ module GetSampledRequests : sig
     'http_type Smaws_Lib.Context.t ->
     get_sampled_requests_request ->
     ( get_sampled_requests_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sampled_requests_request ->
+    ( get_sampled_requests_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
@@ -2083,6 +2573,16 @@ module GetSizeConstraintSet : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_size_constraint_set_request ->
+    ( get_size_constraint_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2109,6 +2609,16 @@ module GetSqlInjectionMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_sql_injection_match_set_request ->
     ( get_sql_injection_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sql_injection_match_set_request ->
+    ( get_sql_injection_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2145,6 +2655,16 @@ module GetWebACL : sig
       | `WAFInvalidAccountException of waf_invalid_account_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_web_acl_request ->
+    ( get_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2171,6 +2691,16 @@ module GetXssMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_xss_match_set_request ->
     ( get_xss_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_xss_match_set_request ->
+    ( get_xss_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2207,6 +2737,16 @@ module ListActivatedRulesInRuleGroup : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_activated_rules_in_rule_group_request ->
+    ( list_activated_rules_in_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2232,6 +2772,15 @@ module ListByteMatchSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_byte_match_sets_request ->
     ( list_byte_match_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_byte_match_sets_request ->
+    ( list_byte_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -2265,6 +2814,15 @@ module ListGeoMatchSets : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_geo_match_sets_request ->
+    ( list_geo_match_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2290,6 +2848,15 @@ module ListIPSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_ip_sets_request ->
     ( list_ip_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ip_sets_request ->
+    ( list_ip_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -2325,6 +2892,16 @@ module ListLoggingConfigurations : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_logging_configurations_request ->
+    ( list_logging_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2350,6 +2927,15 @@ module ListRateBasedRules : sig
     'http_type Smaws_Lib.Context.t ->
     list_rate_based_rules_request ->
     ( list_rate_based_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rate_based_rules_request ->
+    ( list_rate_based_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -2383,6 +2969,15 @@ module ListRegexMatchSets : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_regex_match_sets_request ->
+    ( list_regex_match_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2408,6 +3003,15 @@ module ListRegexPatternSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_regex_pattern_sets_request ->
     ( list_regex_pattern_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_regex_pattern_sets_request ->
+    ( list_regex_pattern_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -2439,6 +3043,14 @@ module ListRuleGroups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rule_groups_request ->
+    ( list_rule_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2464,6 +3076,15 @@ module ListRules : sig
     'http_type Smaws_Lib.Context.t ->
     list_rules_request ->
     ( list_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rules_request ->
+    ( list_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -2497,6 +3118,15 @@ module ListSizeConstraintSets : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_size_constraint_sets_request ->
+    ( list_size_constraint_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2522,6 +3152,15 @@ module ListSqlInjectionMatchSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_sql_injection_match_sets_request ->
     ( list_sql_injection_match_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_sql_injection_match_sets_request ->
+    ( list_sql_injection_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -2555,6 +3194,15 @@ module ListSubscribedRuleGroups : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_subscribed_rule_groups_request ->
+    ( list_subscribed_rule_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2584,6 +3232,19 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFBadRequestException of waf_bad_request_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -2628,6 +3289,15 @@ module ListWebACLs : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_web_ac_ls_request ->
+    ( list_web_ac_ls_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2653,6 +3323,15 @@ module ListXssMatchSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_xss_match_sets_request ->
     ( list_xss_match_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_xss_match_sets_request ->
+    ( list_xss_match_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception ] )
@@ -2684,6 +3363,17 @@ module PutLoggingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     put_logging_configuration_request ->
     ( put_logging_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_logging_configuration_request ->
+    ( put_logging_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
@@ -2741,6 +3431,17 @@ module PutPermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     put_permission_policy_request ->
     ( put_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_permission_policy_request ->
+    ( put_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
@@ -2823,6 +3524,20 @@ module TagResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2867,6 +3582,19 @@ module UntagResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFBadRequestException of waf_bad_request_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -2898,6 +3626,21 @@ module UpdateByteMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_byte_match_set_request ->
     ( update_byte_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_byte_match_set_request ->
+    ( update_byte_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -2997,6 +3740,22 @@ module UpdateGeoMatchSet : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_geo_match_set_request ->
+    ( update_geo_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3065,6 +3824,22 @@ module UpdateIPSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_ip_set_request ->
     ( update_ip_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_ip_set_request ->
+    ( update_ip_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -3184,6 +3959,22 @@ module UpdateRateBasedRule : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_rate_based_rule_request ->
+    ( update_rate_based_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3268,6 +4059,21 @@ module UpdateRegexMatchSet : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_regex_match_set_request ->
+    ( update_regex_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDisallowedNameException of waf_disallowed_name_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3341,6 +4147,21 @@ module UpdateRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_regex_pattern_set_request ->
     ( update_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidRegexPatternException of waf_invalid_regex_pattern_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_regex_pattern_set_request ->
+    ( update_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -3439,6 +4260,22 @@ module UpdateRule : sig
       | `WAFReferencedItemException of waf_referenced_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_rule_request ->
+    ( update_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3520,6 +4357,20 @@ module UpdateRuleGroup : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_rule_group_request ->
+    ( update_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3580,6 +4431,22 @@ module UpdateSizeConstraintSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_size_constraint_set_request ->
     ( update_size_constraint_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_size_constraint_set_request ->
+    ( update_size_constraint_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -3682,6 +4549,21 @@ module UpdateSqlInjectionMatchSet : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFStaleDataException of waf_stale_data_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_sql_injection_match_set_request ->
+    ( update_sql_injection_match_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
 end
 [@@ocaml.doc
   " This is {b AWS WAF Classic} documentation. For more information, see \
@@ -3757,6 +4639,23 @@ module UpdateWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     update_web_acl_request ->
     ( update_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFReferencedItemException of waf_referenced_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_web_acl_request ->
+    ( update_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception
@@ -3864,6 +4763,21 @@ module UpdateXssMatchSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_xss_match_set_request ->
     ( update_xss_match_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidAccountException of waf_invalid_account_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentContainerException of waf_nonexistent_container_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFStaleDataException of waf_stale_data_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_xss_match_set_request ->
+    ( update_xss_match_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidAccountException of waf_invalid_account_exception

--- a/sdks/wafv2/Smaws_Client_WAFV2.mli
+++ b/sdks/wafv2/Smaws_Client_WAFV2.mli
@@ -1545,6 +1545,21 @@ module AssociateWebACL : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_web_acl_request ->
+    ( associate_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFFeatureNotIncludedInPricingPlanException of
+        waf_feature_not_included_in_pricing_plan_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates a web ACL with a resource, to protect the resource. \n\n\
@@ -1621,6 +1636,23 @@ module CheckCapacity : sig
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
       | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    check_capacity_request ->
+    ( check_capacity_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFExpiredManagedRuleGroupVersionException of
+        waf_expired_managed_rule_group_version_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the web ACL capacity unit (WCU) requirements for a specified scope and set of rules. \
@@ -1649,6 +1681,17 @@ module CreateAPIKey : sig
     'http_type Smaws_Lib.Context.t ->
     create_api_key_request ->
     ( create_api_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_api_key_request ->
+    ( create_api_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -1695,6 +1738,21 @@ module CreateIPSet : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_ip_set_request ->
+    ( create_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an [IPSet], which you use to identify web requests that originate from specific IP \
@@ -1719,6 +1777,21 @@ module CreateRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_regex_pattern_set_request ->
     ( create_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_regex_pattern_set_request ->
+    ( create_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDuplicateItemException of waf_duplicate_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -1754,6 +1827,24 @@ module CreateRuleGroup : sig
     'http_type Smaws_Lib.Context.t ->
     create_rule_group_request ->
     ( create_rule_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_rule_group_request ->
+    ( create_rule_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDuplicateItemException of waf_duplicate_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -1817,6 +1908,28 @@ module CreateWebACL : sig
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
       | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_web_acl_request ->
+    ( create_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFConfigurationWarningException of waf_configuration_warning_exception
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFExpiredManagedRuleGroupVersionException of
+        waf_expired_managed_rule_group_version_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a [WebACL] per the specifications provided.\n\n\
@@ -1852,6 +1965,18 @@ module DeleteAPIKey : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_api_key_request ->
+    ( delete_api_key_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified API key. \n\n\
@@ -1873,6 +1998,18 @@ module DeleteFirewallManagerRuleGroups : sig
     'http_type Smaws_Lib.Context.t ->
     delete_firewall_manager_rule_groups_request ->
     ( delete_firewall_manager_rule_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_firewall_manager_rule_groups_request ->
+    ( delete_firewall_manager_rule_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -1914,6 +2051,21 @@ module DeleteIPSet : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ip_set_request ->
+    ( delete_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFAssociatedItemException of waf_associated_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified [IPSet]. \n"]
 
@@ -1938,6 +2090,18 @@ module DeleteLoggingConfiguration : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_logging_configuration_request ->
+    ( delete_logging_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the [LoggingConfiguration] from the specified web ACL.\n"]
 
@@ -1953,6 +2117,16 @@ module DeletePermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_permission_policy_request ->
     ( delete_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_permission_policy_request ->
+    ( delete_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
@@ -1981,6 +2155,21 @@ module DeleteRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     delete_regex_pattern_set_request ->
     ( delete_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFAssociatedItemException of waf_associated_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_regex_pattern_set_request ->
+    ( delete_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFAssociatedItemException of waf_associated_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -2021,6 +2210,21 @@ module DeleteRuleGroup : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rule_group_request ->
+    ( delete_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFAssociatedItemException of waf_associated_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified [RuleGroup].\n"]
 
@@ -2041,6 +2245,21 @@ module DeleteWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     delete_web_acl_request ->
     ( delete_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFAssociatedItemException of waf_associated_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_web_acl_request ->
+    ( delete_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFAssociatedItemException of waf_associated_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -2110,6 +2329,16 @@ module DescribeAllManagedProducts : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_all_managed_products_request ->
+    ( describe_all_managed_products_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides high-level information for the Amazon Web Services Managed Rules rule groups and \
@@ -2127,6 +2356,16 @@ module DescribeManagedProductsByVendor : sig
     'http_type Smaws_Lib.Context.t ->
     describe_managed_products_by_vendor_request ->
     ( describe_managed_products_by_vendor_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_managed_products_by_vendor_request ->
+    ( describe_managed_products_by_vendor_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2161,6 +2400,20 @@ module DescribeManagedRuleGroup : sig
       | `WAFInvalidResourceException of waf_invalid_resource_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_managed_rule_group_request ->
+    ( describe_managed_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFExpiredManagedRuleGroupVersionException of
+        waf_expired_managed_rule_group_version_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides high-level information for a managed rule group, including descriptions of the rules. \n"]
@@ -2178,6 +2431,17 @@ module DisassociateWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_web_acl_request ->
     ( disassociate_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_web_acl_request ->
+    ( disassociate_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2220,6 +2484,17 @@ module GenerateMobileSdkReleaseUrl : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_mobile_sdk_release_url_request ->
+    ( generate_mobile_sdk_release_url_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Generates a presigned download URL for the specified release of the mobile SDK.\n\n\
@@ -2244,6 +2519,18 @@ module GetDecryptedAPIKey : sig
     'http_type Smaws_Lib.Context.t ->
     get_decrypted_api_key_request ->
     ( get_decrypted_api_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_decrypted_api_key_request ->
+    ( get_decrypted_api_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2281,6 +2568,17 @@ module GetIPSet : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ip_set_request ->
+    ( get_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the specified [IPSet].\n"]
 
@@ -2303,6 +2601,17 @@ module GetLoggingConfiguration : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_logging_configuration_request ->
+    ( get_logging_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the [LoggingConfiguration] for the specified web ACL.\n"]
 
@@ -2319,6 +2628,17 @@ module GetManagedRuleSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_managed_rule_set_request ->
     ( get_managed_rule_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_managed_rule_set_request ->
+    ( get_managed_rule_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2356,6 +2676,17 @@ module GetMobileSdkRelease : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mobile_sdk_release_request ->
+    ( get_mobile_sdk_release_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves information for the specified mobile SDK release, including release notes and tags.\n\n\
@@ -2383,6 +2714,16 @@ module GetPermissionPolicy : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_permission_policy_request ->
+    ( get_permission_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the IAM policy that is attached to the specified rule group.\n\n\
@@ -2403,6 +2744,19 @@ module GetRateBasedStatementManagedKeys : sig
     'http_type Smaws_Lib.Context.t ->
     get_rate_based_statement_managed_keys_request ->
     ( get_rate_based_statement_managed_keys_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFUnsupportedAggregateKeyTypeException of waf_unsupported_aggregate_key_type_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rate_based_statement_managed_keys_request ->
+    ( get_rate_based_statement_managed_keys_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2451,6 +2805,17 @@ module GetRegexPatternSet : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_regex_pattern_set_request ->
+    ( get_regex_pattern_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the specified [RegexPatternSet].\n"]
 
@@ -2467,6 +2832,17 @@ module GetRevenueStatistics : sig
     'http_type Smaws_Lib.Context.t ->
     get_revenue_statistics_request ->
     ( get_revenue_statistics_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_revenue_statistics_request ->
+    ( get_revenue_statistics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2500,6 +2876,17 @@ module GetRevenueStatisticsSummary : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_revenue_statistics_summary_request ->
+    ( get_revenue_statistics_summary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a summary of monetization revenue for the specified time window. Returns total \
@@ -2521,6 +2908,17 @@ module GetRevenueStatisticsTimeSeries : sig
     'http_type Smaws_Lib.Context.t ->
     get_revenue_statistics_time_series_request ->
     ( get_revenue_statistics_time_series_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_revenue_statistics_time_series_request ->
+    ( get_revenue_statistics_time_series_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2554,6 +2952,17 @@ module GetRuleGroup : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rule_group_request ->
+    ( get_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the specified [RuleGroup].\n"]
 
@@ -2569,6 +2978,16 @@ module GetSampledRequests : sig
     'http_type Smaws_Lib.Context.t ->
     get_sampled_requests_request ->
     ( get_sampled_requests_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sampled_requests_request ->
+    ( get_sampled_requests_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
@@ -2610,6 +3029,19 @@ module GetTopPathStatisticsByTraffic : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_top_path_statistics_by_traffic_request ->
+    ( get_top_path_statistics_by_traffic_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFFeatureNotIncludedInPricingPlanException of
+        waf_feature_not_included_in_pricing_plan_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves aggregated statistics about the top URI paths accessed by bot traffic for a specified \
@@ -2637,6 +3069,17 @@ module GetWebACL : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_web_acl_request ->
+    ( get_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the specified [WebACL].\n"]
 
@@ -2654,6 +3097,18 @@ module GetWebACLForResource : sig
     'http_type Smaws_Lib.Context.t ->
     get_web_acl_for_resource_request ->
     ( get_web_acl_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_web_acl_for_resource_request ->
+    ( get_web_acl_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2701,6 +3156,17 @@ module ListAPIKeys : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFInvalidResourceException of waf_invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_api_keys_request ->
+    ( list_api_keys_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of the API keys that you've defined for the specified scope. \n\n\
@@ -2730,6 +3196,17 @@ module ListAvailableManagedRuleGroupVersions : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_available_managed_rule_group_versions_request ->
+    ( list_available_managed_rule_group_versions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of the available versions for the specified managed rule group. \n"]
 
@@ -2745,6 +3222,16 @@ module ListAvailableManagedRuleGroups : sig
     'http_type Smaws_Lib.Context.t ->
     list_available_managed_rule_groups_request ->
     ( list_available_managed_rule_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_available_managed_rule_groups_request ->
+    ( list_available_managed_rule_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2773,6 +3260,16 @@ module ListIPSets : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ip_sets_request ->
+    ( list_ip_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves an array of [IPSetSummary] objects for the IP sets that you manage.\n"]
 
@@ -2793,6 +3290,16 @@ module ListLoggingConfigurations : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_logging_configurations_request ->
+    ( list_logging_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves an array of your [LoggingConfiguration] objects.\n"]
 
@@ -2808,6 +3315,16 @@ module ListManagedRuleSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_managed_rule_sets_request ->
     ( list_managed_rule_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_managed_rule_sets_request ->
+    ( list_managed_rule_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2842,6 +3359,16 @@ module ListMobileSdkReleases : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mobile_sdk_releases_request ->
+    ( list_mobile_sdk_releases_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of the available releases for the mobile SDK and the specified device \
@@ -2870,6 +3397,16 @@ module ListRegexPatternSets : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_regex_pattern_sets_request ->
+    ( list_regex_pattern_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves an array of [RegexPatternSetSummary] objects for the regex pattern sets that you \
@@ -2888,6 +3425,17 @@ module ListResourcesForWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     list_resources_for_web_acl_request ->
     ( list_resources_for_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resources_for_web_acl_request ->
+    ( list_resources_for_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2928,6 +3476,16 @@ module ListRuleGroups : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rule_groups_request ->
+    ( list_rule_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves an array of [RuleGroupSummary] objects for the rule groups that you manage. \n"]
@@ -2945,6 +3503,17 @@ module ListSettlementRecords : sig
     'http_type Smaws_Lib.Context.t ->
     list_settlement_records_request ->
     ( list_settlement_records_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_settlement_records_request ->
+    ( list_settlement_records_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -2982,6 +3551,19 @@ module ListTagsForResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the [TagInfoForResource] for the specified resource. Tags are key:value pairs that \
@@ -3010,6 +3592,16 @@ module ListWebACLs : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_web_ac_ls_request ->
+    ( list_web_ac_ls_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves an array of [WebACLSummary] objects for the web ACLs that you manage.\n"]
 
@@ -3032,6 +3624,23 @@ module PutLoggingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     put_logging_configuration_request ->
     ( put_logging_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFFeatureNotIncludedInPricingPlanException of
+        waf_feature_not_included_in_pricing_plan_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFLogDestinationPermissionIssueException of waf_log_destination_permission_issue_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_logging_configuration_request ->
+    ( put_logging_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFFeatureNotIncludedInPricingPlanException of
         waf_feature_not_included_in_pricing_plan_exception
@@ -3121,6 +3730,18 @@ module PutManagedRuleSetVersions : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_managed_rule_set_versions_request ->
+    ( put_managed_rule_set_versions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
 end
 [@@ocaml.doc
   "Defines the versions of your managed rule set that you are offering to the customers. Customers \
@@ -3156,6 +3777,17 @@ module PutPermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     put_permission_policy_request ->
     ( put_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_permission_policy_request ->
+    ( put_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
@@ -3212,6 +3844,20 @@ module TagResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates tags with the specified Amazon Web Services resource. Tags are key:value pairs that \
@@ -3246,6 +3892,19 @@ module UntagResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disassociates tags from an Amazon Web Services resource. Tags are key:value pairs that you can \
@@ -3269,6 +3928,20 @@ module UpdateIPSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_ip_set_request ->
     ( update_ip_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_ip_set_request ->
+    ( update_ip_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDuplicateItemException of waf_duplicate_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -3347,6 +4020,18 @@ module UpdateManagedRuleSetVersionExpiryDate : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_managed_rule_set_version_expiry_date_request ->
+    ( update_managed_rule_set_version_expiry_date_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the expiration information for your managed rule set. Use this to initiate the \
@@ -3378,6 +4063,20 @@ module UpdateRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_regex_pattern_set_request ->
     ( update_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_regex_pattern_set_request ->
+    ( update_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDuplicateItemException of waf_duplicate_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -3454,6 +4153,23 @@ module UpdateRuleGroup : sig
     'http_type Smaws_Lib.Context.t ->
     update_rule_group_request ->
     ( update_rule_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFConfigurationWarningException of waf_configuration_warning_exception
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_rule_group_request ->
+    ( update_rule_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFConfigurationWarningException of waf_configuration_warning_exception
       | `WAFDuplicateItemException of waf_duplicate_item_exception
@@ -3544,6 +4260,28 @@ module UpdateWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     update_web_acl_request ->
     ( update_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFConfigurationWarningException of waf_configuration_warning_exception
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFExpiredManagedRuleGroupVersionException of
+        waf_expired_managed_rule_group_version_exception
+      | `WAFFeatureNotIncludedInPricingPlanException of
+        waf_feature_not_included_in_pricing_plan_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_web_acl_request ->
+    ( update_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFConfigurationWarningException of waf_configuration_warning_exception
       | `WAFDuplicateItemException of waf_duplicate_item_exception

--- a/sdks/wafv2/Smaws_Client_WAFV2.mli
+++ b/sdks/wafv2/Smaws_Client_WAFV2.mli
@@ -1558,7 +1558,8 @@ module AssociateWebACL : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1651,7 +1652,8 @@ module CheckCapacity : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1696,7 +1698,8 @@ module CreateAPIKey : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFLimitsExceededException of waf_limits_exceeded_exception ] )
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1751,7 +1754,8 @@ module CreateIPSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1800,7 +1804,8 @@ module CreateRegexPatternSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1856,7 +1861,8 @@ module CreateRuleGroup : sig
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1928,7 +1934,8 @@ module CreateWebACL : sig
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1975,7 +1982,8 @@ module DeleteAPIKey : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2015,7 +2023,8 @@ module DeleteFirewallManagerRuleGroups : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2064,7 +2073,8 @@ module DeleteIPSet : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified [IPSet]. \n"]
@@ -2100,7 +2110,8 @@ module DeleteLoggingConfiguration : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the [LoggingConfiguration] from the specified web ACL.\n"]
@@ -2130,7 +2141,8 @@ module DeletePermissionPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2178,7 +2190,8 @@ module DeleteRegexPatternSet : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified [RegexPatternSet].\n"]
@@ -2223,7 +2236,8 @@ module DeleteRuleGroup : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified [RuleGroup].\n"]
@@ -2268,7 +2282,8 @@ module DeleteWebACL : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2337,7 +2352,8 @@ module DescribeAllManagedProducts : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2369,7 +2385,8 @@ module DescribeManagedProductsByVendor : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2412,7 +2429,8 @@ module DescribeManagedRuleGroup : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFInvalidResourceException of waf_invalid_resource_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2446,7 +2464,8 @@ module DisassociateWebACL : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2493,7 +2512,8 @@ module GenerateMobileSdkReleaseUrl : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2536,7 +2556,8 @@ module GetDecryptedAPIKey : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFInvalidResourceException of waf_invalid_resource_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2577,7 +2598,8 @@ module GetIPSet : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the specified [IPSet].\n"]
@@ -2610,7 +2632,8 @@ module GetLoggingConfiguration : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the [LoggingConfiguration] for the specified web ACL.\n"]
@@ -2643,7 +2666,8 @@ module GetManagedRuleSet : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2685,7 +2709,8 @@ module GetMobileSdkRelease : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2722,7 +2747,8 @@ module GetPermissionPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2763,7 +2789,7 @@ module GetRateBasedStatementManagedKeys : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFUnsupportedAggregateKeyTypeException of waf_unsupported_aggregate_key_type_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2814,7 +2840,8 @@ module GetRegexPatternSet : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the specified [RegexPatternSet].\n"]
@@ -2847,7 +2874,8 @@ module GetRevenueStatistics : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2885,7 +2913,8 @@ module GetRevenueStatisticsSummary : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2923,7 +2952,8 @@ module GetRevenueStatisticsTimeSeries : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2961,7 +2991,8 @@ module GetRuleGroup : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the specified [RuleGroup].\n"]
@@ -2991,7 +3022,8 @@ module GetSampledRequests : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3040,7 +3072,8 @@ module GetTopPathStatisticsByTraffic : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3078,7 +3111,8 @@ module GetWebACL : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the specified [WebACL].\n"]
@@ -3114,7 +3148,8 @@ module GetWebACLForResource : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3165,7 +3200,8 @@ module ListAPIKeys : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFInvalidResourceException of waf_invalid_resource_exception ] )
+      | `WAFInvalidResourceException of waf_invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3205,7 +3241,8 @@ module ListAvailableManagedRuleGroupVersions : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of the available versions for the specified managed rule group. \n"]
@@ -3235,7 +3272,8 @@ module ListAvailableManagedRuleGroups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3268,7 +3306,8 @@ module ListIPSets : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves an array of [IPSetSummary] objects for the IP sets that you manage.\n"]
@@ -3298,7 +3337,8 @@ module ListLoggingConfigurations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves an array of your [LoggingConfiguration] objects.\n"]
@@ -3328,7 +3368,8 @@ module ListManagedRuleSets : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3367,7 +3408,8 @@ module ListMobileSdkReleases : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3405,7 +3447,8 @@ module ListRegexPatternSets : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3440,7 +3483,8 @@ module ListResourcesForWebACL : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3484,7 +3528,8 @@ module ListRuleGroups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3518,7 +3563,8 @@ module ListSettlementRecords : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3562,7 +3608,8 @@ module ListTagsForResource : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3600,7 +3647,8 @@ module ListWebACLs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves an array of [WebACLSummary] objects for the web ACLs that you manage.\n"]
@@ -3651,7 +3699,8 @@ module PutLoggingConfiguration : sig
       | `WAFLogDestinationPermissionIssueException of waf_log_destination_permission_issue_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
-      | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception ] )
+      | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3740,7 +3789,8 @@ module PutManagedRuleSetVersions : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3792,7 +3842,8 @@ module PutPermissionPolicy : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3856,7 +3907,8 @@ module TagResource : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3903,7 +3955,8 @@ module UntagResource : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3949,7 +4002,8 @@ module UpdateIPSet : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4030,7 +4084,8 @@ module UpdateManagedRuleSetVersionExpiryDate : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4084,7 +4139,8 @@ module UpdateRegexPatternSet : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4180,7 +4236,8 @@ module UpdateRuleGroup : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4297,7 +4354,8 @@ module UpdateWebACL : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/wafv2/operations.ml
+++ b/sdks/wafv2/operations.ml
@@ -47,6 +47,13 @@ module AssociateWebACL = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.AssociateWebACL" ~service
       ~context ~input ~output_deserializer:Json_deserializers.associate_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_web_acl_request) =
+    let input = Json_serializers.associate_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.AssociateWebACL"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_web_acl_response_of_yojson
+      ~error_deserializer
 end
 
 module CheckCapacity = struct
@@ -102,6 +109,12 @@ module CheckCapacity = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.CheckCapacity" ~service
       ~context ~input ~output_deserializer:Json_deserializers.check_capacity_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : check_capacity_request) =
+    let input = Json_serializers.check_capacity_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.CheckCapacity"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.check_capacity_response_of_yojson ~error_deserializer
 end
 
 module CreateAPIKey = struct
@@ -136,6 +149,12 @@ module CreateAPIKey = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.CreateAPIKey" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_api_key_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_api_key_request) =
+    let input = Json_serializers.create_api_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.CreateAPIKey"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_api_key_response_of_yojson ~error_deserializer
 end
 
 module CreateIPSet = struct
@@ -187,6 +206,12 @@ module CreateIPSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.CreateIPSet" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_ip_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_ip_set_request) =
+    let input = Json_serializers.create_ip_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.CreateIPSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_ip_set_response_of_yojson ~error_deserializer
 end
 
 module CreateRegexPatternSet = struct
@@ -237,6 +262,13 @@ module CreateRegexPatternSet = struct
     let input = Json_serializers.create_regex_pattern_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.CreateRegexPatternSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.create_regex_pattern_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_regex_pattern_set_request) =
+    let input = Json_serializers.create_regex_pattern_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.CreateRegexPatternSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_regex_pattern_set_response_of_yojson
       ~error_deserializer
 end
@@ -301,6 +333,13 @@ module CreateRuleGroup = struct
     let input = Json_serializers.create_rule_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.CreateRuleGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_rule_group_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_rule_group_request) =
+    let input = Json_serializers.create_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.CreateRuleGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_rule_group_response_of_yojson
       ~error_deserializer
 end
 
@@ -378,6 +417,12 @@ module CreateWebACL = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.CreateWebACL" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_web_acl_request) =
+    let input = Json_serializers.create_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.CreateWebACL"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_web_acl_response_of_yojson ~error_deserializer
 end
 
 module DeleteAPIKey = struct
@@ -416,6 +461,12 @@ module DeleteAPIKey = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.DeleteAPIKey" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_api_key_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_api_key_request) =
+    let input = Json_serializers.delete_api_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.DeleteAPIKey"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_api_key_response_of_yojson ~error_deserializer
 end
 
 module DeleteFirewallManagerRuleGroups = struct
@@ -452,6 +503,13 @@ module DeleteFirewallManagerRuleGroups = struct
   let request context (request : delete_firewall_manager_rule_groups_request) =
     let input = Json_serializers.delete_firewall_manager_rule_groups_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSWAF_20190729.DeleteFirewallManagerRuleGroups" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_firewall_manager_rule_groups_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_firewall_manager_rule_groups_request) =
+    let input = Json_serializers.delete_firewall_manager_rule_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSWAF_20190729.DeleteFirewallManagerRuleGroups" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_firewall_manager_rule_groups_response_of_yojson
       ~error_deserializer
@@ -506,6 +564,12 @@ module DeleteIPSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.DeleteIPSet" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_ip_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_ip_set_request) =
+    let input = Json_serializers.delete_ip_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.DeleteIPSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_ip_set_response_of_yojson ~error_deserializer
 end
 
 module DeleteLoggingConfiguration = struct
@@ -545,6 +609,13 @@ module DeleteLoggingConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_logging_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_logging_configuration_request) =
+    let input = Json_serializers.delete_logging_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.DeleteLoggingConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_logging_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DeletePermissionPolicy = struct
@@ -574,6 +645,13 @@ module DeletePermissionPolicy = struct
     let input = Json_serializers.delete_permission_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.DeletePermissionPolicy"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_permission_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_permission_policy_request) =
+    let input = Json_serializers.delete_permission_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.DeletePermissionPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_permission_policy_response_of_yojson
       ~error_deserializer
 end
@@ -628,6 +706,13 @@ module DeleteRegexPatternSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.delete_regex_pattern_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_regex_pattern_set_request) =
+    let input = Json_serializers.delete_regex_pattern_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.DeleteRegexPatternSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_regex_pattern_set_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteRuleGroup = struct
@@ -678,6 +763,13 @@ module DeleteRuleGroup = struct
     let input = Json_serializers.delete_rule_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.DeleteRuleGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_rule_group_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_rule_group_request) =
+    let input = Json_serializers.delete_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.DeleteRuleGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_rule_group_response_of_yojson
       ~error_deserializer
 end
 
@@ -730,6 +822,12 @@ module DeleteWebACL = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.DeleteWebACL" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_web_acl_request) =
+    let input = Json_serializers.delete_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.DeleteWebACL"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_web_acl_response_of_yojson ~error_deserializer
 end
 
 module DescribeAllManagedProducts = struct
@@ -761,6 +859,13 @@ module DescribeAllManagedProducts = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_all_managed_products_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_all_managed_products_request) =
+    let input = Json_serializers.describe_all_managed_products_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.DescribeAllManagedProducts" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_all_managed_products_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeManagedProductsByVendor = struct
@@ -789,6 +894,13 @@ module DescribeManagedProductsByVendor = struct
   let request context (request : describe_managed_products_by_vendor_request) =
     let input = Json_serializers.describe_managed_products_by_vendor_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSWAF_20190729.DescribeManagedProductsByVendor" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_managed_products_by_vendor_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_managed_products_by_vendor_request) =
+    let input = Json_serializers.describe_managed_products_by_vendor_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSWAF_20190729.DescribeManagedProductsByVendor" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_managed_products_by_vendor_response_of_yojson
       ~error_deserializer
@@ -836,6 +948,13 @@ module DescribeManagedRuleGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_managed_rule_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_managed_rule_group_request) =
+    let input = Json_serializers.describe_managed_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.DescribeManagedRuleGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_managed_rule_group_response_of_yojson
+      ~error_deserializer
 end
 
 module DisassociateWebACL = struct
@@ -871,6 +990,13 @@ module DisassociateWebACL = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_web_acl_request) =
+    let input = Json_serializers.disassociate_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.DisassociateWebACL" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_web_acl_response_of_yojson
+      ~error_deserializer
 end
 
 module GenerateMobileSdkReleaseUrl = struct
@@ -904,6 +1030,13 @@ module GenerateMobileSdkReleaseUrl = struct
     let input = Json_serializers.generate_mobile_sdk_release_url_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.GenerateMobileSdkReleaseUrl"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.generate_mobile_sdk_release_url_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : generate_mobile_sdk_release_url_request) =
+    let input = Json_serializers.generate_mobile_sdk_release_url_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GenerateMobileSdkReleaseUrl" ~service ~context ~input
       ~output_deserializer:Json_deserializers.generate_mobile_sdk_release_url_response_of_yojson
       ~error_deserializer
 end
@@ -945,6 +1078,13 @@ module GetDecryptedAPIKey = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_decrypted_api_key_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_decrypted_api_key_request) =
+    let input = Json_serializers.get_decrypted_api_key_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetDecryptedAPIKey" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_decrypted_api_key_response_of_yojson
+      ~error_deserializer
 end
 
 module GetIPSet = struct
@@ -979,6 +1119,12 @@ module GetIPSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.GetIPSet" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_ip_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_ip_set_request) =
+    let input = Json_serializers.get_ip_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.GetIPSet"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.get_ip_set_response_of_yojson
+      ~error_deserializer
 end
 
 module GetLoggingConfiguration = struct
@@ -1012,6 +1158,13 @@ module GetLoggingConfiguration = struct
     let input = Json_serializers.get_logging_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.GetLoggingConfiguration"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_logging_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_logging_configuration_request) =
+    let input = Json_serializers.get_logging_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetLoggingConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_logging_configuration_response_of_yojson
       ~error_deserializer
 end
@@ -1049,6 +1202,13 @@ module GetManagedRuleSet = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_managed_rule_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_managed_rule_set_request) =
+    let input = Json_serializers.get_managed_rule_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetManagedRuleSet" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_managed_rule_set_response_of_yojson
+      ~error_deserializer
 end
 
 module GetMobileSdkRelease = struct
@@ -1084,6 +1244,13 @@ module GetMobileSdkRelease = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_mobile_sdk_release_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_mobile_sdk_release_request) =
+    let input = Json_serializers.get_mobile_sdk_release_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetMobileSdkRelease" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_mobile_sdk_release_response_of_yojson
+      ~error_deserializer
 end
 
 module GetPermissionPolicy = struct
@@ -1113,6 +1280,13 @@ module GetPermissionPolicy = struct
     let input = Json_serializers.get_permission_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.GetPermissionPolicy" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_permission_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_permission_policy_request) =
+    let input = Json_serializers.get_permission_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetPermissionPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_permission_policy_response_of_yojson
       ~error_deserializer
 end
@@ -1156,6 +1330,14 @@ module GetRateBasedStatementManagedKeys = struct
       ~output_deserializer:
         Json_deserializers.get_rate_based_statement_managed_keys_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_rate_based_statement_managed_keys_request) =
+    let input = Json_serializers.get_rate_based_statement_managed_keys_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetRateBasedStatementManagedKeys" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.get_rate_based_statement_managed_keys_response_of_yojson
+      ~error_deserializer
 end
 
 module GetRegexPatternSet = struct
@@ -1189,6 +1371,13 @@ module GetRegexPatternSet = struct
     let input = Json_serializers.get_regex_pattern_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.GetRegexPatternSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_regex_pattern_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_regex_pattern_set_request) =
+    let input = Json_serializers.get_regex_pattern_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetRegexPatternSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_regex_pattern_set_response_of_yojson
       ~error_deserializer
 end
@@ -1226,6 +1415,13 @@ module GetRevenueStatistics = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_revenue_statistics_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_revenue_statistics_request) =
+    let input = Json_serializers.get_revenue_statistics_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetRevenueStatistics" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_revenue_statistics_response_of_yojson
+      ~error_deserializer
 end
 
 module GetRevenueStatisticsSummary = struct
@@ -1259,6 +1455,13 @@ module GetRevenueStatisticsSummary = struct
     let input = Json_serializers.get_revenue_statistics_summary_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.GetRevenueStatisticsSummary"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_revenue_statistics_summary_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_revenue_statistics_summary_request) =
+    let input = Json_serializers.get_revenue_statistics_summary_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetRevenueStatisticsSummary" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_revenue_statistics_summary_response_of_yojson
       ~error_deserializer
 end
@@ -1296,6 +1499,13 @@ module GetRevenueStatisticsTimeSeries = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_revenue_statistics_time_series_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_revenue_statistics_time_series_request) =
+    let input = Json_serializers.get_revenue_statistics_time_series_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetRevenueStatisticsTimeSeries" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_revenue_statistics_time_series_response_of_yojson
+      ~error_deserializer
 end
 
 module GetRuleGroup = struct
@@ -1330,6 +1540,12 @@ module GetRuleGroup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.GetRuleGroup" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_rule_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_rule_group_request) =
+    let input = Json_serializers.get_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.GetRuleGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_rule_group_response_of_yojson ~error_deserializer
 end
 
 module GetSampledRequests = struct
@@ -1359,6 +1575,13 @@ module GetSampledRequests = struct
     let input = Json_serializers.get_sampled_requests_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.GetSampledRequests" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_sampled_requests_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_sampled_requests_request) =
+    let input = Json_serializers.get_sampled_requests_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetSampledRequests" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_sampled_requests_response_of_yojson
       ~error_deserializer
 end
@@ -1402,6 +1625,13 @@ module GetTopPathStatisticsByTraffic = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_top_path_statistics_by_traffic_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_top_path_statistics_by_traffic_request) =
+    let input = Json_serializers.get_top_path_statistics_by_traffic_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetTopPathStatisticsByTraffic" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_top_path_statistics_by_traffic_response_of_yojson
+      ~error_deserializer
 end
 
 module GetWebACL = struct
@@ -1436,6 +1666,12 @@ module GetWebACL = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.GetWebACL" ~service ~context
       ~input ~output_deserializer:Json_deserializers.get_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_web_acl_request) =
+    let input = Json_serializers.get_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.GetWebACL"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_web_acl_response_of_yojson ~error_deserializer
 end
 
 module GetWebACLForResource = struct
@@ -1475,6 +1711,13 @@ module GetWebACLForResource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.get_web_acl_for_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_web_acl_for_resource_request) =
+    let input = Json_serializers.get_web_acl_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.GetWebACLForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_web_acl_for_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAPIKeys = struct
@@ -1509,6 +1752,12 @@ module ListAPIKeys = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.ListAPIKeys" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_api_keys_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_api_keys_request) =
+    let input = Json_serializers.list_api_keys_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.ListAPIKeys"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_api_keys_response_of_yojson ~error_deserializer
 end
 
 module ListAvailableManagedRuleGroupVersions = struct
@@ -1547,6 +1796,16 @@ module ListAvailableManagedRuleGroupVersions = struct
       ~output_deserializer:
         Json_deserializers.list_available_managed_rule_group_versions_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_available_managed_rule_group_versions_request) =
+    let input =
+      Json_serializers.list_available_managed_rule_group_versions_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.ListAvailableManagedRuleGroupVersions" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.list_available_managed_rule_group_versions_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAvailableManagedRuleGroups = struct
@@ -1576,6 +1835,13 @@ module ListAvailableManagedRuleGroups = struct
     let input = Json_serializers.list_available_managed_rule_groups_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.ListAvailableManagedRuleGroups"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_available_managed_rule_groups_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_available_managed_rule_groups_request) =
+    let input = Json_serializers.list_available_managed_rule_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.ListAvailableManagedRuleGroups" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_available_managed_rule_groups_response_of_yojson
       ~error_deserializer
 end
@@ -1608,6 +1874,12 @@ module ListIPSets = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.ListIPSets" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_ip_sets_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_ip_sets_request) =
+    let input = Json_serializers.list_ip_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.ListIPSets"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_ip_sets_response_of_yojson ~error_deserializer
 end
 
 module ListLoggingConfigurations = struct
@@ -1637,6 +1909,13 @@ module ListLoggingConfigurations = struct
     let input = Json_serializers.list_logging_configurations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.ListLoggingConfigurations"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_logging_configurations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_logging_configurations_request) =
+    let input = Json_serializers.list_logging_configurations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.ListLoggingConfigurations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_logging_configurations_response_of_yojson
       ~error_deserializer
 end
@@ -1670,6 +1949,13 @@ module ListManagedRuleSets = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_managed_rule_sets_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_managed_rule_sets_request) =
+    let input = Json_serializers.list_managed_rule_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.ListManagedRuleSets" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_managed_rule_sets_response_of_yojson
+      ~error_deserializer
 end
 
 module ListMobileSdkReleases = struct
@@ -1701,6 +1987,13 @@ module ListMobileSdkReleases = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_mobile_sdk_releases_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_mobile_sdk_releases_request) =
+    let input = Json_serializers.list_mobile_sdk_releases_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.ListMobileSdkReleases" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_mobile_sdk_releases_response_of_yojson
+      ~error_deserializer
 end
 
 module ListRegexPatternSets = struct
@@ -1730,6 +2023,13 @@ module ListRegexPatternSets = struct
     let input = Json_serializers.list_regex_pattern_sets_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.ListRegexPatternSets" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_regex_pattern_sets_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_regex_pattern_sets_request) =
+    let input = Json_serializers.list_regex_pattern_sets_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.ListRegexPatternSets" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_regex_pattern_sets_response_of_yojson
       ~error_deserializer
 end
@@ -1767,6 +2067,13 @@ module ListResourcesForWebACL = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_resources_for_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_resources_for_web_acl_request) =
+    let input = Json_serializers.list_resources_for_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.ListResourcesForWebACL" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resources_for_web_acl_response_of_yojson
+      ~error_deserializer
 end
 
 module ListRuleGroups = struct
@@ -1796,6 +2103,13 @@ module ListRuleGroups = struct
     let input = Json_serializers.list_rule_groups_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.ListRuleGroups" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_rule_groups_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_rule_groups_request) =
+    let input = Json_serializers.list_rule_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.ListRuleGroups"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_rule_groups_response_of_yojson
       ~error_deserializer
 end
 
@@ -1830,6 +2144,13 @@ module ListSettlementRecords = struct
     let input = Json_serializers.list_settlement_records_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.ListSettlementRecords" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_settlement_records_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_settlement_records_request) =
+    let input = Json_serializers.list_settlement_records_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.ListSettlementRecords" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_settlement_records_response_of_yojson
       ~error_deserializer
 end
@@ -1876,6 +2197,13 @@ module ListTagsForResource = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.ListTagsForResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module ListWebACLs = struct
@@ -1906,6 +2234,12 @@ module ListWebACLs = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.ListWebACLs" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_web_ac_ls_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_web_ac_ls_request) =
+    let input = Json_serializers.list_web_ac_ls_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.ListWebACLs"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_web_ac_ls_response_of_yojson ~error_deserializer
 end
 
 module PutLoggingConfiguration = struct
@@ -1965,6 +2299,13 @@ module PutLoggingConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_logging_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_logging_configuration_request) =
+    let input = Json_serializers.put_logging_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.PutLoggingConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_logging_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module PutManagedRuleSetVersions = struct
@@ -2004,6 +2345,13 @@ module PutManagedRuleSetVersions = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_managed_rule_set_versions_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_managed_rule_set_versions_request) =
+    let input = Json_serializers.put_managed_rule_set_versions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.PutManagedRuleSetVersions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_managed_rule_set_versions_response_of_yojson
+      ~error_deserializer
 end
 
 module PutPermissionPolicy = struct
@@ -2038,6 +2386,13 @@ module PutPermissionPolicy = struct
     let input = Json_serializers.put_permission_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.PutPermissionPolicy" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.put_permission_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_permission_policy_request) =
+    let input = Json_serializers.put_permission_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.PutPermissionPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_permission_policy_response_of_yojson
       ~error_deserializer
 end
@@ -2087,6 +2442,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.TagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module UntagResource = struct
@@ -2130,6 +2491,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
 module UpdateIPSet = struct
@@ -2176,6 +2543,12 @@ module UpdateIPSet = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.UpdateIPSet" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_ip_set_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_ip_set_request) =
+    let input = Json_serializers.update_ip_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.UpdateIPSet"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_ip_set_response_of_yojson ~error_deserializer
 end
 
 module UpdateManagedRuleSetVersionExpiryDate = struct
@@ -2214,6 +2587,17 @@ module UpdateManagedRuleSetVersionExpiryDate = struct
       Json_serializers.update_managed_rule_set_version_expiry_date_request_to_yojson request
     in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"AWSWAF_20190729.UpdateManagedRuleSetVersionExpiryDate" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.update_managed_rule_set_version_expiry_date_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_managed_rule_set_version_expiry_date_request)
+      =
+    let input =
+      Json_serializers.update_managed_rule_set_version_expiry_date_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"AWSWAF_20190729.UpdateManagedRuleSetVersionExpiryDate" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.update_managed_rule_set_version_expiry_date_response_of_yojson
@@ -2263,6 +2647,13 @@ module UpdateRegexPatternSet = struct
     let input = Json_serializers.update_regex_pattern_set_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.UpdateRegexPatternSet" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.update_regex_pattern_set_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_regex_pattern_set_request) =
+    let input = Json_serializers.update_regex_pattern_set_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"AWSWAF_20190729.UpdateRegexPatternSet" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_regex_pattern_set_response_of_yojson
       ~error_deserializer
 end
@@ -2322,6 +2713,13 @@ module UpdateRuleGroup = struct
     let input = Json_serializers.update_rule_group_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.UpdateRuleGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_rule_group_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_rule_group_request) =
+    let input = Json_serializers.update_rule_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.UpdateRuleGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_rule_group_response_of_yojson
       ~error_deserializer
 end
 
@@ -2396,4 +2794,10 @@ module UpdateWebACL = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"AWSWAF_20190729.UpdateWebACL" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_web_acl_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_web_acl_request) =
+    let input = Json_serializers.update_web_acl_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"AWSWAF_20190729.UpdateWebACL"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_web_acl_response_of_yojson ~error_deserializer
 end

--- a/sdks/wafv2/operations.mli
+++ b/sdks/wafv2/operations.mli
@@ -27,6 +27,21 @@ module AssociateWebACL : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_web_acl_request ->
+    ( associate_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFFeatureNotIncludedInPricingPlanException of
+        waf_feature_not_included_in_pricing_plan_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates a web ACL with a resource, to protect the resource. \n\n\
@@ -103,6 +118,23 @@ module CheckCapacity : sig
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
       | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    check_capacity_request ->
+    ( check_capacity_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFExpiredManagedRuleGroupVersionException of
+        waf_expired_managed_rule_group_version_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the web ACL capacity unit (WCU) requirements for a specified scope and set of rules. \
@@ -131,6 +163,17 @@ module CreateAPIKey : sig
     'http_type Smaws_Lib.Context.t ->
     create_api_key_request ->
     ( create_api_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_api_key_request ->
+    ( create_api_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -177,6 +220,21 @@ module CreateIPSet : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_ip_set_request ->
+    ( create_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates an [IPSet], which you use to identify web requests that originate from specific IP \
@@ -201,6 +259,21 @@ module CreateRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     create_regex_pattern_set_request ->
     ( create_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_regex_pattern_set_request ->
+    ( create_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDuplicateItemException of waf_duplicate_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -236,6 +309,24 @@ module CreateRuleGroup : sig
     'http_type Smaws_Lib.Context.t ->
     create_rule_group_request ->
     ( create_rule_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_rule_group_request ->
+    ( create_rule_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDuplicateItemException of waf_duplicate_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -299,6 +390,28 @@ module CreateWebACL : sig
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
       | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_web_acl_request ->
+    ( create_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFConfigurationWarningException of waf_configuration_warning_exception
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFExpiredManagedRuleGroupVersionException of
+        waf_expired_managed_rule_group_version_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a [WebACL] per the specifications provided.\n\n\
@@ -334,6 +447,18 @@ module DeleteAPIKey : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_api_key_request ->
+    ( delete_api_key_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes the specified API key. \n\n\
@@ -355,6 +480,18 @@ module DeleteFirewallManagerRuleGroups : sig
     'http_type Smaws_Lib.Context.t ->
     delete_firewall_manager_rule_groups_request ->
     ( delete_firewall_manager_rule_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_firewall_manager_rule_groups_request ->
+    ( delete_firewall_manager_rule_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -396,6 +533,21 @@ module DeleteIPSet : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_ip_set_request ->
+    ( delete_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFAssociatedItemException of waf_associated_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified [IPSet]. \n"]
 
@@ -420,6 +572,18 @@ module DeleteLoggingConfiguration : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_logging_configuration_request ->
+    ( delete_logging_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the [LoggingConfiguration] from the specified web ACL.\n"]
 
@@ -435,6 +599,16 @@ module DeletePermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     delete_permission_policy_request ->
     ( delete_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_permission_policy_request ->
+    ( delete_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
@@ -463,6 +637,21 @@ module DeleteRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     delete_regex_pattern_set_request ->
     ( delete_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFAssociatedItemException of waf_associated_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_regex_pattern_set_request ->
+    ( delete_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFAssociatedItemException of waf_associated_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -503,6 +692,21 @@ module DeleteRuleGroup : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_rule_group_request ->
+    ( delete_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFAssociatedItemException of waf_associated_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified [RuleGroup].\n"]
 
@@ -523,6 +727,21 @@ module DeleteWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     delete_web_acl_request ->
     ( delete_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFAssociatedItemException of waf_associated_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_web_acl_request ->
+    ( delete_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFAssociatedItemException of waf_associated_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -592,6 +811,16 @@ module DescribeAllManagedProducts : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_all_managed_products_request ->
+    ( describe_all_managed_products_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides high-level information for the Amazon Web Services Managed Rules rule groups and \
@@ -609,6 +838,16 @@ module DescribeManagedProductsByVendor : sig
     'http_type Smaws_Lib.Context.t ->
     describe_managed_products_by_vendor_request ->
     ( describe_managed_products_by_vendor_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_managed_products_by_vendor_request ->
+    ( describe_managed_products_by_vendor_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -643,6 +882,20 @@ module DescribeManagedRuleGroup : sig
       | `WAFInvalidResourceException of waf_invalid_resource_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_managed_rule_group_request ->
+    ( describe_managed_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFExpiredManagedRuleGroupVersionException of
+        waf_expired_managed_rule_group_version_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Provides high-level information for a managed rule group, including descriptions of the rules. \n"]
@@ -660,6 +913,17 @@ module DisassociateWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_web_acl_request ->
     ( disassociate_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_web_acl_request ->
+    ( disassociate_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -702,6 +966,17 @@ module GenerateMobileSdkReleaseUrl : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    generate_mobile_sdk_release_url_request ->
+    ( generate_mobile_sdk_release_url_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Generates a presigned download URL for the specified release of the mobile SDK.\n\n\
@@ -726,6 +1001,18 @@ module GetDecryptedAPIKey : sig
     'http_type Smaws_Lib.Context.t ->
     get_decrypted_api_key_request ->
     ( get_decrypted_api_key_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_decrypted_api_key_request ->
+    ( get_decrypted_api_key_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -763,6 +1050,17 @@ module GetIPSet : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_ip_set_request ->
+    ( get_ip_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the specified [IPSet].\n"]
 
@@ -785,6 +1083,17 @@ module GetLoggingConfiguration : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_logging_configuration_request ->
+    ( get_logging_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the [LoggingConfiguration] for the specified web ACL.\n"]
 
@@ -801,6 +1110,17 @@ module GetManagedRuleSet : sig
     'http_type Smaws_Lib.Context.t ->
     get_managed_rule_set_request ->
     ( get_managed_rule_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_managed_rule_set_request ->
+    ( get_managed_rule_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -838,6 +1158,17 @@ module GetMobileSdkRelease : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mobile_sdk_release_request ->
+    ( get_mobile_sdk_release_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves information for the specified mobile SDK release, including release notes and tags.\n\n\
@@ -865,6 +1196,16 @@ module GetPermissionPolicy : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_permission_policy_request ->
+    ( get_permission_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Returns the IAM policy that is attached to the specified rule group.\n\n\
@@ -885,6 +1226,19 @@ module GetRateBasedStatementManagedKeys : sig
     'http_type Smaws_Lib.Context.t ->
     get_rate_based_statement_managed_keys_request ->
     ( get_rate_based_statement_managed_keys_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFUnsupportedAggregateKeyTypeException of waf_unsupported_aggregate_key_type_exception ]
+    )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rate_based_statement_managed_keys_request ->
+    ( get_rate_based_statement_managed_keys_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -933,6 +1287,17 @@ module GetRegexPatternSet : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_regex_pattern_set_request ->
+    ( get_regex_pattern_set_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the specified [RegexPatternSet].\n"]
 
@@ -949,6 +1314,17 @@ module GetRevenueStatistics : sig
     'http_type Smaws_Lib.Context.t ->
     get_revenue_statistics_request ->
     ( get_revenue_statistics_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_revenue_statistics_request ->
+    ( get_revenue_statistics_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -982,6 +1358,17 @@ module GetRevenueStatisticsSummary : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_revenue_statistics_summary_request ->
+    ( get_revenue_statistics_summary_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a summary of monetization revenue for the specified time window. Returns total \
@@ -1003,6 +1390,17 @@ module GetRevenueStatisticsTimeSeries : sig
     'http_type Smaws_Lib.Context.t ->
     get_revenue_statistics_time_series_request ->
     ( get_revenue_statistics_time_series_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_revenue_statistics_time_series_request ->
+    ( get_revenue_statistics_time_series_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -1036,6 +1434,17 @@ module GetRuleGroup : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_rule_group_request ->
+    ( get_rule_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the specified [RuleGroup].\n"]
 
@@ -1051,6 +1460,16 @@ module GetSampledRequests : sig
     'http_type Smaws_Lib.Context.t ->
     get_sampled_requests_request ->
     ( get_sampled_requests_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_sampled_requests_request ->
+    ( get_sampled_requests_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
@@ -1092,6 +1511,19 @@ module GetTopPathStatisticsByTraffic : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_top_path_statistics_by_traffic_request ->
+    ( get_top_path_statistics_by_traffic_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFFeatureNotIncludedInPricingPlanException of
+        waf_feature_not_included_in_pricing_plan_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves aggregated statistics about the top URI paths accessed by bot traffic for a specified \
@@ -1119,6 +1551,17 @@ module GetWebACL : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_web_acl_request ->
+    ( get_web_acl_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves the specified [WebACL].\n"]
 
@@ -1136,6 +1579,18 @@ module GetWebACLForResource : sig
     'http_type Smaws_Lib.Context.t ->
     get_web_acl_for_resource_request ->
     ( get_web_acl_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_web_acl_for_resource_request ->
+    ( get_web_acl_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -1183,6 +1638,17 @@ module ListAPIKeys : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFInvalidResourceException of waf_invalid_resource_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_api_keys_request ->
+    ( list_api_keys_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of the API keys that you've defined for the specified scope. \n\n\
@@ -1212,6 +1678,17 @@ module ListAvailableManagedRuleGroupVersions : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_available_managed_rule_group_versions_request ->
+    ( list_available_managed_rule_group_versions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
 end
 [@@ocaml.doc "Returns a list of the available versions for the specified managed rule group. \n"]
 
@@ -1227,6 +1704,16 @@ module ListAvailableManagedRuleGroups : sig
     'http_type Smaws_Lib.Context.t ->
     list_available_managed_rule_groups_request ->
     ( list_available_managed_rule_groups_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_available_managed_rule_groups_request ->
+    ( list_available_managed_rule_groups_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -1255,6 +1742,16 @@ module ListIPSets : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_ip_sets_request ->
+    ( list_ip_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves an array of [IPSetSummary] objects for the IP sets that you manage.\n"]
 
@@ -1275,6 +1772,16 @@ module ListLoggingConfigurations : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_logging_configurations_request ->
+    ( list_logging_configurations_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves an array of your [LoggingConfiguration] objects.\n"]
 
@@ -1290,6 +1797,16 @@ module ListManagedRuleSets : sig
     'http_type Smaws_Lib.Context.t ->
     list_managed_rule_sets_request ->
     ( list_managed_rule_sets_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_managed_rule_sets_request ->
+    ( list_managed_rule_sets_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -1324,6 +1841,16 @@ module ListMobileSdkReleases : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mobile_sdk_releases_request ->
+    ( list_mobile_sdk_releases_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves a list of the available releases for the mobile SDK and the specified device \
@@ -1352,6 +1879,16 @@ module ListRegexPatternSets : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_regex_pattern_sets_request ->
+    ( list_regex_pattern_sets_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves an array of [RegexPatternSetSummary] objects for the regex pattern sets that you \
@@ -1370,6 +1907,17 @@ module ListResourcesForWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     list_resources_for_web_acl_request ->
     ( list_resources_for_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resources_for_web_acl_request ->
+    ( list_resources_for_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -1410,6 +1958,16 @@ module ListRuleGroups : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_rule_groups_request ->
+    ( list_rule_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves an array of [RuleGroupSummary] objects for the rule groups that you manage. \n"]
@@ -1427,6 +1985,17 @@ module ListSettlementRecords : sig
     'http_type Smaws_Lib.Context.t ->
     list_settlement_records_request ->
     ( list_settlement_records_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_settlement_records_request ->
+    ( list_settlement_records_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
@@ -1464,6 +2033,19 @@ module ListTagsForResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   "Retrieves the [TagInfoForResource] for the specified resource. Tags are key:value pairs that \
@@ -1492,6 +2074,16 @@ module ListWebACLs : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_web_ac_ls_request ->
+    ( list_web_ac_ls_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+    result
 end
 [@@ocaml.doc "Retrieves an array of [WebACLSummary] objects for the web ACLs that you manage.\n"]
 
@@ -1514,6 +2106,23 @@ module PutLoggingConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     put_logging_configuration_request ->
     ( put_logging_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFFeatureNotIncludedInPricingPlanException of
+        waf_feature_not_included_in_pricing_plan_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFLogDestinationPermissionIssueException of waf_log_destination_permission_issue_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_logging_configuration_request ->
+    ( put_logging_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFFeatureNotIncludedInPricingPlanException of
         waf_feature_not_included_in_pricing_plan_exception
@@ -1603,6 +2212,18 @@ module PutManagedRuleSetVersions : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_managed_rule_set_versions_request ->
+    ( put_managed_rule_set_versions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
 end
 [@@ocaml.doc
   "Defines the versions of your managed rule set that you are offering to the customers. Customers \
@@ -1638,6 +2259,17 @@ module PutPermissionPolicy : sig
     'http_type Smaws_Lib.Context.t ->
     put_permission_policy_request ->
     ( put_permission_policy_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_permission_policy_request ->
+    ( put_permission_policy_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
@@ -1694,6 +2326,20 @@ module TagResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   "Associates tags with the specified Amazon Web Services resource. Tags are key:value pairs that \
@@ -1728,6 +2374,19 @@ module UntagResource : sig
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFTagOperationException of waf_tag_operation_exception
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+    result
 end
 [@@ocaml.doc
   "Disassociates tags from an Amazon Web Services resource. Tags are key:value pairs that you can \
@@ -1751,6 +2410,20 @@ module UpdateIPSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_ip_set_request ->
     ( update_ip_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_ip_set_request ->
+    ( update_ip_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDuplicateItemException of waf_duplicate_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -1829,6 +2502,18 @@ module UpdateManagedRuleSetVersionExpiryDate : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_managed_rule_set_version_expiry_date_request ->
+    ( update_managed_rule_set_version_expiry_date_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates the expiration information for your managed rule set. Use this to initiate the \
@@ -1860,6 +2545,20 @@ module UpdateRegexPatternSet : sig
     'http_type Smaws_Lib.Context.t ->
     update_regex_pattern_set_request ->
     ( update_regex_pattern_set_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_regex_pattern_set_request ->
+    ( update_regex_pattern_set_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFDuplicateItemException of waf_duplicate_item_exception
       | `WAFInternalErrorException of waf_internal_error_exception
@@ -1936,6 +2635,23 @@ module UpdateRuleGroup : sig
     'http_type Smaws_Lib.Context.t ->
     update_rule_group_request ->
     ( update_rule_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFConfigurationWarningException of waf_configuration_warning_exception
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_rule_group_request ->
+    ( update_rule_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFConfigurationWarningException of waf_configuration_warning_exception
       | `WAFDuplicateItemException of waf_duplicate_item_exception
@@ -2025,6 +2741,28 @@ module UpdateWebACL : sig
     'http_type Smaws_Lib.Context.t ->
     update_web_acl_request ->
     ( update_web_acl_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `WAFConfigurationWarningException of waf_configuration_warning_exception
+      | `WAFDuplicateItemException of waf_duplicate_item_exception
+      | `WAFExpiredManagedRuleGroupVersionException of
+        waf_expired_managed_rule_group_version_exception
+      | `WAFFeatureNotIncludedInPricingPlanException of
+        waf_feature_not_included_in_pricing_plan_exception
+      | `WAFInternalErrorException of waf_internal_error_exception
+      | `WAFInvalidOperationException of waf_invalid_operation_exception
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception
+      | `WAFInvalidResourceException of waf_invalid_resource_exception
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception
+      | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_web_acl_request ->
+    ( update_web_acl_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFConfigurationWarningException of waf_configuration_warning_exception
       | `WAFDuplicateItemException of waf_duplicate_item_exception

--- a/sdks/wafv2/operations.mli
+++ b/sdks/wafv2/operations.mli
@@ -40,7 +40,8 @@ module AssociateWebACL : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -133,7 +134,8 @@ module CheckCapacity : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -178,7 +180,8 @@ module CreateAPIKey : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFLimitsExceededException of waf_limits_exceeded_exception ] )
+      | `WAFLimitsExceededException of waf_limits_exceeded_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -233,7 +236,8 @@ module CreateIPSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -282,7 +286,8 @@ module CreateRegexPatternSet : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -338,7 +343,8 @@ module CreateRuleGroup : sig
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -410,7 +416,8 @@ module CreateWebACL : sig
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
       | `WAFTagOperationException of waf_tag_operation_exception
       | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -457,7 +464,8 @@ module DeleteAPIKey : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -497,7 +505,8 @@ module DeleteFirewallManagerRuleGroups : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -546,7 +555,8 @@ module DeleteIPSet : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified [IPSet]. \n"]
@@ -582,7 +592,8 @@ module DeleteLoggingConfiguration : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the [LoggingConfiguration] from the specified web ACL.\n"]
@@ -612,7 +623,8 @@ module DeletePermissionPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -660,7 +672,8 @@ module DeleteRegexPatternSet : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified [RegexPatternSet].\n"]
@@ -705,7 +718,8 @@ module DeleteRuleGroup : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified [RuleGroup].\n"]
@@ -750,7 +764,8 @@ module DeleteWebACL : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -819,7 +834,8 @@ module DescribeAllManagedProducts : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -851,7 +867,8 @@ module DescribeManagedProductsByVendor : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -894,7 +911,8 @@ module DescribeManagedRuleGroup : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFInvalidResourceException of waf_invalid_resource_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -928,7 +946,8 @@ module DisassociateWebACL : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -975,7 +994,8 @@ module GenerateMobileSdkReleaseUrl : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1018,7 +1038,8 @@ module GetDecryptedAPIKey : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFInvalidResourceException of waf_invalid_resource_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1059,7 +1080,8 @@ module GetIPSet : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the specified [IPSet].\n"]
@@ -1092,7 +1114,8 @@ module GetLoggingConfiguration : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the [LoggingConfiguration] for the specified web ACL.\n"]
@@ -1125,7 +1148,8 @@ module GetManagedRuleSet : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1167,7 +1191,8 @@ module GetMobileSdkRelease : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1204,7 +1229,8 @@ module GetPermissionPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1245,7 +1271,7 @@ module GetRateBasedStatementManagedKeys : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFUnsupportedAggregateKeyTypeException of waf_unsupported_aggregate_key_type_exception ]
-    )
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1296,7 +1322,8 @@ module GetRegexPatternSet : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the specified [RegexPatternSet].\n"]
@@ -1329,7 +1356,8 @@ module GetRevenueStatistics : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1367,7 +1395,8 @@ module GetRevenueStatisticsSummary : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1405,7 +1434,8 @@ module GetRevenueStatisticsTimeSeries : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1443,7 +1473,8 @@ module GetRuleGroup : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the specified [RuleGroup].\n"]
@@ -1473,7 +1504,8 @@ module GetSampledRequests : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1522,7 +1554,8 @@ module GetTopPathStatisticsByTraffic : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1560,7 +1593,8 @@ module GetWebACL : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves the specified [WebACL].\n"]
@@ -1596,7 +1630,8 @@ module GetWebACLForResource : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1647,7 +1682,8 @@ module ListAPIKeys : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFInvalidResourceException of waf_invalid_resource_exception ] )
+      | `WAFInvalidResourceException of waf_invalid_resource_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1687,7 +1723,8 @@ module ListAvailableManagedRuleGroupVersions : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns a list of the available versions for the specified managed rule group. \n"]
@@ -1717,7 +1754,8 @@ module ListAvailableManagedRuleGroups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1750,7 +1788,8 @@ module ListIPSets : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves an array of [IPSetSummary] objects for the IP sets that you manage.\n"]
@@ -1780,7 +1819,8 @@ module ListLoggingConfigurations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves an array of your [LoggingConfiguration] objects.\n"]
@@ -1810,7 +1850,8 @@ module ListManagedRuleSets : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1849,7 +1890,8 @@ module ListMobileSdkReleases : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1887,7 +1929,8 @@ module ListRegexPatternSets : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1922,7 +1965,8 @@ module ListResourcesForWebACL : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1966,7 +2010,8 @@ module ListRuleGroups : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2000,7 +2045,8 @@ module ListSettlementRecords : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2044,7 +2090,8 @@ module ListTagsForResource : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2082,7 +2129,8 @@ module ListWebACLs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidOperationException of waf_invalid_operation_exception
-      | `WAFInvalidParameterException of waf_invalid_parameter_exception ] )
+      | `WAFInvalidParameterException of waf_invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Retrieves an array of [WebACLSummary] objects for the web ACLs that you manage.\n"]
@@ -2133,7 +2181,8 @@ module PutLoggingConfiguration : sig
       | `WAFLogDestinationPermissionIssueException of waf_log_destination_permission_issue_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
-      | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception ] )
+      | `WAFServiceLinkedRoleErrorException of waf_service_linked_role_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2222,7 +2271,8 @@ module PutManagedRuleSetVersions : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2274,7 +2324,8 @@ module PutPermissionPolicy : sig
       | `WAFInternalErrorException of waf_internal_error_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFInvalidPermissionPolicyException of waf_invalid_permission_policy_exception
-      | `WAFNonexistentItemException of waf_nonexistent_item_exception ] )
+      | `WAFNonexistentItemException of waf_nonexistent_item_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2338,7 +2389,8 @@ module TagResource : sig
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2385,7 +2437,8 @@ module UntagResource : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFTagOperationException of waf_tag_operation_exception
-      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ] )
+      | `WAFTagOperationInternalErrorException of waf_tag_operation_internal_error_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2431,7 +2484,8 @@ module UpdateIPSet : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2512,7 +2566,8 @@ module UpdateManagedRuleSetVersionExpiryDate : sig
       | `WAFInvalidOperationException of waf_invalid_operation_exception
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2566,7 +2621,8 @@ module UpdateRegexPatternSet : sig
       | `WAFInvalidParameterException of waf_invalid_parameter_exception
       | `WAFLimitsExceededException of waf_limits_exceeded_exception
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
-      | `WAFOptimisticLockException of waf_optimistic_lock_exception ] )
+      | `WAFOptimisticLockException of waf_optimistic_lock_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2662,7 +2718,8 @@ module UpdateRuleGroup : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2778,7 +2835,8 @@ module UpdateWebACL : sig
       | `WAFNonexistentItemException of waf_nonexistent_item_exception
       | `WAFOptimisticLockException of waf_optimistic_lock_exception
       | `WAFSubscriptionNotFoundException of waf_subscription_not_found_exception
-      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ] )
+      | `WAFUnavailableEntityException of waf_unavailable_entity_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/workmail/Smaws_Client_WorkMail.mli
+++ b/sdks/workmail/Smaws_Client_WorkMail.mli
@@ -1304,6 +1304,19 @@ module AssociateDelegateToResource : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_delegate_to_resource_request ->
+    ( associate_delegate_to_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Adds a member (user or group) to the resource's set of delegates.\n"]
 
@@ -1325,6 +1338,22 @@ module AssociateMemberToGroup : sig
     'http_type Smaws_Lib.Context.t ->
     associate_member_to_group_request ->
     ( associate_member_to_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_member_to_group_request ->
+    ( associate_member_to_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception
@@ -1358,6 +1387,17 @@ module AssumeImpersonationRole : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_impersonation_role_request ->
+    ( assume_impersonation_role_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Assumes an impersonation role for the given WorkMail organization. This method returns an \
@@ -1376,6 +1416,17 @@ module CancelMailboxExportJob : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_mailbox_export_job_request ->
     ( cancel_mailbox_export_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_mailbox_export_job_request ->
+    ( cancel_mailbox_export_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1418,6 +1469,22 @@ module CreateAlias : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_alias_request ->
+    ( create_alias_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EmailAddressInUseException of email_address_in_use_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Adds an alias to the set of a given member (user or group) of WorkMail.\n"]
 
@@ -1435,6 +1502,18 @@ module CreateAvailabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     create_availability_configuration_request ->
     ( create_availability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_availability_configuration_request ->
+    ( create_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -1475,6 +1554,22 @@ module CreateGroup : sig
       | `ReservedNameException of reserved_name_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_group_request ->
+    ( create_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ReservedNameException of reserved_name_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a group that can be used in WorkMail by calling the [RegisterToWorkMail] operation.\n"]
@@ -1488,6 +1583,14 @@ module CreateIdentityCenterApplication : sig
     'http_type Smaws_Lib.Context.t ->
     create_identity_center_application_request ->
     ( create_identity_center_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_identity_center_application_request ->
+    ( create_identity_center_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception ] )
     result
@@ -1512,6 +1615,19 @@ module CreateImpersonationRole : sig
     'http_type Smaws_Lib.Context.t ->
     create_impersonation_role_request ->
     ( create_impersonation_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_impersonation_role_request ->
+    ( create_impersonation_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -1547,6 +1663,17 @@ module CreateMobileDeviceAccessRule : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_mobile_device_access_rule_request ->
+    ( create_mobile_device_access_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Creates a new mobile device access rule for the specified WorkMail organization.\n"]
 
@@ -1564,6 +1691,18 @@ module CreateOrganization : sig
     'http_type Smaws_Lib.Context.t ->
     create_organization_request ->
     ( create_organization_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryInUseException of directory_in_use_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NameAvailabilityException of name_availability_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_organization_request ->
+    ( create_organization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryInUseException of directory_in_use_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -1621,6 +1760,22 @@ module CreateResource : sig
       | `ReservedNameException of reserved_name_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_resource_request ->
+    ( create_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ReservedNameException of reserved_name_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Creates a new WorkMail resource.\n"]
 
@@ -1655,6 +1810,23 @@ module CreateUser : sig
       | `ReservedNameException of reserved_name_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_user_request ->
+    ( create_user_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidPasswordException of invalid_password_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ReservedNameException of reserved_name_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a user who can be used in WorkMail by calling the [RegisterToWorkMail] operation.\n"]
@@ -1670,6 +1842,15 @@ module DeleteAccessControlRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_access_control_rule_request ->
     ( delete_access_control_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_access_control_rule_request ->
+    ( delete_access_control_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -1703,6 +1884,18 @@ module DeleteAlias : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_alias_request ->
+    ( delete_alias_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Remove one or more specified aliases from a set of aliases for a given user.\n"]
 
@@ -1717,6 +1910,15 @@ module DeleteAvailabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_availability_configuration_request ->
     ( delete_availability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_availability_configuration_request ->
+    ( delete_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -1737,6 +1939,16 @@ module DeleteEmailMonitoringConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_email_monitoring_configuration_request ->
     ( delete_email_monitoring_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_email_monitoring_configuration_request ->
+    ( delete_email_monitoring_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -1772,6 +1984,21 @@ module DeleteGroup : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_group_request ->
+    ( delete_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a group from WorkMail.\n"]
 
@@ -1786,6 +2013,15 @@ module DeleteIdentityCenterApplication : sig
     'http_type Smaws_Lib.Context.t ->
     delete_identity_center_application_request ->
     ( delete_identity_center_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_identity_center_application_request ->
+    ( delete_identity_center_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -1812,6 +2048,16 @@ module DeleteIdentityProviderConfiguration : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_identity_provider_configuration_request ->
+    ( delete_identity_provider_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   " Disables the integration between IdC and WorkMail. Authentication will continue with the \
@@ -1830,6 +2076,16 @@ module DeleteImpersonationRole : sig
     'http_type Smaws_Lib.Context.t ->
     delete_impersonation_role_request ->
     ( delete_impersonation_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_impersonation_role_request ->
+    ( delete_impersonation_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -1859,6 +2115,18 @@ module DeleteMailboxPermissions : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_mailbox_permissions_request ->
+    ( delete_mailbox_permissions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes permissions granted to a member (user or group).\n"]
 
@@ -1875,6 +2143,17 @@ module DeleteMobileDeviceAccessOverride : sig
     'http_type Smaws_Lib.Context.t ->
     delete_mobile_device_access_override_request ->
     ( delete_mobile_device_access_override_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_mobile_device_access_override_request ->
+    ( delete_mobile_device_access_override_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1907,6 +2186,16 @@ module DeleteMobileDeviceAccessRule : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_mobile_device_access_rule_request ->
+    ( delete_mobile_device_access_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a mobile device access rule for the specified WorkMail organization.\n\n\
@@ -1927,6 +2216,16 @@ module DeleteOrganization : sig
     'http_type Smaws_Lib.Context.t ->
     delete_organization_request ->
     ( delete_organization_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_organization_request ->
+    ( delete_organization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -1957,6 +2256,16 @@ module DeletePersonalAccessToken : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_personal_access_token_request ->
+    ( delete_personal_access_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc " Deletes the Personal Access Token from the provided WorkMail Organization. \n"]
 
@@ -1974,6 +2283,18 @@ module DeleteResource : sig
     'http_type Smaws_Lib.Context.t ->
     delete_resource_request ->
     ( delete_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_request ->
+    ( delete_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2001,6 +2322,16 @@ module DeleteRetentionPolicy : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_retention_policy_request ->
+    ( delete_retention_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified retention policy from the specified organization.\n"]
 
@@ -2021,6 +2352,21 @@ module DeleteUser : sig
     'http_type Smaws_Lib.Context.t ->
     delete_user_request ->
     ( delete_user_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_user_request ->
+    ( delete_user_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception
@@ -2060,6 +2406,18 @@ module DeregisterFromWorkMail : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_from_work_mail_request ->
+    ( deregister_from_work_mail_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Mark a user, group, or resource as no longer used in WorkMail. This action disassociates the \
@@ -2080,6 +2438,18 @@ module DeregisterMailDomain : sig
     'http_type Smaws_Lib.Context.t ->
     deregister_mail_domain_request ->
     ( deregister_mail_domain_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidCustomSesConfigurationException of invalid_custom_ses_configuration_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainInUseException of mail_domain_in_use_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_mail_domain_request ->
+    ( deregister_mail_domain_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidCustomSesConfigurationException of invalid_custom_ses_configuration_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2112,6 +2482,17 @@ module DescribeEmailMonitoringConfiguration : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_email_monitoring_configuration_request ->
+    ( describe_email_monitoring_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Describes the current email monitoring configuration for a specified organization.\n"]
 
@@ -2128,6 +2509,17 @@ module DescribeEntity : sig
     'http_type Smaws_Lib.Context.t ->
     describe_entity_request ->
     ( describe_entity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_entity_request ->
+    ( describe_entity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2156,6 +2548,17 @@ module DescribeGroup : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_group_request ->
+    ( describe_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the data available for the group.\n"]
 
@@ -2178,6 +2581,17 @@ module DescribeIdentityProviderConfiguration : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_identity_provider_configuration_request ->
+    ( describe_identity_provider_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   " Returns detailed information on the current IdC setup for the WorkMail organization. \n"]
@@ -2193,6 +2607,15 @@ module DescribeInboundDmarcSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_inbound_dmarc_settings_request ->
     ( describe_inbound_dmarc_settings_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_inbound_dmarc_settings_request ->
+    ( describe_inbound_dmarc_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -2219,6 +2642,17 @@ module DescribeMailboxExportJob : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_mailbox_export_job_request ->
+    ( describe_mailbox_export_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Describes the current status of a mailbox export job.\n"]
 
@@ -2233,6 +2667,15 @@ module DescribeOrganization : sig
     'http_type Smaws_Lib.Context.t ->
     describe_organization_request ->
     ( describe_organization_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_request ->
+    ( describe_organization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception ] )
@@ -2254,6 +2697,18 @@ module DescribeResource : sig
     'http_type Smaws_Lib.Context.t ->
     describe_resource_request ->
     ( describe_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_resource_request ->
+    ( describe_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2289,6 +2744,20 @@ module DescribeUser : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_user_request ->
+    ( describe_user_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Provides information regarding the user.\n"]
 
@@ -2307,6 +2776,19 @@ module DisassociateDelegateFromResource : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_delegate_from_resource_request ->
     ( disassociate_delegate_from_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_delegate_from_resource_request ->
+    ( disassociate_delegate_from_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -2347,6 +2829,22 @@ module DisassociateMemberFromGroup : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_member_from_group_request ->
+    ( disassociate_member_from_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Removes a member from a group.\n"]
 
@@ -2364,6 +2862,18 @@ module GetAccessControlEffect : sig
     'http_type Smaws_Lib.Context.t ->
     get_access_control_effect_request ->
     ( get_access_control_effect_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_access_control_effect_request ->
+    ( get_access_control_effect_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2396,6 +2906,17 @@ module GetDefaultRetentionPolicy : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_default_retention_policy_request ->
+    ( get_default_retention_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Gets the default retention policy details for the specified organization.\n"]
 
@@ -2412,6 +2933,17 @@ module GetImpersonationRole : sig
     'http_type Smaws_Lib.Context.t ->
     get_impersonation_role_request ->
     ( get_impersonation_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_impersonation_role_request ->
+    ( get_impersonation_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -2444,6 +2976,19 @@ module GetImpersonationRoleEffect : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_impersonation_role_effect_request ->
+    ( get_impersonation_role_effect_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Tests whether the given impersonation role can impersonate a target user.\n"]
 
@@ -2460,6 +3005,17 @@ module GetMailboxDetails : sig
     'http_type Smaws_Lib.Context.t ->
     get_mailbox_details_request ->
     ( get_mailbox_details_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mailbox_details_request ->
+    ( get_mailbox_details_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2488,6 +3044,17 @@ module GetMailDomain : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mail_domain_request ->
+    ( get_mail_domain_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets details for a mail domain, including domain records required to configure your domain with \
@@ -2505,6 +3072,16 @@ module GetMobileDeviceAccessEffect : sig
     'http_type Smaws_Lib.Context.t ->
     get_mobile_device_access_effect_request ->
     ( get_mobile_device_access_effect_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mobile_device_access_effect_request ->
+    ( get_mobile_device_access_effect_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -2537,6 +3114,18 @@ module GetMobileDeviceAccessOverride : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mobile_device_access_override_request ->
+    ( get_mobile_device_access_override_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets the mobile device access override for the given WorkMail organization, user, and device.\n"]
@@ -2560,6 +3149,17 @@ module GetPersonalAccessTokenMetadata : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_personal_access_token_metadata_request ->
+    ( get_personal_access_token_metadata_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   " Requests details of a specific Personal Access Token within the WorkMail organization. \n"]
@@ -2575,6 +3175,15 @@ module ListAccessControlRules : sig
     'http_type Smaws_Lib.Context.t ->
     list_access_control_rules_request ->
     ( list_access_control_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_access_control_rules_request ->
+    ( list_access_control_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -2603,6 +3212,18 @@ module ListAliases : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_aliases_request ->
+    ( list_aliases_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Creates a paginated call to list the aliases associated with a given entity.\n"]
 
@@ -2618,6 +3239,16 @@ module ListAvailabilityConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     list_availability_configurations_request ->
     ( list_availability_configurations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_availability_configurations_request ->
+    ( list_availability_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -2640,6 +3271,18 @@ module ListGroupMembers : sig
     'http_type Smaws_Lib.Context.t ->
     list_group_members_request ->
     ( list_group_members_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_group_members_request ->
+    ( list_group_members_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -2670,6 +3313,17 @@ module ListGroups : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_groups_request ->
+    ( list_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Returns summaries of the organization's groups.\n"]
 
@@ -2687,6 +3341,18 @@ module ListGroupsForEntity : sig
     'http_type Smaws_Lib.Context.t ->
     list_groups_for_entity_request ->
     ( list_groups_for_entity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_groups_for_entity_request ->
+    ( list_groups_for_entity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -2714,6 +3380,16 @@ module ListImpersonationRoles : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_impersonation_roles_request ->
+    ( list_impersonation_roles_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Lists all the impersonation roles for the given WorkMail organization.\n"]
 
@@ -2729,6 +3405,16 @@ module ListMailboxExportJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_mailbox_export_jobs_request ->
     ( list_mailbox_export_jobs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mailbox_export_jobs_request ->
+    ( list_mailbox_export_jobs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -2757,6 +3443,17 @@ module ListMailboxPermissions : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mailbox_permissions_request ->
+    ( list_mailbox_permissions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the mailbox permissions associated with a user, group, or resource mailbox.\n"]
 
@@ -2772,6 +3469,16 @@ module ListMailDomains : sig
     'http_type Smaws_Lib.Context.t ->
     list_mail_domains_request ->
     ( list_mail_domains_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mail_domains_request ->
+    ( list_mail_domains_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -2793,6 +3500,17 @@ module ListMobileDeviceAccessOverrides : sig
     'http_type Smaws_Lib.Context.t ->
     list_mobile_device_access_overrides_request ->
     ( list_mobile_device_access_overrides_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mobile_device_access_overrides_request ->
+    ( list_mobile_device_access_overrides_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2821,6 +3539,16 @@ module ListMobileDeviceAccessRules : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mobile_device_access_rules_request ->
+    ( list_mobile_device_access_rules_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the mobile device access rules for the specified WorkMail organization.\n"]
 
@@ -2833,6 +3561,14 @@ module ListOrganizations : sig
     'http_type Smaws_Lib.Context.t ->
     list_organizations_request ->
     ( list_organizations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_organizations_request ->
+    ( list_organizations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception ] )
     result
@@ -2853,6 +3589,18 @@ module ListPersonalAccessTokens : sig
     'http_type Smaws_Lib.Context.t ->
     list_personal_access_tokens_request ->
     ( list_personal_access_tokens_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_personal_access_tokens_request ->
+    ( list_personal_access_tokens_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -2886,6 +3634,19 @@ module ListResourceDelegates : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_delegates_request ->
+    ( list_resource_delegates_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the delegates associated with a resource. Users and groups can be resource delegates and \
@@ -2910,6 +3671,17 @@ module ListResources : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resources_request ->
+    ( list_resources_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns summaries of the organization's resources.\n"]
 
@@ -2923,6 +3695,14 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -2946,6 +3726,16 @@ module ListUsers : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_users_request ->
+    ( list_users_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Returns summaries of the organization's users.\n"]
 
@@ -2964,6 +3754,19 @@ module PutAccessControlRule : sig
     'http_type Smaws_Lib.Context.t ->
     put_access_control_rule_request ->
     ( put_access_control_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_access_control_rule_request ->
+    ( put_access_control_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2998,6 +3801,17 @@ module PutEmailMonitoringConfiguration : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_email_monitoring_configuration_request ->
+    ( put_email_monitoring_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates or updates the email monitoring configuration for a specified organization.\n"]
@@ -3015,6 +3829,17 @@ module PutIdentityProviderConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     put_identity_provider_configuration_request ->
     ( put_identity_provider_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_identity_provider_configuration_request ->
+    ( put_identity_provider_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -3043,6 +3868,15 @@ module PutInboundDmarcSettings : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_inbound_dmarc_settings_request ->
+    ( put_inbound_dmarc_settings_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Enables or disables a DMARC policy for a given organization.\n"]
 
@@ -3060,6 +3894,18 @@ module PutMailboxPermissions : sig
     'http_type Smaws_Lib.Context.t ->
     put_mailbox_permissions_request ->
     ( put_mailbox_permissions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_mailbox_permissions_request ->
+    ( put_mailbox_permissions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -3092,6 +3938,18 @@ module PutMobileDeviceAccessOverride : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_mobile_device_access_override_request ->
+    ( put_mobile_device_access_override_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates or updates a mobile device access override for the given WorkMail organization, user, \
@@ -3116,6 +3974,17 @@ module PutRetentionPolicy : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_retention_policy_request ->
+    ( put_retention_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Puts a retention policy to the specified organization.\n"]
 
@@ -3133,6 +4002,18 @@ module RegisterMailDomain : sig
     'http_type Smaws_Lib.Context.t ->
     register_mail_domain_request ->
     ( register_mail_domain_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MailDomainInUseException of mail_domain_in_use_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_mail_domain_request ->
+    ( register_mail_domain_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -3168,6 +4049,26 @@ module RegisterToWorkMail : sig
     'http_type Smaws_Lib.Context.t ->
     register_to_work_mail_request ->
     ( register_to_work_mail_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EmailAddressInUseException of email_address_in_use_exception
+      | `EntityAlreadyRegisteredException of entity_already_registered_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_to_work_mail_request ->
+    ( register_to_work_mail_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception
@@ -3226,6 +4127,23 @@ module ResetPassword : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reset_password_request ->
+    ( reset_password_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidPasswordException of invalid_password_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Allows the administrator to reset the password for a user.\n"]
 
@@ -3243,6 +4161,18 @@ module StartMailboxExportJob : sig
     'http_type Smaws_Lib.Context.t ->
     start_mailbox_export_job_request ->
     ( start_mailbox_export_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_mailbox_export_job_request ->
+    ( start_mailbox_export_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -3277,6 +4207,17 @@ module TagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc "Applies the specified tags to the specified WorkMailorganization resource.\n"]
 
@@ -3293,6 +4234,17 @@ module TestAvailabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     test_availability_configuration_request ->
     ( test_availability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_availability_configuration_request ->
+    ( test_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -3325,6 +4277,14 @@ module UntagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Untags the specified tags from the specified WorkMail organization resource.\n"]
 
@@ -3341,6 +4301,17 @@ module UpdateAvailabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     update_availability_configuration_request ->
     ( update_availability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_availability_configuration_request ->
+    ( update_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -3365,6 +4336,18 @@ module UpdateDefaultMailDomain : sig
     'http_type Smaws_Lib.Context.t ->
     update_default_mail_domain_request ->
     ( update_default_mail_domain_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_default_mail_domain_request ->
+    ( update_default_mail_domain_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `MailDomainNotFoundException of mail_domain_not_found_exception
@@ -3401,6 +4384,19 @@ module UpdateGroup : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_group_request ->
+    ( update_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates attributes in a group.\n"]
 
@@ -3420,6 +4416,20 @@ module UpdateImpersonationRole : sig
     'http_type Smaws_Lib.Context.t ->
     update_impersonation_role_request ->
     ( update_impersonation_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_impersonation_role_request ->
+    ( update_impersonation_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -3453,6 +4463,18 @@ module UpdateMailboxQuota : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_mailbox_quota_request ->
+    ( update_mailbox_quota_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Updates a user's current mailbox quota for a specified organization and user.\n"]
 
@@ -3469,6 +4491,17 @@ module UpdateMobileDeviceAccessRule : sig
     'http_type Smaws_Lib.Context.t ->
     update_mobile_device_access_rule_request ->
     ( update_mobile_device_access_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_mobile_device_access_rule_request ->
+    ( update_mobile_device_access_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -3499,6 +4532,25 @@ module UpdatePrimaryEmailAddress : sig
     'http_type Smaws_Lib.Context.t ->
     update_primary_email_address_request ->
     ( update_primary_email_address_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EmailAddressInUseException of email_address_in_use_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_primary_email_address_request ->
+    ( update_primary_email_address_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception
@@ -3554,6 +4606,25 @@ module UpdateResource : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_resource_request ->
+    ( update_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EmailAddressInUseException of email_address_in_use_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidConfigurationException of invalid_configuration_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates data for the resource. To have the latest information, it must be preceded by a \
@@ -3579,6 +4650,22 @@ module UpdateUser : sig
     'http_type Smaws_Lib.Context.t ->
     update_user_request ->
     ( update_user_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_user_request ->
+    ( update_user_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception

--- a/sdks/workmail/Smaws_Client_WorkMail.mli
+++ b/sdks/workmail/Smaws_Client_WorkMail.mli
@@ -1315,7 +1315,8 @@ module AssociateDelegateToResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds a member (user or group) to the resource's set of delegates.\n"]
@@ -1363,7 +1364,8 @@ module AssociateMemberToGroup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds a member (user or group) to the group's set.\n"]
@@ -1396,7 +1398,8 @@ module AssumeImpersonationRole : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1431,7 +1434,8 @@ module CancelMailboxExportJob : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1483,7 +1487,8 @@ module CreateAlias : sig
       | `MailDomainNotFoundException of mail_domain_not_found_exception
       | `MailDomainStateException of mail_domain_state_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds an alias to the set of a given member (user or group) of WorkMail.\n"]
@@ -1519,7 +1524,8 @@ module CreateAvailabilityConfiguration : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NameAvailabilityException of name_availability_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1568,7 +1574,8 @@ module CreateGroup : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
       | `ReservedNameException of reserved_name_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1592,7 +1599,8 @@ module CreateIdentityCenterApplication : sig
     create_identity_center_application_request ->
     ( create_identity_center_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterException of invalid_parameter_exception ] )
+      | `InvalidParameterException of invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1634,7 +1642,8 @@ module CreateImpersonationRole : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1672,7 +1681,8 @@ module CreateMobileDeviceAccessRule : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a new mobile device access rule for the specified WorkMail organization.\n"]
@@ -1708,7 +1718,8 @@ module CreateOrganization : sig
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NameAvailabilityException of name_availability_exception ] )
+      | `NameAvailabilityException of name_availability_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1774,7 +1785,8 @@ module CreateResource : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
       | `ReservedNameException of reserved_name_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a new WorkMail resource.\n"]
@@ -1825,7 +1837,8 @@ module CreateUser : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
       | `ReservedNameException of reserved_name_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1853,7 +1866,8 @@ module DeleteAccessControlRule : sig
     ( delete_access_control_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1894,7 +1908,8 @@ module DeleteAlias : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Remove one or more specified aliases from a set of aliases for a given user.\n"]
@@ -1921,7 +1936,8 @@ module DeleteAvailabilityConfiguration : sig
     ( delete_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1952,7 +1968,8 @@ module DeleteEmailMonitoringConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the email monitoring configuration for a specified organization.\n"]
@@ -1997,7 +2014,8 @@ module DeleteGroup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a group from WorkMail.\n"]
@@ -2024,7 +2042,8 @@ module DeleteIdentityCenterApplication : sig
     ( delete_identity_center_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2056,7 +2075,8 @@ module DeleteIdentityProviderConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2089,7 +2109,8 @@ module DeleteImpersonationRole : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an impersonation role for the given WorkMail organization.\n"]
@@ -2125,7 +2146,8 @@ module DeleteMailboxPermissions : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes permissions granted to a member (user or group).\n"]
@@ -2158,7 +2180,8 @@ module DeleteMobileDeviceAccessOverride : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2194,7 +2217,8 @@ module DeleteMobileDeviceAccessRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2229,7 +2253,8 @@ module DeleteOrganization : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2264,7 +2289,8 @@ module DeletePersonalAccessToken : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Deletes the Personal Access Token from the provided WorkMail Organization. \n"]
@@ -2300,7 +2326,8 @@ module DeleteResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified resource.\n"]
@@ -2330,7 +2357,8 @@ module DeleteRetentionPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified retention policy from the specified organization.\n"]
@@ -2375,7 +2403,8 @@ module DeleteUser : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2416,7 +2445,8 @@ module DeregisterFromWorkMail : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2455,7 +2485,8 @@ module DeregisterMailDomain : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `MailDomainInUseException of mail_domain_in_use_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2491,7 +2522,8 @@ module DescribeEmailMonitoringConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes the current email monitoring configuration for a specified organization.\n"]
@@ -2524,7 +2556,8 @@ module DescribeEntity : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns basic details about an entity in WorkMail. \n"]
@@ -2557,7 +2590,8 @@ module DescribeGroup : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the data available for the group.\n"]
@@ -2590,7 +2624,8 @@ module DescribeIdentityProviderConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2618,7 +2653,8 @@ module DescribeInboundDmarcSettings : sig
     ( describe_inbound_dmarc_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the settings in a DMARC policy for a specified organization.\n"]
@@ -2651,7 +2687,8 @@ module DescribeMailboxExportJob : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes the current status of a mailbox export job.\n"]
@@ -2678,7 +2715,8 @@ module DescribeOrganization : sig
     ( describe_organization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
-      | `OrganizationNotFoundException of organization_not_found_exception ] )
+      | `OrganizationNotFoundException of organization_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides more information regarding a given organization based on its identifier.\n"]
@@ -2714,7 +2752,8 @@ module DescribeResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the data available for the resource.\n"]
@@ -2756,7 +2795,8 @@ module DescribeUser : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides information regarding the user.\n"]
@@ -2795,7 +2835,8 @@ module DisassociateDelegateFromResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a member from the resource's set of delegates.\n"]
@@ -2843,7 +2884,8 @@ module DisassociateMemberFromGroup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a member from a group.\n"]
@@ -2879,7 +2921,8 @@ module GetAccessControlEffect : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2915,7 +2958,8 @@ module GetDefaultRetentionPolicy : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the default retention policy details for the specified organization.\n"]
@@ -2948,7 +2992,8 @@ module GetImpersonationRole : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the impersonation role details for the given WorkMail organization.\n"]
@@ -2987,7 +3032,8 @@ module GetImpersonationRoleEffect : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Tests whether the given impersonation role can impersonate a target user.\n"]
@@ -3020,7 +3066,8 @@ module GetMailboxDetails : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Requests a user's mailbox details for a specified organization and user.\n"]
@@ -3053,7 +3100,8 @@ module GetMailDomain : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `MailDomainNotFoundException of mail_domain_not_found_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3085,7 +3133,8 @@ module GetMobileDeviceAccessEffect : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3124,7 +3173,8 @@ module GetMobileDeviceAccessOverride : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3158,7 +3208,8 @@ module GetPersonalAccessTokenMetadata : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3186,7 +3237,8 @@ module ListAccessControlRules : sig
     ( list_access_control_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the access control rules for the specified organization.\n"]
@@ -3222,7 +3274,8 @@ module ListAliases : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a paginated call to list the aliases associated with a given entity.\n"]
@@ -3252,7 +3305,8 @@ module ListAvailabilityConfigurations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List all the [AvailabilityConfiguration]'s for the given WorkMail organization.\n"]
@@ -3288,7 +3342,8 @@ module ListGroupMembers : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3322,7 +3377,8 @@ module ListGroups : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns summaries of the organization's groups.\n"]
@@ -3358,7 +3414,8 @@ module ListGroupsForEntity : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns all the groups to which an entity belongs.\n"]
@@ -3388,7 +3445,8 @@ module ListImpersonationRoles : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all the impersonation roles for the given WorkMail organization.\n"]
@@ -3418,7 +3476,8 @@ module ListMailboxExportJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3452,7 +3511,8 @@ module ListMailboxPermissions : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the mailbox permissions associated with a user, group, or resource mailbox.\n"]
@@ -3482,7 +3542,8 @@ module ListMailDomains : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the mail domains in a given WorkMail organization.\n"]
@@ -3515,7 +3576,8 @@ module ListMobileDeviceAccessOverrides : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3547,7 +3609,8 @@ module ListMobileDeviceAccessRules : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the mobile device access rules for the specified WorkMail organization.\n"]
@@ -3570,7 +3633,8 @@ module ListOrganizations : sig
     list_organizations_request ->
     ( list_organizations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterException of invalid_parameter_exception ] )
+      | `InvalidParameterException of invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns summaries of the customer's organizations.\n"]
@@ -3606,7 +3670,8 @@ module ListPersonalAccessTokens : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns a summary of your Personal Access Tokens. \n"]
@@ -3645,7 +3710,8 @@ module ListResourceDelegates : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3680,7 +3746,8 @@ module ListResources : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns summaries of the organization's resources.\n"]
@@ -3704,7 +3771,8 @@ module ListTagsForResource : sig
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the tags applied to an WorkMail organization resource.\n"]
@@ -3734,7 +3802,8 @@ module ListUsers : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns summaries of the organization's users.\n"]
@@ -3773,7 +3842,8 @@ module PutAccessControlRule : sig
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3810,7 +3880,8 @@ module PutEmailMonitoringConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3844,7 +3915,8 @@ module PutIdentityProviderConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3875,7 +3947,8 @@ module PutInboundDmarcSettings : sig
     ( put_inbound_dmarc_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Enables or disables a DMARC policy for a given organization.\n"]
@@ -3911,7 +3984,8 @@ module PutMailboxPermissions : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3948,7 +4022,8 @@ module PutMobileDeviceAccessOverride : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3983,7 +4058,8 @@ module PutRetentionPolicy : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Puts a retention policy to the specified organization.\n"]
@@ -4019,7 +4095,8 @@ module RegisterMailDomain : sig
       | `LimitExceededException of limit_exceeded_exception
       | `MailDomainInUseException of mail_domain_in_use_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4082,7 +4159,8 @@ module RegisterToWorkMail : sig
       | `MailDomainStateException of mail_domain_state_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4142,7 +4220,8 @@ module ResetPassword : sig
       | `InvalidPasswordException of invalid_password_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Allows the administrator to reset the password for a user.\n"]
@@ -4178,7 +4257,8 @@ module StartMailboxExportJob : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4216,7 +4296,8 @@ module TagResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Applies the specified tags to the specified WorkMailorganization resource.\n"]
@@ -4249,7 +4330,8 @@ module TestAvailabilityConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4283,7 +4365,8 @@ module UntagResource : sig
     untag_resource_request ->
     ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Untags the specified tags from the specified WorkMail organization resource.\n"]
@@ -4316,7 +4399,8 @@ module UpdateAvailabilityConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4353,7 +4437,8 @@ module UpdateDefaultMailDomain : sig
       | `MailDomainNotFoundException of mail_domain_not_found_exception
       | `MailDomainStateException of mail_domain_state_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4395,7 +4480,8 @@ module UpdateGroup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates attributes in a group.\n"]
@@ -4437,7 +4523,8 @@ module UpdateImpersonationRole : sig
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an impersonation role for the given WorkMail organization.\n"]
@@ -4473,7 +4560,8 @@ module UpdateMailboxQuota : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a user's current mailbox quota for a specified organization and user.\n"]
@@ -4506,7 +4594,8 @@ module UpdateMobileDeviceAccessRule : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a mobile device access rule for the specified WorkMail organization.\n"]
@@ -4563,7 +4652,8 @@ module UpdatePrimaryEmailAddress : sig
       | `MailDomainStateException of mail_domain_state_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4623,7 +4713,8 @@ module UpdateResource : sig
       | `NameAvailabilityException of name_availability_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -4675,7 +4766,8 @@ module UpdateUser : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks/workmail/operations.ml
+++ b/sdks/workmail/operations.ml
@@ -41,6 +41,13 @@ module AssociateDelegateToResource = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_delegate_to_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_delegate_to_resource_request) =
+    let input = Json_serializers.associate_delegate_to_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.AssociateDelegateToResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_delegate_to_resource_response_of_yojson
+      ~error_deserializer
 end
 
 module AssociateMemberToGroup = struct
@@ -93,6 +100,13 @@ module AssociateMemberToGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.associate_member_to_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : associate_member_to_group_request) =
+    let input = Json_serializers.associate_member_to_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.AssociateMemberToGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.associate_member_to_group_response_of_yojson
+      ~error_deserializer
 end
 
 module AssumeImpersonationRole = struct
@@ -128,6 +142,13 @@ module AssumeImpersonationRole = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.assume_impersonation_role_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : assume_impersonation_role_request) =
+    let input = Json_serializers.assume_impersonation_role_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.AssumeImpersonationRole" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.assume_impersonation_role_response_of_yojson
+      ~error_deserializer
 end
 
 module CancelMailboxExportJob = struct
@@ -161,6 +182,13 @@ module CancelMailboxExportJob = struct
     let input = Json_serializers.cancel_mailbox_export_job_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.CancelMailboxExportJob"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.cancel_mailbox_export_job_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : cancel_mailbox_export_job_request) =
+    let input = Json_serializers.cancel_mailbox_export_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.CancelMailboxExportJob" ~service ~context ~input
       ~output_deserializer:Json_deserializers.cancel_mailbox_export_job_response_of_yojson
       ~error_deserializer
 end
@@ -215,6 +243,12 @@ module CreateAlias = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.CreateAlias" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_alias_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_alias_request) =
+    let input = Json_serializers.create_alias_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.CreateAlias"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_alias_response_of_yojson ~error_deserializer
 end
 
 module CreateAvailabilityConfiguration = struct
@@ -250,6 +284,13 @@ module CreateAvailabilityConfiguration = struct
   let request context (request : create_availability_configuration_request) =
     let input = Json_serializers.create_availability_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"WorkMailService.CreateAvailabilityConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_availability_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_availability_configuration_request) =
+    let input = Json_serializers.create_availability_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"WorkMailService.CreateAvailabilityConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_availability_configuration_response_of_yojson
       ~error_deserializer
@@ -304,6 +345,12 @@ module CreateGroup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.CreateGroup" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_group_request) =
+    let input = Json_serializers.create_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.CreateGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_group_response_of_yojson ~error_deserializer
 end
 
 module CreateIdentityCenterApplication = struct
@@ -324,6 +371,13 @@ module CreateIdentityCenterApplication = struct
   let request context (request : create_identity_center_application_request) =
     let input = Json_serializers.create_identity_center_application_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"WorkMailService.CreateIdentityCenterApplication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_identity_center_application_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_identity_center_application_request) =
+    let input = Json_serializers.create_identity_center_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"WorkMailService.CreateIdentityCenterApplication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_identity_center_application_response_of_yojson
       ~error_deserializer
@@ -368,6 +422,13 @@ module CreateImpersonationRole = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_impersonation_role_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_impersonation_role_request) =
+    let input = Json_serializers.create_impersonation_role_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.CreateImpersonationRole" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_impersonation_role_response_of_yojson
+      ~error_deserializer
 end
 
 module CreateMobileDeviceAccessRule = struct
@@ -400,6 +461,13 @@ module CreateMobileDeviceAccessRule = struct
     let input = Json_serializers.create_mobile_device_access_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.CreateMobileDeviceAccessRule"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_mobile_device_access_rule_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_mobile_device_access_rule_request) =
+    let input = Json_serializers.create_mobile_device_access_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.CreateMobileDeviceAccessRule" ~service ~context ~input
       ~output_deserializer:Json_deserializers.create_mobile_device_access_rule_response_of_yojson
       ~error_deserializer
 end
@@ -438,6 +506,13 @@ module CreateOrganization = struct
     let input = Json_serializers.create_organization_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.CreateOrganization" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_organization_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : create_organization_request) =
+    let input = Json_serializers.create_organization_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.CreateOrganization" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_organization_response_of_yojson
       ~error_deserializer
 end
 
@@ -490,6 +565,12 @@ module CreateResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.CreateResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.create_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_resource_request) =
+    let input = Json_serializers.create_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.CreateResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_resource_response_of_yojson ~error_deserializer
 end
 
 module CreateUser = struct
@@ -545,6 +626,12 @@ module CreateUser = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.CreateUser" ~service ~context
       ~input ~output_deserializer:Json_deserializers.create_user_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : create_user_request) =
+    let input = Json_serializers.create_user_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.CreateUser"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.create_user_response_of_yojson ~error_deserializer
 end
 
 module DeleteAccessControlRule = struct
@@ -570,6 +657,13 @@ module DeleteAccessControlRule = struct
     let input = Json_serializers.delete_access_control_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeleteAccessControlRule"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_access_control_rule_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_access_control_rule_request) =
+    let input = Json_serializers.delete_access_control_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeleteAccessControlRule" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_access_control_rule_response_of_yojson
       ~error_deserializer
 end
@@ -609,6 +703,12 @@ module DeleteAlias = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeleteAlias" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_alias_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_alias_request) =
+    let input = Json_serializers.delete_alias_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.DeleteAlias"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_alias_response_of_yojson ~error_deserializer
 end
 
 module DeleteAvailabilityConfiguration = struct
@@ -633,6 +733,13 @@ module DeleteAvailabilityConfiguration = struct
   let request context (request : delete_availability_configuration_request) =
     let input = Json_serializers.delete_availability_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"WorkMailService.DeleteAvailabilityConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_availability_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_availability_configuration_request) =
+    let input = Json_serializers.delete_availability_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"WorkMailService.DeleteAvailabilityConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_availability_configuration_response_of_yojson
       ~error_deserializer
@@ -664,6 +771,14 @@ module DeleteEmailMonitoringConfiguration = struct
   let request context (request : delete_email_monitoring_configuration_request) =
     let input = Json_serializers.delete_email_monitoring_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"WorkMailService.DeleteEmailMonitoringConfiguration" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.delete_email_monitoring_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_email_monitoring_configuration_request) =
+    let input = Json_serializers.delete_email_monitoring_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"WorkMailService.DeleteEmailMonitoringConfiguration" ~service ~context ~input
       ~output_deserializer:
         Json_deserializers.delete_email_monitoring_configuration_response_of_yojson
@@ -715,6 +830,12 @@ module DeleteGroup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeleteGroup" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_group_request) =
+    let input = Json_serializers.delete_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.DeleteGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_group_response_of_yojson ~error_deserializer
 end
 
 module DeleteIdentityCenterApplication = struct
@@ -739,6 +860,13 @@ module DeleteIdentityCenterApplication = struct
   let request context (request : delete_identity_center_application_request) =
     let input = Json_serializers.delete_identity_center_application_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"WorkMailService.DeleteIdentityCenterApplication" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_identity_center_application_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_identity_center_application_request) =
+    let input = Json_serializers.delete_identity_center_application_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"WorkMailService.DeleteIdentityCenterApplication" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_identity_center_application_response_of_yojson
       ~error_deserializer
@@ -774,6 +902,14 @@ module DeleteIdentityProviderConfiguration = struct
       ~output_deserializer:
         Json_deserializers.delete_identity_provider_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_identity_provider_configuration_request) =
+    let input = Json_serializers.delete_identity_provider_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeleteIdentityProviderConfiguration" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.delete_identity_provider_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteImpersonationRole = struct
@@ -803,6 +939,13 @@ module DeleteImpersonationRole = struct
     let input = Json_serializers.delete_impersonation_role_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeleteImpersonationRole"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_impersonation_role_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_impersonation_role_request) =
+    let input = Json_serializers.delete_impersonation_role_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeleteImpersonationRole" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_impersonation_role_response_of_yojson
       ~error_deserializer
 end
@@ -843,6 +986,13 @@ module DeleteMailboxPermissions = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_mailbox_permissions_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_mailbox_permissions_request) =
+    let input = Json_serializers.delete_mailbox_permissions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeleteMailboxPermissions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_mailbox_permissions_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteMobileDeviceAccessOverride = struct
@@ -879,6 +1029,14 @@ module DeleteMobileDeviceAccessOverride = struct
       ~output_deserializer:
         Json_deserializers.delete_mobile_device_access_override_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_mobile_device_access_override_request) =
+    let input = Json_serializers.delete_mobile_device_access_override_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeleteMobileDeviceAccessOverride" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.delete_mobile_device_access_override_response_of_yojson
+      ~error_deserializer
 end
 
 module DeleteMobileDeviceAccessRule = struct
@@ -908,6 +1066,13 @@ module DeleteMobileDeviceAccessRule = struct
     let input = Json_serializers.delete_mobile_device_access_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeleteMobileDeviceAccessRule"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_mobile_device_access_rule_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_mobile_device_access_rule_request) =
+    let input = Json_serializers.delete_mobile_device_access_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeleteMobileDeviceAccessRule" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_mobile_device_access_rule_response_of_yojson
       ~error_deserializer
 end
@@ -940,6 +1105,13 @@ module DeleteOrganization = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeleteOrganization" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_organization_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_organization_request) =
+    let input = Json_serializers.delete_organization_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeleteOrganization" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_organization_response_of_yojson
+      ~error_deserializer
 end
 
 module DeletePersonalAccessToken = struct
@@ -969,6 +1141,13 @@ module DeletePersonalAccessToken = struct
     let input = Json_serializers.delete_personal_access_token_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeletePersonalAccessToken"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_personal_access_token_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_personal_access_token_request) =
+    let input = Json_serializers.delete_personal_access_token_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeletePersonalAccessToken" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_personal_access_token_response_of_yojson
       ~error_deserializer
 end
@@ -1008,6 +1187,12 @@ module DeleteResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeleteResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.delete_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_resource_request) =
+    let input = Json_serializers.delete_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.DeleteResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_resource_response_of_yojson ~error_deserializer
 end
 
 module DeleteRetentionPolicy = struct
@@ -1037,6 +1222,13 @@ module DeleteRetentionPolicy = struct
     let input = Json_serializers.delete_retention_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeleteRetentionPolicy" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.delete_retention_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : delete_retention_policy_request) =
+    let input = Json_serializers.delete_retention_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeleteRetentionPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.delete_retention_policy_response_of_yojson
       ~error_deserializer
 end
@@ -1086,6 +1278,12 @@ module DeleteUser = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeleteUser" ~service ~context
       ~input ~output_deserializer:Json_deserializers.delete_user_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : delete_user_request) =
+    let input = Json_serializers.delete_user_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.DeleteUser"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.delete_user_response_of_yojson ~error_deserializer
 end
 
 module DeregisterFromWorkMail = struct
@@ -1122,6 +1320,13 @@ module DeregisterFromWorkMail = struct
     let input = Json_serializers.deregister_from_work_mail_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DeregisterFromWorkMail"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.deregister_from_work_mail_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : deregister_from_work_mail_request) =
+    let input = Json_serializers.deregister_from_work_mail_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeregisterFromWorkMail" ~service ~context ~input
       ~output_deserializer:Json_deserializers.deregister_from_work_mail_response_of_yojson
       ~error_deserializer
 end
@@ -1164,6 +1369,13 @@ module DeregisterMailDomain = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.deregister_mail_domain_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : deregister_mail_domain_request) =
+    let input = Json_serializers.deregister_mail_domain_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DeregisterMailDomain" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.deregister_mail_domain_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeEmailMonitoringConfiguration = struct
@@ -1202,6 +1414,16 @@ module DescribeEmailMonitoringConfiguration = struct
       ~output_deserializer:
         Json_deserializers.describe_email_monitoring_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_email_monitoring_configuration_request) =
+    let input =
+      Json_serializers.describe_email_monitoring_configuration_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DescribeEmailMonitoringConfiguration" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_email_monitoring_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeEntity = struct
@@ -1236,6 +1458,12 @@ module DescribeEntity = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DescribeEntity" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_entity_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_entity_request) =
+    let input = Json_serializers.describe_entity_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.DescribeEntity"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_entity_response_of_yojson ~error_deserializer
 end
 
 module DescribeGroup = struct
@@ -1270,6 +1498,12 @@ module DescribeGroup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DescribeGroup" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_group_request) =
+    let input = Json_serializers.describe_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.DescribeGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_group_response_of_yojson ~error_deserializer
 end
 
 module DescribeIdentityProviderConfiguration = struct
@@ -1308,6 +1542,16 @@ module DescribeIdentityProviderConfiguration = struct
       ~output_deserializer:
         Json_deserializers.describe_identity_provider_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_identity_provider_configuration_request) =
+    let input =
+      Json_serializers.describe_identity_provider_configuration_request_to_yojson request
+    in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DescribeIdentityProviderConfiguration" ~service ~context ~input
+      ~output_deserializer:
+        Json_deserializers.describe_identity_provider_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeInboundDmarcSettings = struct
@@ -1333,6 +1577,13 @@ module DescribeInboundDmarcSettings = struct
     let input = Json_serializers.describe_inbound_dmarc_settings_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DescribeInboundDmarcSettings"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_inbound_dmarc_settings_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_inbound_dmarc_settings_request) =
+    let input = Json_serializers.describe_inbound_dmarc_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DescribeInboundDmarcSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_inbound_dmarc_settings_response_of_yojson
       ~error_deserializer
 end
@@ -1370,6 +1621,13 @@ module DescribeMailboxExportJob = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_mailbox_export_job_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_mailbox_export_job_request) =
+    let input = Json_serializers.describe_mailbox_export_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DescribeMailboxExportJob" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_mailbox_export_job_response_of_yojson
+      ~error_deserializer
 end
 
 module DescribeOrganization = struct
@@ -1395,6 +1653,13 @@ module DescribeOrganization = struct
     let input = Json_serializers.describe_organization_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DescribeOrganization" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.describe_organization_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_organization_request) =
+    let input = Json_serializers.describe_organization_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DescribeOrganization" ~service ~context ~input
       ~output_deserializer:Json_deserializers.describe_organization_response_of_yojson
       ~error_deserializer
 end
@@ -1434,6 +1699,13 @@ module DescribeResource = struct
     let input = Json_serializers.describe_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DescribeResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.describe_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : describe_resource_request) =
+    let input = Json_serializers.describe_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.DescribeResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_resource_response_of_yojson
       ~error_deserializer
 end
 
@@ -1479,6 +1751,12 @@ module DescribeUser = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.DescribeUser" ~service ~context
       ~input ~output_deserializer:Json_deserializers.describe_user_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : describe_user_request) =
+    let input = Json_serializers.describe_user_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.DescribeUser"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.describe_user_response_of_yojson ~error_deserializer
 end
 
 module DisassociateDelegateFromResource = struct
@@ -1518,6 +1796,13 @@ module DisassociateDelegateFromResource = struct
   let request context (request : disassociate_delegate_from_resource_request) =
     let input = Json_serializers.disassociate_delegate_from_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"WorkMailService.DisassociateDelegateFromResource" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_delegate_from_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_delegate_from_resource_request) =
+    let input = Json_serializers.disassociate_delegate_from_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"WorkMailService.DisassociateDelegateFromResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_delegate_from_resource_response_of_yojson
       ~error_deserializer
@@ -1573,6 +1858,13 @@ module DisassociateMemberFromGroup = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.disassociate_member_from_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : disassociate_member_from_group_request) =
+    let input = Json_serializers.disassociate_member_from_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.DisassociateMemberFromGroup" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.disassociate_member_from_group_response_of_yojson
+      ~error_deserializer
 end
 
 module GetAccessControlEffect = struct
@@ -1612,6 +1904,13 @@ module GetAccessControlEffect = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_access_control_effect_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_access_control_effect_request) =
+    let input = Json_serializers.get_access_control_effect_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.GetAccessControlEffect" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_access_control_effect_response_of_yojson
+      ~error_deserializer
 end
 
 module GetDefaultRetentionPolicy = struct
@@ -1647,6 +1946,13 @@ module GetDefaultRetentionPolicy = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_default_retention_policy_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_default_retention_policy_request) =
+    let input = Json_serializers.get_default_retention_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.GetDefaultRetentionPolicy" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_default_retention_policy_response_of_yojson
+      ~error_deserializer
 end
 
 module GetImpersonationRole = struct
@@ -1680,6 +1986,13 @@ module GetImpersonationRole = struct
     let input = Json_serializers.get_impersonation_role_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.GetImpersonationRole" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.get_impersonation_role_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_impersonation_role_request) =
+    let input = Json_serializers.get_impersonation_role_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.GetImpersonationRole" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_impersonation_role_response_of_yojson
       ~error_deserializer
 end
@@ -1724,6 +2037,13 @@ module GetImpersonationRoleEffect = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_impersonation_role_effect_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_impersonation_role_effect_request) =
+    let input = Json_serializers.get_impersonation_role_effect_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.GetImpersonationRoleEffect" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_impersonation_role_effect_response_of_yojson
+      ~error_deserializer
 end
 
 module GetMailboxDetails = struct
@@ -1757,6 +2077,13 @@ module GetMailboxDetails = struct
     let input = Json_serializers.get_mailbox_details_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.GetMailboxDetails" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_mailbox_details_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_mailbox_details_request) =
+    let input = Json_serializers.get_mailbox_details_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.GetMailboxDetails" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_mailbox_details_response_of_yojson
       ~error_deserializer
 end
 
@@ -1792,6 +2119,12 @@ module GetMailDomain = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.GetMailDomain" ~service
       ~context ~input ~output_deserializer:Json_deserializers.get_mail_domain_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_mail_domain_request) =
+    let input = Json_serializers.get_mail_domain_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.GetMailDomain"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_mail_domain_response_of_yojson ~error_deserializer
 end
 
 module GetMobileDeviceAccessEffect = struct
@@ -1821,6 +2154,13 @@ module GetMobileDeviceAccessEffect = struct
     let input = Json_serializers.get_mobile_device_access_effect_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.GetMobileDeviceAccessEffect"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_mobile_device_access_effect_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : get_mobile_device_access_effect_request) =
+    let input = Json_serializers.get_mobile_device_access_effect_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.GetMobileDeviceAccessEffect" ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_mobile_device_access_effect_response_of_yojson
       ~error_deserializer
 end
@@ -1862,6 +2202,13 @@ module GetMobileDeviceAccessOverride = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_mobile_device_access_override_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_mobile_device_access_override_request) =
+    let input = Json_serializers.get_mobile_device_access_override_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.GetMobileDeviceAccessOverride" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_mobile_device_access_override_response_of_yojson
+      ~error_deserializer
 end
 
 module GetPersonalAccessTokenMetadata = struct
@@ -1897,6 +2244,13 @@ module GetPersonalAccessTokenMetadata = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.get_personal_access_token_metadata_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : get_personal_access_token_metadata_request) =
+    let input = Json_serializers.get_personal_access_token_metadata_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.GetPersonalAccessTokenMetadata" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.get_personal_access_token_metadata_response_of_yojson
+      ~error_deserializer
 end
 
 module ListAccessControlRules = struct
@@ -1922,6 +2276,13 @@ module ListAccessControlRules = struct
     let input = Json_serializers.list_access_control_rules_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListAccessControlRules"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_access_control_rules_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_access_control_rules_request) =
+    let input = Json_serializers.list_access_control_rules_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListAccessControlRules" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_access_control_rules_response_of_yojson
       ~error_deserializer
 end
@@ -1961,6 +2322,12 @@ module ListAliases = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListAliases" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_aliases_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_aliases_request) =
+    let input = Json_serializers.list_aliases_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.ListAliases"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_aliases_response_of_yojson ~error_deserializer
 end
 
 module ListAvailabilityConfigurations = struct
@@ -1990,6 +2357,13 @@ module ListAvailabilityConfigurations = struct
     let input = Json_serializers.list_availability_configurations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListAvailabilityConfigurations"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_availability_configurations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_availability_configurations_request) =
+    let input = Json_serializers.list_availability_configurations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListAvailabilityConfigurations" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_availability_configurations_response_of_yojson
       ~error_deserializer
 end
@@ -2029,6 +2403,13 @@ module ListGroupMembers = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListGroupMembers" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_group_members_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_group_members_request) =
+    let input = Json_serializers.list_group_members_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.ListGroupMembers"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_group_members_response_of_yojson
+      ~error_deserializer
 end
 
 module ListGroups = struct
@@ -2063,6 +2444,12 @@ module ListGroups = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListGroups" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_groups_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_groups_request) =
+    let input = Json_serializers.list_groups_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.ListGroups"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_groups_response_of_yojson ~error_deserializer
 end
 
 module ListGroupsForEntity = struct
@@ -2101,6 +2488,13 @@ module ListGroupsForEntity = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_groups_for_entity_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_groups_for_entity_request) =
+    let input = Json_serializers.list_groups_for_entity_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListGroupsForEntity" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_groups_for_entity_response_of_yojson
+      ~error_deserializer
 end
 
 module ListImpersonationRoles = struct
@@ -2132,6 +2526,13 @@ module ListImpersonationRoles = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_impersonation_roles_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_impersonation_roles_request) =
+    let input = Json_serializers.list_impersonation_roles_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListImpersonationRoles" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_impersonation_roles_response_of_yojson
+      ~error_deserializer
 end
 
 module ListMailboxExportJobs = struct
@@ -2161,6 +2562,13 @@ module ListMailboxExportJobs = struct
     let input = Json_serializers.list_mailbox_export_jobs_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListMailboxExportJobs" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_mailbox_export_jobs_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_mailbox_export_jobs_request) =
+    let input = Json_serializers.list_mailbox_export_jobs_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListMailboxExportJobs" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_mailbox_export_jobs_response_of_yojson
       ~error_deserializer
 end
@@ -2198,6 +2606,13 @@ module ListMailboxPermissions = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_mailbox_permissions_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_mailbox_permissions_request) =
+    let input = Json_serializers.list_mailbox_permissions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListMailboxPermissions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_mailbox_permissions_response_of_yojson
+      ~error_deserializer
 end
 
 module ListMailDomains = struct
@@ -2227,6 +2642,13 @@ module ListMailDomains = struct
     let input = Json_serializers.list_mail_domains_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListMailDomains" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_mail_domains_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_mail_domains_request) =
+    let input = Json_serializers.list_mail_domains_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.ListMailDomains"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_mail_domains_response_of_yojson
       ~error_deserializer
 end
 
@@ -2263,6 +2685,13 @@ module ListMobileDeviceAccessOverrides = struct
       ~shape_name:"WorkMailService.ListMobileDeviceAccessOverrides" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_mobile_device_access_overrides_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_mobile_device_access_overrides_request) =
+    let input = Json_serializers.list_mobile_device_access_overrides_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListMobileDeviceAccessOverrides" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_mobile_device_access_overrides_response_of_yojson
+      ~error_deserializer
 end
 
 module ListMobileDeviceAccessRules = struct
@@ -2294,6 +2723,13 @@ module ListMobileDeviceAccessRules = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_mobile_device_access_rules_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_mobile_device_access_rules_request) =
+    let input = Json_serializers.list_mobile_device_access_rules_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListMobileDeviceAccessRules" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_mobile_device_access_rules_response_of_yojson
+      ~error_deserializer
 end
 
 module ListOrganizations = struct
@@ -2315,6 +2751,13 @@ module ListOrganizations = struct
     let input = Json_serializers.list_organizations_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListOrganizations" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_organizations_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_organizations_request) =
+    let input = Json_serializers.list_organizations_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListOrganizations" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_organizations_response_of_yojson
       ~error_deserializer
 end
 
@@ -2352,6 +2795,13 @@ module ListPersonalAccessTokens = struct
     let input = Json_serializers.list_personal_access_tokens_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListPersonalAccessTokens"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_personal_access_tokens_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_personal_access_tokens_request) =
+    let input = Json_serializers.list_personal_access_tokens_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListPersonalAccessTokens" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_personal_access_tokens_response_of_yojson
       ~error_deserializer
 end
@@ -2396,6 +2846,13 @@ module ListResourceDelegates = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.list_resource_delegates_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_resource_delegates_request) =
+    let input = Json_serializers.list_resource_delegates_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListResourceDelegates" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resource_delegates_response_of_yojson
+      ~error_deserializer
 end
 
 module ListResources = struct
@@ -2430,6 +2887,12 @@ module ListResources = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListResources" ~service
       ~context ~input ~output_deserializer:Json_deserializers.list_resources_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : list_resources_request) =
+    let input = Json_serializers.list_resources_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.ListResources"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.list_resources_response_of_yojson ~error_deserializer
 end
 
 module ListTagsForResource = struct
@@ -2451,6 +2914,13 @@ module ListTagsForResource = struct
     let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListTagsForResource" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_tags_for_resource_request) =
+    let input = Json_serializers.list_tags_for_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.ListTagsForResource" ~service ~context ~input
       ~output_deserializer:Json_deserializers.list_tags_for_resource_response_of_yojson
       ~error_deserializer
 end
@@ -2482,6 +2952,12 @@ module ListUsers = struct
     let input = Json_serializers.list_users_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ListUsers" ~service ~context
       ~input ~output_deserializer:Json_deserializers.list_users_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : list_users_request) =
+    let input = Json_serializers.list_users_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.ListUsers"
+      ~service ~context ~input ~output_deserializer:Json_deserializers.list_users_response_of_yojson
       ~error_deserializer
 end
 
@@ -2525,6 +3001,13 @@ module PutAccessControlRule = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.put_access_control_rule_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_access_control_rule_request) =
+    let input = Json_serializers.put_access_control_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.PutAccessControlRule" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_access_control_rule_response_of_yojson
+      ~error_deserializer
 end
 
 module PutEmailMonitoringConfiguration = struct
@@ -2557,6 +3040,13 @@ module PutEmailMonitoringConfiguration = struct
   let request context (request : put_email_monitoring_configuration_request) =
     let input = Json_serializers.put_email_monitoring_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"WorkMailService.PutEmailMonitoringConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_email_monitoring_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_email_monitoring_configuration_request) =
+    let input = Json_serializers.put_email_monitoring_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"WorkMailService.PutEmailMonitoringConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_email_monitoring_configuration_response_of_yojson
       ~error_deserializer
@@ -2595,6 +3085,13 @@ module PutIdentityProviderConfiguration = struct
       ~shape_name:"WorkMailService.PutIdentityProviderConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_identity_provider_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_identity_provider_configuration_request) =
+    let input = Json_serializers.put_identity_provider_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.PutIdentityProviderConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_identity_provider_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module PutInboundDmarcSettings = struct
@@ -2620,6 +3117,13 @@ module PutInboundDmarcSettings = struct
     let input = Json_serializers.put_inbound_dmarc_settings_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.PutInboundDmarcSettings"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_inbound_dmarc_settings_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_inbound_dmarc_settings_request) =
+    let input = Json_serializers.put_inbound_dmarc_settings_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.PutInboundDmarcSettings" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_inbound_dmarc_settings_response_of_yojson
       ~error_deserializer
 end
@@ -2660,6 +3164,13 @@ module PutMailboxPermissions = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.put_mailbox_permissions_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_mailbox_permissions_request) =
+    let input = Json_serializers.put_mailbox_permissions_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.PutMailboxPermissions" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_mailbox_permissions_response_of_yojson
+      ~error_deserializer
 end
 
 module PutMobileDeviceAccessOverride = struct
@@ -2698,6 +3209,13 @@ module PutMobileDeviceAccessOverride = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_mobile_device_access_override_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : put_mobile_device_access_override_request) =
+    let input = Json_serializers.put_mobile_device_access_override_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.PutMobileDeviceAccessOverride" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.put_mobile_device_access_override_response_of_yojson
+      ~error_deserializer
 end
 
 module PutRetentionPolicy = struct
@@ -2730,6 +3248,13 @@ module PutRetentionPolicy = struct
     let input = Json_serializers.put_retention_policy_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.PutRetentionPolicy" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.put_retention_policy_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : put_retention_policy_request) =
+    let input = Json_serializers.put_retention_policy_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.PutRetentionPolicy" ~service ~context ~input
       ~output_deserializer:Json_deserializers.put_retention_policy_response_of_yojson
       ~error_deserializer
 end
@@ -2768,6 +3293,13 @@ module RegisterMailDomain = struct
     let input = Json_serializers.register_mail_domain_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.RegisterMailDomain" ~service
       ~context ~input
+      ~output_deserializer:Json_deserializers.register_mail_domain_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : register_mail_domain_request) =
+    let input = Json_serializers.register_mail_domain_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.RegisterMailDomain" ~service ~context ~input
       ~output_deserializer:Json_deserializers.register_mail_domain_response_of_yojson
       ~error_deserializer
 end
@@ -2839,6 +3371,13 @@ module RegisterToWorkMail = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.register_to_work_mail_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : register_to_work_mail_request) =
+    let input = Json_serializers.register_to_work_mail_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.RegisterToWorkMail" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.register_to_work_mail_response_of_yojson
+      ~error_deserializer
 end
 
 module ResetPassword = struct
@@ -2894,6 +3433,12 @@ module ResetPassword = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.ResetPassword" ~service
       ~context ~input ~output_deserializer:Json_deserializers.reset_password_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : reset_password_request) =
+    let input = Json_serializers.reset_password_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.ResetPassword"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.reset_password_response_of_yojson ~error_deserializer
 end
 
 module StartMailboxExportJob = struct
@@ -2932,6 +3477,13 @@ module StartMailboxExportJob = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.start_mailbox_export_job_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : start_mailbox_export_job_request) =
+    let input = Json_serializers.start_mailbox_export_job_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.StartMailboxExportJob" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.start_mailbox_export_job_response_of_yojson
+      ~error_deserializer
 end
 
 module TagResource = struct
@@ -2965,6 +3517,12 @@ module TagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.TagResource" ~service ~context
       ~input ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : tag_resource_request) =
+    let input = Json_serializers.tag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.TagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.tag_resource_response_of_yojson ~error_deserializer
 end
 
 module TestAvailabilityConfiguration = struct
@@ -3000,6 +3558,13 @@ module TestAvailabilityConfiguration = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.test_availability_configuration_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : test_availability_configuration_request) =
+    let input = Json_serializers.test_availability_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.TestAvailabilityConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.test_availability_configuration_response_of_yojson
+      ~error_deserializer
 end
 
 module UntagResource = struct
@@ -3022,6 +3587,12 @@ module UntagResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.UntagResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : untag_resource_request) =
+    let input = Json_serializers.untag_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.UntagResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.untag_resource_response_of_yojson ~error_deserializer
 end
 
 module UpdateAvailabilityConfiguration = struct
@@ -3054,6 +3625,13 @@ module UpdateAvailabilityConfiguration = struct
   let request context (request : update_availability_configuration_request) =
     let input = Json_serializers.update_availability_configuration_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request
+      ~shape_name:"WorkMailService.UpdateAvailabilityConfiguration" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_availability_configuration_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_availability_configuration_request) =
+    let input = Json_serializers.update_availability_configuration_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
       ~shape_name:"WorkMailService.UpdateAvailabilityConfiguration" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_availability_configuration_response_of_yojson
       ~error_deserializer
@@ -3094,6 +3672,13 @@ module UpdateDefaultMailDomain = struct
     let input = Json_serializers.update_default_mail_domain_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.UpdateDefaultMailDomain"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_default_mail_domain_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_default_mail_domain_request) =
+    let input = Json_serializers.update_default_mail_domain_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.UpdateDefaultMailDomain" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_default_mail_domain_response_of_yojson
       ~error_deserializer
 end
@@ -3137,6 +3722,12 @@ module UpdateGroup = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.UpdateGroup" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_group_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_group_request) =
+    let input = Json_serializers.update_group_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.UpdateGroup"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_group_response_of_yojson ~error_deserializer
 end
 
 module UpdateImpersonationRole = struct
@@ -3182,6 +3773,13 @@ module UpdateImpersonationRole = struct
       ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_impersonation_role_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_impersonation_role_request) =
+    let input = Json_serializers.update_impersonation_role_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.UpdateImpersonationRole" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_impersonation_role_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateMailboxQuota = struct
@@ -3220,6 +3818,13 @@ module UpdateMailboxQuota = struct
       ~context ~input
       ~output_deserializer:Json_deserializers.update_mailbox_quota_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_mailbox_quota_request) =
+    let input = Json_serializers.update_mailbox_quota_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.UpdateMailboxQuota" ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_mailbox_quota_response_of_yojson
+      ~error_deserializer
 end
 
 module UpdateMobileDeviceAccessRule = struct
@@ -3253,6 +3858,13 @@ module UpdateMobileDeviceAccessRule = struct
     let input = Json_serializers.update_mobile_device_access_rule_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.UpdateMobileDeviceAccessRule"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_mobile_device_access_rule_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_mobile_device_access_rule_request) =
+    let input = Json_serializers.update_mobile_device_access_rule_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.UpdateMobileDeviceAccessRule" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_mobile_device_access_rule_response_of_yojson
       ~error_deserializer
 end
@@ -3317,6 +3929,13 @@ module UpdatePrimaryEmailAddress = struct
     let input = Json_serializers.update_primary_email_address_request_to_yojson request in
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.UpdatePrimaryEmailAddress"
       ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_primary_email_address_response_of_yojson
+      ~error_deserializer
+
+  let request_with_metadata context (request : update_primary_email_address_request) =
+    let input = Json_serializers.update_primary_email_address_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata
+      ~shape_name:"WorkMailService.UpdatePrimaryEmailAddress" ~service ~context ~input
       ~output_deserializer:Json_deserializers.update_primary_email_address_response_of_yojson
       ~error_deserializer
 end
@@ -3384,6 +4003,12 @@ module UpdateResource = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.UpdateResource" ~service
       ~context ~input ~output_deserializer:Json_deserializers.update_resource_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_resource_request) =
+    let input = Json_serializers.update_resource_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.UpdateResource"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_resource_response_of_yojson ~error_deserializer
 end
 
 module UpdateUser = struct
@@ -3435,4 +4060,10 @@ module UpdateUser = struct
     Smaws_Lib.Protocols.AwsJson.request ~shape_name:"WorkMailService.UpdateUser" ~service ~context
       ~input ~output_deserializer:Json_deserializers.update_user_response_of_yojson
       ~error_deserializer
+
+  let request_with_metadata context (request : update_user_request) =
+    let input = Json_serializers.update_user_request_to_yojson request in
+    Smaws_Lib.Protocols.AwsJson.request_with_metadata ~shape_name:"WorkMailService.UpdateUser"
+      ~service ~context ~input
+      ~output_deserializer:Json_deserializers.update_user_response_of_yojson ~error_deserializer
 end

--- a/sdks/workmail/operations.mli
+++ b/sdks/workmail/operations.mli
@@ -23,6 +23,19 @@ module AssociateDelegateToResource : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_delegate_to_resource_request ->
+    ( associate_delegate_to_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Adds a member (user or group) to the resource's set of delegates.\n"]
 
@@ -44,6 +57,22 @@ module AssociateMemberToGroup : sig
     'http_type Smaws_Lib.Context.t ->
     associate_member_to_group_request ->
     ( associate_member_to_group_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    associate_member_to_group_request ->
+    ( associate_member_to_group_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception
@@ -77,6 +106,17 @@ module AssumeImpersonationRole : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    assume_impersonation_role_request ->
+    ( assume_impersonation_role_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Assumes an impersonation role for the given WorkMail organization. This method returns an \
@@ -95,6 +135,17 @@ module CancelMailboxExportJob : sig
     'http_type Smaws_Lib.Context.t ->
     cancel_mailbox_export_job_request ->
     ( cancel_mailbox_export_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    cancel_mailbox_export_job_request ->
+    ( cancel_mailbox_export_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -137,6 +188,22 @@ module CreateAlias : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_alias_request ->
+    ( create_alias_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EmailAddressInUseException of email_address_in_use_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Adds an alias to the set of a given member (user or group) of WorkMail.\n"]
 
@@ -154,6 +221,18 @@ module CreateAvailabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     create_availability_configuration_request ->
     ( create_availability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_availability_configuration_request ->
+    ( create_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -194,6 +273,22 @@ module CreateGroup : sig
       | `ReservedNameException of reserved_name_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_group_request ->
+    ( create_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ReservedNameException of reserved_name_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a group that can be used in WorkMail by calling the [RegisterToWorkMail] operation.\n"]
@@ -207,6 +302,14 @@ module CreateIdentityCenterApplication : sig
     'http_type Smaws_Lib.Context.t ->
     create_identity_center_application_request ->
     ( create_identity_center_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_identity_center_application_request ->
+    ( create_identity_center_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception ] )
     result
@@ -231,6 +334,19 @@ module CreateImpersonationRole : sig
     'http_type Smaws_Lib.Context.t ->
     create_impersonation_role_request ->
     ( create_impersonation_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_impersonation_role_request ->
+    ( create_impersonation_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -266,6 +382,17 @@ module CreateMobileDeviceAccessRule : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_mobile_device_access_rule_request ->
+    ( create_mobile_device_access_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Creates a new mobile device access rule for the specified WorkMail organization.\n"]
 
@@ -283,6 +410,18 @@ module CreateOrganization : sig
     'http_type Smaws_Lib.Context.t ->
     create_organization_request ->
     ( create_organization_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryInUseException of directory_in_use_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `NameAvailabilityException of name_availability_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_organization_request ->
+    ( create_organization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryInUseException of directory_in_use_exception
       | `DirectoryUnavailableException of directory_unavailable_exception
@@ -340,6 +479,22 @@ module CreateResource : sig
       | `ReservedNameException of reserved_name_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_resource_request ->
+    ( create_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ReservedNameException of reserved_name_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Creates a new WorkMail resource.\n"]
 
@@ -374,6 +529,23 @@ module CreateUser : sig
       | `ReservedNameException of reserved_name_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    create_user_request ->
+    ( create_user_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidPasswordException of invalid_password_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ReservedNameException of reserved_name_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates a user who can be used in WorkMail by calling the [RegisterToWorkMail] operation.\n"]
@@ -389,6 +561,15 @@ module DeleteAccessControlRule : sig
     'http_type Smaws_Lib.Context.t ->
     delete_access_control_rule_request ->
     ( delete_access_control_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_access_control_rule_request ->
+    ( delete_access_control_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -422,6 +603,18 @@ module DeleteAlias : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_alias_request ->
+    ( delete_alias_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Remove one or more specified aliases from a set of aliases for a given user.\n"]
 
@@ -436,6 +629,15 @@ module DeleteAvailabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_availability_configuration_request ->
     ( delete_availability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_availability_configuration_request ->
+    ( delete_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -456,6 +658,16 @@ module DeleteEmailMonitoringConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     delete_email_monitoring_configuration_request ->
     ( delete_email_monitoring_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_email_monitoring_configuration_request ->
+    ( delete_email_monitoring_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -491,6 +703,21 @@ module DeleteGroup : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_group_request ->
+    ( delete_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes a group from WorkMail.\n"]
 
@@ -505,6 +732,15 @@ module DeleteIdentityCenterApplication : sig
     'http_type Smaws_Lib.Context.t ->
     delete_identity_center_application_request ->
     ( delete_identity_center_application_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_identity_center_application_request ->
+    ( delete_identity_center_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -531,6 +767,16 @@ module DeleteIdentityProviderConfiguration : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_identity_provider_configuration_request ->
+    ( delete_identity_provider_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   " Disables the integration between IdC and WorkMail. Authentication will continue with the \
@@ -549,6 +795,16 @@ module DeleteImpersonationRole : sig
     'http_type Smaws_Lib.Context.t ->
     delete_impersonation_role_request ->
     ( delete_impersonation_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_impersonation_role_request ->
+    ( delete_impersonation_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -578,6 +834,18 @@ module DeleteMailboxPermissions : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_mailbox_permissions_request ->
+    ( delete_mailbox_permissions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes permissions granted to a member (user or group).\n"]
 
@@ -594,6 +862,17 @@ module DeleteMobileDeviceAccessOverride : sig
     'http_type Smaws_Lib.Context.t ->
     delete_mobile_device_access_override_request ->
     ( delete_mobile_device_access_override_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_mobile_device_access_override_request ->
+    ( delete_mobile_device_access_override_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -626,6 +905,16 @@ module DeleteMobileDeviceAccessRule : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_mobile_device_access_rule_request ->
+    ( delete_mobile_device_access_rule_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Deletes a mobile device access rule for the specified WorkMail organization.\n\n\
@@ -646,6 +935,16 @@ module DeleteOrganization : sig
     'http_type Smaws_Lib.Context.t ->
     delete_organization_request ->
     ( delete_organization_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_organization_request ->
+    ( delete_organization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -676,6 +975,16 @@ module DeletePersonalAccessToken : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_personal_access_token_request ->
+    ( delete_personal_access_token_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc " Deletes the Personal Access Token from the provided WorkMail Organization. \n"]
 
@@ -693,6 +1002,18 @@ module DeleteResource : sig
     'http_type Smaws_Lib.Context.t ->
     delete_resource_request ->
     ( delete_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_resource_request ->
+    ( delete_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -720,6 +1041,16 @@ module DeleteRetentionPolicy : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_retention_policy_request ->
+    ( delete_retention_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Deletes the specified retention policy from the specified organization.\n"]
 
@@ -740,6 +1071,21 @@ module DeleteUser : sig
     'http_type Smaws_Lib.Context.t ->
     delete_user_request ->
     ( delete_user_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    delete_user_request ->
+    ( delete_user_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception
@@ -779,6 +1125,18 @@ module DeregisterFromWorkMail : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_from_work_mail_request ->
+    ( deregister_from_work_mail_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Mark a user, group, or resource as no longer used in WorkMail. This action disassociates the \
@@ -799,6 +1157,18 @@ module DeregisterMailDomain : sig
     'http_type Smaws_Lib.Context.t ->
     deregister_mail_domain_request ->
     ( deregister_mail_domain_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidCustomSesConfigurationException of invalid_custom_ses_configuration_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainInUseException of mail_domain_in_use_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    deregister_mail_domain_request ->
+    ( deregister_mail_domain_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidCustomSesConfigurationException of invalid_custom_ses_configuration_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -831,6 +1201,17 @@ module DescribeEmailMonitoringConfiguration : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_email_monitoring_configuration_request ->
+    ( describe_email_monitoring_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Describes the current email monitoring configuration for a specified organization.\n"]
 
@@ -847,6 +1228,17 @@ module DescribeEntity : sig
     'http_type Smaws_Lib.Context.t ->
     describe_entity_request ->
     ( describe_entity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_entity_request ->
+    ( describe_entity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -875,6 +1267,17 @@ module DescribeGroup : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_group_request ->
+    ( describe_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Returns the data available for the group.\n"]
 
@@ -897,6 +1300,17 @@ module DescribeIdentityProviderConfiguration : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_identity_provider_configuration_request ->
+    ( describe_identity_provider_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   " Returns detailed information on the current IdC setup for the WorkMail organization. \n"]
@@ -912,6 +1326,15 @@ module DescribeInboundDmarcSettings : sig
     'http_type Smaws_Lib.Context.t ->
     describe_inbound_dmarc_settings_request ->
     ( describe_inbound_dmarc_settings_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_inbound_dmarc_settings_request ->
+    ( describe_inbound_dmarc_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -938,6 +1361,17 @@ module DescribeMailboxExportJob : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_mailbox_export_job_request ->
+    ( describe_mailbox_export_job_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Describes the current status of a mailbox export job.\n"]
 
@@ -952,6 +1386,15 @@ module DescribeOrganization : sig
     'http_type Smaws_Lib.Context.t ->
     describe_organization_request ->
     ( describe_organization_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_organization_request ->
+    ( describe_organization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception ] )
@@ -973,6 +1416,18 @@ module DescribeResource : sig
     'http_type Smaws_Lib.Context.t ->
     describe_resource_request ->
     ( describe_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_resource_request ->
+    ( describe_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1008,6 +1463,20 @@ module DescribeUser : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    describe_user_request ->
+    ( describe_user_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Provides information regarding the user.\n"]
 
@@ -1026,6 +1495,19 @@ module DisassociateDelegateFromResource : sig
     'http_type Smaws_Lib.Context.t ->
     disassociate_delegate_from_resource_request ->
     ( disassociate_delegate_from_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_delegate_from_resource_request ->
+    ( disassociate_delegate_from_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -1066,6 +1548,22 @@ module DisassociateMemberFromGroup : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    disassociate_member_from_group_request ->
+    ( disassociate_member_from_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Removes a member from a group.\n"]
 
@@ -1083,6 +1581,18 @@ module GetAccessControlEffect : sig
     'http_type Smaws_Lib.Context.t ->
     get_access_control_effect_request ->
     ( get_access_control_effect_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_access_control_effect_request ->
+    ( get_access_control_effect_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1115,6 +1625,17 @@ module GetDefaultRetentionPolicy : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_default_retention_policy_request ->
+    ( get_default_retention_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Gets the default retention policy details for the specified organization.\n"]
 
@@ -1131,6 +1652,17 @@ module GetImpersonationRole : sig
     'http_type Smaws_Lib.Context.t ->
     get_impersonation_role_request ->
     ( get_impersonation_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_impersonation_role_request ->
+    ( get_impersonation_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -1163,6 +1695,19 @@ module GetImpersonationRoleEffect : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_impersonation_role_effect_request ->
+    ( get_impersonation_role_effect_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Tests whether the given impersonation role can impersonate a target user.\n"]
 
@@ -1179,6 +1724,17 @@ module GetMailboxDetails : sig
     'http_type Smaws_Lib.Context.t ->
     get_mailbox_details_request ->
     ( get_mailbox_details_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mailbox_details_request ->
+    ( get_mailbox_details_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1207,6 +1763,17 @@ module GetMailDomain : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mail_domain_request ->
+    ( get_mail_domain_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets details for a mail domain, including domain records required to configure your domain with \
@@ -1224,6 +1791,16 @@ module GetMobileDeviceAccessEffect : sig
     'http_type Smaws_Lib.Context.t ->
     get_mobile_device_access_effect_request ->
     ( get_mobile_device_access_effect_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mobile_device_access_effect_request ->
+    ( get_mobile_device_access_effect_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -1256,6 +1833,18 @@ module GetMobileDeviceAccessOverride : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_mobile_device_access_override_request ->
+    ( get_mobile_device_access_override_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Gets the mobile device access override for the given WorkMail organization, user, and device.\n"]
@@ -1279,6 +1868,17 @@ module GetPersonalAccessTokenMetadata : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    get_personal_access_token_metadata_request ->
+    ( get_personal_access_token_metadata_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   " Requests details of a specific Personal Access Token within the WorkMail organization. \n"]
@@ -1294,6 +1894,15 @@ module ListAccessControlRules : sig
     'http_type Smaws_Lib.Context.t ->
     list_access_control_rules_request ->
     ( list_access_control_rules_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_access_control_rules_request ->
+    ( list_access_control_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
@@ -1322,6 +1931,18 @@ module ListAliases : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_aliases_request ->
+    ( list_aliases_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Creates a paginated call to list the aliases associated with a given entity.\n"]
 
@@ -1337,6 +1958,16 @@ module ListAvailabilityConfigurations : sig
     'http_type Smaws_Lib.Context.t ->
     list_availability_configurations_request ->
     ( list_availability_configurations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_availability_configurations_request ->
+    ( list_availability_configurations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -1359,6 +1990,18 @@ module ListGroupMembers : sig
     'http_type Smaws_Lib.Context.t ->
     list_group_members_request ->
     ( list_group_members_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_group_members_request ->
+    ( list_group_members_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -1389,6 +2032,17 @@ module ListGroups : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_groups_request ->
+    ( list_groups_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Returns summaries of the organization's groups.\n"]
 
@@ -1406,6 +2060,18 @@ module ListGroupsForEntity : sig
     'http_type Smaws_Lib.Context.t ->
     list_groups_for_entity_request ->
     ( list_groups_for_entity_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_groups_for_entity_request ->
+    ( list_groups_for_entity_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -1433,6 +2099,16 @@ module ListImpersonationRoles : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_impersonation_roles_request ->
+    ( list_impersonation_roles_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Lists all the impersonation roles for the given WorkMail organization.\n"]
 
@@ -1448,6 +2124,16 @@ module ListMailboxExportJobs : sig
     'http_type Smaws_Lib.Context.t ->
     list_mailbox_export_jobs_request ->
     ( list_mailbox_export_jobs_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mailbox_export_jobs_request ->
+    ( list_mailbox_export_jobs_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -1476,6 +2162,17 @@ module ListMailboxPermissions : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mailbox_permissions_request ->
+    ( list_mailbox_permissions_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the mailbox permissions associated with a user, group, or resource mailbox.\n"]
 
@@ -1491,6 +2188,16 @@ module ListMailDomains : sig
     'http_type Smaws_Lib.Context.t ->
     list_mail_domains_request ->
     ( list_mail_domains_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mail_domains_request ->
+    ( list_mail_domains_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -1512,6 +2219,17 @@ module ListMobileDeviceAccessOverrides : sig
     'http_type Smaws_Lib.Context.t ->
     list_mobile_device_access_overrides_request ->
     ( list_mobile_device_access_overrides_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mobile_device_access_overrides_request ->
+    ( list_mobile_device_access_overrides_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1540,6 +2258,16 @@ module ListMobileDeviceAccessRules : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_mobile_device_access_rules_request ->
+    ( list_mobile_device_access_rules_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Lists the mobile device access rules for the specified WorkMail organization.\n"]
 
@@ -1552,6 +2280,14 @@ module ListOrganizations : sig
     'http_type Smaws_Lib.Context.t ->
     list_organizations_request ->
     ( list_organizations_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_organizations_request ->
+    ( list_organizations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception ] )
     result
@@ -1572,6 +2308,18 @@ module ListPersonalAccessTokens : sig
     'http_type Smaws_Lib.Context.t ->
     list_personal_access_tokens_request ->
     ( list_personal_access_tokens_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_personal_access_tokens_request ->
+    ( list_personal_access_tokens_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -1605,6 +2353,19 @@ module ListResourceDelegates : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resource_delegates_request ->
+    ( list_resource_delegates_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Lists the delegates associated with a resource. Users and groups can be resource delegates and \
@@ -1629,6 +2390,17 @@ module ListResources : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_resources_request ->
+    ( list_resources_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Returns summaries of the organization's resources.\n"]
 
@@ -1642,6 +2414,14 @@ module ListTagsForResource : sig
     'http_type Smaws_Lib.Context.t ->
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_tags_for_resource_request ->
+    ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
@@ -1665,6 +2445,16 @@ module ListUsers : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    list_users_request ->
+    ( list_users_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Returns summaries of the organization's users.\n"]
 
@@ -1683,6 +2473,19 @@ module PutAccessControlRule : sig
     'http_type Smaws_Lib.Context.t ->
     put_access_control_rule_request ->
     ( put_access_control_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_access_control_rule_request ->
+    ( put_access_control_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1717,6 +2520,17 @@ module PutEmailMonitoringConfiguration : sig
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_email_monitoring_configuration_request ->
+    ( put_email_monitoring_configuration_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates or updates the email monitoring configuration for a specified organization.\n"]
@@ -1734,6 +2548,17 @@ module PutIdentityProviderConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     put_identity_provider_configuration_request ->
     ( put_identity_provider_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_identity_provider_configuration_request ->
+    ( put_identity_provider_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -1762,6 +2587,15 @@ module PutInboundDmarcSettings : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_inbound_dmarc_settings_request ->
+    ( put_inbound_dmarc_settings_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Enables or disables a DMARC policy for a given organization.\n"]
 
@@ -1779,6 +2613,18 @@ module PutMailboxPermissions : sig
     'http_type Smaws_Lib.Context.t ->
     put_mailbox_permissions_request ->
     ( put_mailbox_permissions_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_mailbox_permissions_request ->
+    ( put_mailbox_permissions_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -1811,6 +2657,18 @@ module PutMobileDeviceAccessOverride : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_mobile_device_access_override_request ->
+    ( put_mobile_device_access_override_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc
   "Creates or updates a mobile device access override for the given WorkMail organization, user, \
@@ -1835,6 +2693,17 @@ module PutRetentionPolicy : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    put_retention_policy_request ->
+    ( put_retention_policy_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Puts a retention policy to the specified organization.\n"]
 
@@ -1852,6 +2721,18 @@ module RegisterMailDomain : sig
     'http_type Smaws_Lib.Context.t ->
     register_mail_domain_request ->
     ( register_mail_domain_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `MailDomainInUseException of mail_domain_in_use_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_mail_domain_request ->
+    ( register_mail_domain_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
@@ -1887,6 +2768,26 @@ module RegisterToWorkMail : sig
     'http_type Smaws_Lib.Context.t ->
     register_to_work_mail_request ->
     ( register_to_work_mail_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EmailAddressInUseException of email_address_in_use_exception
+      | `EntityAlreadyRegisteredException of entity_already_registered_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    register_to_work_mail_request ->
+    ( register_to_work_mail_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception
@@ -1945,6 +2846,23 @@ module ResetPassword : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    reset_password_request ->
+    ( reset_password_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `InvalidPasswordException of invalid_password_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Allows the administrator to reset the password for a user.\n"]
 
@@ -1962,6 +2880,18 @@ module StartMailboxExportJob : sig
     'http_type Smaws_Lib.Context.t ->
     start_mailbox_export_job_request ->
     ( start_mailbox_export_job_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    start_mailbox_export_job_request ->
+    ( start_mailbox_export_job_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -1996,6 +2926,17 @@ module TagResource : sig
       | `ResourceNotFoundException of resource_not_found_exception
       | `TooManyTagsException of too_many_tags_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    tag_resource_request ->
+    ( tag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception
+      | `TooManyTagsException of too_many_tags_exception ] )
+    result
 end
 [@@ocaml.doc "Applies the specified tags to the specified WorkMailorganization resource.\n"]
 
@@ -2012,6 +2953,17 @@ module TestAvailabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     test_availability_configuration_request ->
     ( test_availability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    test_availability_configuration_request ->
+    ( test_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -2044,6 +2996,14 @@ module UntagResource : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `ResourceNotFoundException of resource_not_found_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    untag_resource_request ->
+    ( untag_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
 end
 [@@ocaml.doc "Untags the specified tags from the specified WorkMail organization resource.\n"]
 
@@ -2060,6 +3020,17 @@ module UpdateAvailabilityConfiguration : sig
     'http_type Smaws_Lib.Context.t ->
     update_availability_configuration_request ->
     ( update_availability_configuration_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_availability_configuration_request ->
+    ( update_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
@@ -2084,6 +3055,18 @@ module UpdateDefaultMailDomain : sig
     'http_type Smaws_Lib.Context.t ->
     update_default_mail_domain_request ->
     ( update_default_mail_domain_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_default_mail_domain_request ->
+    ( update_default_mail_domain_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `MailDomainNotFoundException of mail_domain_not_found_exception
@@ -2120,6 +3103,19 @@ module UpdateGroup : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_group_request ->
+    ( update_group_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc "Updates attributes in a group.\n"]
 
@@ -2139,6 +3135,20 @@ module UpdateImpersonationRole : sig
     'http_type Smaws_Lib.Context.t ->
     update_impersonation_role_request ->
     ( update_impersonation_role_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `LimitExceededException of limit_exceeded_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `ResourceNotFoundException of resource_not_found_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_impersonation_role_request ->
+    ( update_impersonation_role_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `EntityStateException of entity_state_exception
@@ -2172,6 +3182,18 @@ module UpdateMailboxQuota : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_mailbox_quota_request ->
+    ( update_mailbox_quota_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
 end
 [@@ocaml.doc "Updates a user's current mailbox quota for a specified organization and user.\n"]
 
@@ -2188,6 +3210,17 @@ module UpdateMobileDeviceAccessRule : sig
     'http_type Smaws_Lib.Context.t ->
     update_mobile_device_access_rule_request ->
     ( update_mobile_device_access_rule_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `EntityNotFoundException of entity_not_found_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_mobile_device_access_rule_request ->
+    ( update_mobile_device_access_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
@@ -2218,6 +3251,25 @@ module UpdatePrimaryEmailAddress : sig
     'http_type Smaws_Lib.Context.t ->
     update_primary_email_address_request ->
     ( update_primary_email_address_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EmailAddressInUseException of email_address_in_use_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_primary_email_address_request ->
+    ( update_primary_email_address_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception
@@ -2273,6 +3325,25 @@ module UpdateResource : sig
       | `OrganizationStateException of organization_state_exception
       | `UnsupportedOperationException of unsupported_operation_exception ] )
     result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_resource_request ->
+    ( update_resource_response Smaws_Lib.Response.t,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EmailAddressInUseException of email_address_in_use_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidConfigurationException of invalid_configuration_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `MailDomainNotFoundException of mail_domain_not_found_exception
+      | `MailDomainStateException of mail_domain_state_exception
+      | `NameAvailabilityException of name_availability_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
 end
 [@@ocaml.doc
   "Updates data for the resource. To have the latest information, it must be preceded by a \
@@ -2297,6 +3368,22 @@ module UpdateUser : sig
     'http_type Smaws_Lib.Context.t ->
     update_user_request ->
     ( update_user_response,
+      [> Smaws_Lib.Protocols.AwsJson.error
+      | `DirectoryServiceAuthenticationFailedException of
+        directory_service_authentication_failed_exception
+      | `DirectoryUnavailableException of directory_unavailable_exception
+      | `EntityNotFoundException of entity_not_found_exception
+      | `EntityStateException of entity_state_exception
+      | `InvalidParameterException of invalid_parameter_exception
+      | `OrganizationNotFoundException of organization_not_found_exception
+      | `OrganizationStateException of organization_state_exception
+      | `UnsupportedOperationException of unsupported_operation_exception ] )
+    result
+
+  val request_with_metadata :
+    'http_type Smaws_Lib.Context.t ->
+    update_user_request ->
+    ( update_user_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `DirectoryServiceAuthenticationFailedException of
         directory_service_authentication_failed_exception

--- a/sdks/workmail/operations.mli
+++ b/sdks/workmail/operations.mli
@@ -34,7 +34,8 @@ module AssociateDelegateToResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds a member (user or group) to the resource's set of delegates.\n"]
@@ -82,7 +83,8 @@ module AssociateMemberToGroup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds a member (user or group) to the group's set.\n"]
@@ -115,7 +117,8 @@ module AssumeImpersonationRole : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -150,7 +153,8 @@ module CancelMailboxExportJob : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -202,7 +206,8 @@ module CreateAlias : sig
       | `MailDomainNotFoundException of mail_domain_not_found_exception
       | `MailDomainStateException of mail_domain_state_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Adds an alias to the set of a given member (user or group) of WorkMail.\n"]
@@ -238,7 +243,8 @@ module CreateAvailabilityConfiguration : sig
       | `LimitExceededException of limit_exceeded_exception
       | `NameAvailabilityException of name_availability_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -287,7 +293,8 @@ module CreateGroup : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
       | `ReservedNameException of reserved_name_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -311,7 +318,8 @@ module CreateIdentityCenterApplication : sig
     create_identity_center_application_request ->
     ( create_identity_center_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterException of invalid_parameter_exception ] )
+      | `InvalidParameterException of invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -353,7 +361,8 @@ module CreateImpersonationRole : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -391,7 +400,8 @@ module CreateMobileDeviceAccessRule : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a new mobile device access rule for the specified WorkMail organization.\n"]
@@ -427,7 +437,8 @@ module CreateOrganization : sig
       | `DirectoryUnavailableException of directory_unavailable_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
-      | `NameAvailabilityException of name_availability_exception ] )
+      | `NameAvailabilityException of name_availability_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -493,7 +504,8 @@ module CreateResource : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
       | `ReservedNameException of reserved_name_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a new WorkMail resource.\n"]
@@ -544,7 +556,8 @@ module CreateUser : sig
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
       | `ReservedNameException of reserved_name_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -572,7 +585,8 @@ module DeleteAccessControlRule : sig
     ( delete_access_control_rule_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -613,7 +627,8 @@ module DeleteAlias : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Remove one or more specified aliases from a set of aliases for a given user.\n"]
@@ -640,7 +655,8 @@ module DeleteAvailabilityConfiguration : sig
     ( delete_availability_configuration_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -671,7 +687,8 @@ module DeleteEmailMonitoringConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the email monitoring configuration for a specified organization.\n"]
@@ -716,7 +733,8 @@ module DeleteGroup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes a group from WorkMail.\n"]
@@ -743,7 +761,8 @@ module DeleteIdentityCenterApplication : sig
     ( delete_identity_center_application_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -775,7 +794,8 @@ module DeleteIdentityProviderConfiguration : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -808,7 +828,8 @@ module DeleteImpersonationRole : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes an impersonation role for the given WorkMail organization.\n"]
@@ -844,7 +865,8 @@ module DeleteMailboxPermissions : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes permissions granted to a member (user or group).\n"]
@@ -877,7 +899,8 @@ module DeleteMobileDeviceAccessOverride : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -913,7 +936,8 @@ module DeleteMobileDeviceAccessRule : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -948,7 +972,8 @@ module DeleteOrganization : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -983,7 +1008,8 @@ module DeletePersonalAccessToken : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Deletes the Personal Access Token from the provided WorkMail Organization. \n"]
@@ -1019,7 +1045,8 @@ module DeleteResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified resource.\n"]
@@ -1049,7 +1076,8 @@ module DeleteRetentionPolicy : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Deletes the specified retention policy from the specified organization.\n"]
@@ -1094,7 +1122,8 @@ module DeleteUser : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1135,7 +1164,8 @@ module DeregisterFromWorkMail : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1174,7 +1204,8 @@ module DeregisterMailDomain : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `MailDomainInUseException of mail_domain_in_use_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1210,7 +1241,8 @@ module DescribeEmailMonitoringConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes the current email monitoring configuration for a specified organization.\n"]
@@ -1243,7 +1275,8 @@ module DescribeEntity : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns basic details about an entity in WorkMail. \n"]
@@ -1276,7 +1309,8 @@ module DescribeGroup : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the data available for the group.\n"]
@@ -1309,7 +1343,8 @@ module DescribeIdentityProviderConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1337,7 +1372,8 @@ module DescribeInboundDmarcSettings : sig
     ( describe_inbound_dmarc_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the settings in a DMARC policy for a specified organization.\n"]
@@ -1370,7 +1406,8 @@ module DescribeMailboxExportJob : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Describes the current status of a mailbox export job.\n"]
@@ -1397,7 +1434,8 @@ module DescribeOrganization : sig
     ( describe_organization_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
-      | `OrganizationNotFoundException of organization_not_found_exception ] )
+      | `OrganizationNotFoundException of organization_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides more information regarding a given organization based on its identifier.\n"]
@@ -1433,7 +1471,8 @@ module DescribeResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns the data available for the resource.\n"]
@@ -1475,7 +1514,8 @@ module DescribeUser : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Provides information regarding the user.\n"]
@@ -1514,7 +1554,8 @@ module DisassociateDelegateFromResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a member from the resource's set of delegates.\n"]
@@ -1562,7 +1603,8 @@ module DisassociateMemberFromGroup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Removes a member from a group.\n"]
@@ -1598,7 +1640,8 @@ module GetAccessControlEffect : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1634,7 +1677,8 @@ module GetDefaultRetentionPolicy : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the default retention policy details for the specified organization.\n"]
@@ -1667,7 +1711,8 @@ module GetImpersonationRole : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Gets the impersonation role details for the given WorkMail organization.\n"]
@@ -1706,7 +1751,8 @@ module GetImpersonationRoleEffect : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Tests whether the given impersonation role can impersonate a target user.\n"]
@@ -1739,7 +1785,8 @@ module GetMailboxDetails : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Requests a user's mailbox details for a specified organization and user.\n"]
@@ -1772,7 +1819,8 @@ module GetMailDomain : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `MailDomainNotFoundException of mail_domain_not_found_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1804,7 +1852,8 @@ module GetMobileDeviceAccessEffect : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1843,7 +1892,8 @@ module GetMobileDeviceAccessOverride : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1877,7 +1927,8 @@ module GetPersonalAccessTokenMetadata : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -1905,7 +1956,8 @@ module ListAccessControlRules : sig
     ( list_access_control_rules_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the access control rules for the specified organization.\n"]
@@ -1941,7 +1993,8 @@ module ListAliases : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Creates a paginated call to list the aliases associated with a given entity.\n"]
@@ -1971,7 +2024,8 @@ module ListAvailabilityConfigurations : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "List all the [AvailabilityConfiguration]'s for the given WorkMail organization.\n"]
@@ -2007,7 +2061,8 @@ module ListGroupMembers : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2041,7 +2096,8 @@ module ListGroups : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns summaries of the organization's groups.\n"]
@@ -2077,7 +2133,8 @@ module ListGroupsForEntity : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns all the groups to which an entity belongs.\n"]
@@ -2107,7 +2164,8 @@ module ListImpersonationRoles : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists all the impersonation roles for the given WorkMail organization.\n"]
@@ -2137,7 +2195,8 @@ module ListMailboxExportJobs : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2171,7 +2230,8 @@ module ListMailboxPermissions : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the mailbox permissions associated with a user, group, or resource mailbox.\n"]
@@ -2201,7 +2261,8 @@ module ListMailDomains : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the mail domains in a given WorkMail organization.\n"]
@@ -2234,7 +2295,8 @@ module ListMobileDeviceAccessOverrides : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2266,7 +2328,8 @@ module ListMobileDeviceAccessRules : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the mobile device access rules for the specified WorkMail organization.\n"]
@@ -2289,7 +2352,8 @@ module ListOrganizations : sig
     list_organizations_request ->
     ( list_organizations_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `InvalidParameterException of invalid_parameter_exception ] )
+      | `InvalidParameterException of invalid_parameter_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns summaries of the customer's organizations.\n"]
@@ -2325,7 +2389,8 @@ module ListPersonalAccessTokens : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc " Returns a summary of your Personal Access Tokens. \n"]
@@ -2364,7 +2429,8 @@ module ListResourceDelegates : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2399,7 +2465,8 @@ module ListResources : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns summaries of the organization's resources.\n"]
@@ -2423,7 +2490,8 @@ module ListTagsForResource : sig
     list_tags_for_resource_request ->
     ( list_tags_for_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Lists the tags applied to an WorkMail organization resource.\n"]
@@ -2453,7 +2521,8 @@ module ListUsers : sig
       [> Smaws_Lib.Protocols.AwsJson.error
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Returns summaries of the organization's users.\n"]
@@ -2492,7 +2561,8 @@ module PutAccessControlRule : sig
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2529,7 +2599,8 @@ module PutEmailMonitoringConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2563,7 +2634,8 @@ module PutIdentityProviderConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2594,7 +2666,8 @@ module PutInboundDmarcSettings : sig
     ( put_inbound_dmarc_settings_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Enables or disables a DMARC policy for a given organization.\n"]
@@ -2630,7 +2703,8 @@ module PutMailboxPermissions : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2667,7 +2741,8 @@ module PutMobileDeviceAccessOverride : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2702,7 +2777,8 @@ module PutRetentionPolicy : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Puts a retention policy to the specified organization.\n"]
@@ -2738,7 +2814,8 @@ module RegisterMailDomain : sig
       | `LimitExceededException of limit_exceeded_exception
       | `MailDomainInUseException of mail_domain_in_use_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2801,7 +2878,8 @@ module RegisterToWorkMail : sig
       | `MailDomainStateException of mail_domain_state_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2861,7 +2939,8 @@ module ResetPassword : sig
       | `InvalidPasswordException of invalid_password_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Allows the administrator to reset the password for a user.\n"]
@@ -2897,7 +2976,8 @@ module StartMailboxExportJob : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -2935,7 +3015,8 @@ module TagResource : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationStateException of organization_state_exception
       | `ResourceNotFoundException of resource_not_found_exception
-      | `TooManyTagsException of too_many_tags_exception ] )
+      | `TooManyTagsException of too_many_tags_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Applies the specified tags to the specified WorkMailorganization resource.\n"]
@@ -2968,7 +3049,8 @@ module TestAvailabilityConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3002,7 +3084,8 @@ module UntagResource : sig
     untag_resource_request ->
     ( untag_resource_response Smaws_Lib.Response.t,
       [> Smaws_Lib.Protocols.AwsJson.error
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Untags the specified tags from the specified WorkMail organization resource.\n"]
@@ -3035,7 +3118,8 @@ module UpdateAvailabilityConfiguration : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3072,7 +3156,8 @@ module UpdateDefaultMailDomain : sig
       | `MailDomainNotFoundException of mail_domain_not_found_exception
       | `MailDomainStateException of mail_domain_state_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3114,7 +3199,8 @@ module UpdateGroup : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates attributes in a group.\n"]
@@ -3156,7 +3242,8 @@ module UpdateImpersonationRole : sig
       | `LimitExceededException of limit_exceeded_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `ResourceNotFoundException of resource_not_found_exception ] )
+      | `ResourceNotFoundException of resource_not_found_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates an impersonation role for the given WorkMail organization.\n"]
@@ -3192,7 +3279,8 @@ module UpdateMailboxQuota : sig
       | `EntityStateException of entity_state_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a user's current mailbox quota for a specified organization and user.\n"]
@@ -3225,7 +3313,8 @@ module UpdateMobileDeviceAccessRule : sig
       | `EntityNotFoundException of entity_not_found_exception
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
-      | `OrganizationStateException of organization_state_exception ] )
+      | `OrganizationStateException of organization_state_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc "Updates a mobile device access rule for the specified WorkMail organization.\n"]
@@ -3282,7 +3371,8 @@ module UpdatePrimaryEmailAddress : sig
       | `MailDomainStateException of mail_domain_state_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3342,7 +3432,8 @@ module UpdateResource : sig
       | `NameAvailabilityException of name_availability_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc
@@ -3393,7 +3484,8 @@ module UpdateUser : sig
       | `InvalidParameterException of invalid_parameter_exception
       | `OrganizationNotFoundException of organization_not_found_exception
       | `OrganizationStateException of organization_state_exception
-      | `UnsupportedOperationException of unsupported_operation_exception ] )
+      | `UnsupportedOperationException of unsupported_operation_exception ]
+      * Smaws_Lib.Response.metadata )
     result
 end
 [@@ocaml.doc

--- a/sdks_examples/dune
+++ b/sdks_examples/dune
@@ -28,3 +28,8 @@
  (name sts_GetCallerIdentity)
  (modules sts_GetCallerIdentity)
  (libraries smaws-lib eio_main logs fmt smaws-clients))
+
+(executable
+ (name sts_GetCallerIdentityError)
+ (modules sts_GetCallerIdentityError)
+ (libraries smaws-lib eio_main logs fmt smaws-clients))

--- a/sdks_examples/sts_GetCallerIdentity.ml
+++ b/sdks_examples/sts_GetCallerIdentity.ml
@@ -28,20 +28,24 @@ let _ =
           match
             begin
               let open Smaws_Clients.STS in
-              let+ result : Types.get_caller_identity_response =
-                GetCallerIdentity.request context (make_get_caller_identity_request ())
+              let+ { Response.response = result; metadata } =
+                GetCallerIdentity.request_with_metadata context
+                  (make_get_caller_identity_request ())
               in
               Logs.info (fun m ->
-                  m "SUCCESS:@.  UserId:  %s@.  Account: %s@.  Arn:     %s"
+                  m "SUCCESS:@.  RequestId: %s@.  UserId:  %s@.  Account: %s@.  Arn:     %s"
+                    (metadata.request_id |> Option.value ~default:"<>")
                     (result.user_id |> Option.value ~default:"<>")
                     (result.account |> Option.value ~default:"<>")
                     (result.arn |> Option.value ~default:"<>"))
             end
           with
           | Ok _ -> ()
-          | Error (`HttpError e) -> Logs.err (fun m -> m "HTTP Error %a" Http.pp_http_failure e)
-          | Error (`XmlParseError msg) -> Logs.err (fun m -> m "XML Parse Error: %s" msg)
-          | Error (`AWSServiceError { _type = { namespace; name }; message }) ->
+          | Error (`HttpError e, _) -> Logs.err (fun m -> m "HTTP Error %a" Http.pp_http_failure e)
+          | Error (`XmlParseError msg, _) -> Logs.err (fun m -> m "XML Parse Error: %s" msg)
+          | Error (`AWSServiceError { _type = { namespace; name }; message }, metadata) ->
               Logs.err (fun m ->
-                  m "AWS Service Error %s:%s - %s" namespace name (Option.value ~default:"" message))
+                  m "AWS Service Error %s:%s - %s (RequestId: %s)" namespace name
+                    (Option.value ~default:"" message)
+                    (Option.value ~default:"" metadata.request_id))
           | Error _ -> Logs.err (fun m -> m "Unknown error")))

--- a/sdks_examples/sts_GetCallerIdentityError.ml
+++ b/sdks_examples/sts_GetCallerIdentityError.ml
@@ -1,0 +1,47 @@
+Logs.set_reporter (Logs.format_reporter ());;
+Logs.set_level (Some Logs.Debug);;
+
+(** Live error-path validation: STS GetCallerIdentity with invalid credentials.
+
+    Run: `dune exec -- ./sts_GetCallerIdentityError.exe [region]`
+
+    Uses deliberately invalid dummy credentials so AWS returns a service error. The example prints
+    both the error details and the AWS request id from the response metadata carried on the error
+    tuple. *)
+
+let () =
+  let region =
+    if Array.length Sys.argv > 1 then Array.get Sys.argv 1
+    else Sys.getenv_opt "AWS_DEFAULT_REGION" |> Option.value ~default:"us-east-1"
+  in
+  Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+          let open Smaws_Lib in
+          let config =
+            Config.make
+              ~resolveRegion:(fun () -> region)
+              ~resolveAuth:(fun () -> Auth.Dummy.resolve ())
+              ()
+          in
+          let context = Context.make_with_eio_http ~sw ~config env in
+
+          match
+            Smaws_Clients.STS.GetCallerIdentity.request_with_metadata context
+              (Smaws_Clients.STS.make_get_caller_identity_request ())
+          with
+          | Ok { Response.response = result; metadata } ->
+              Logs.info (fun m ->
+                  m "Unexpected success:@.  RequestId: %s@.  Account: %s"
+                    (metadata.request_id |> Option.value ~default:"<>")
+                    (result.account |> Option.value ~default:"<>"))
+          | Error (`HttpError e, _) -> Logs.err (fun m -> m "HTTP Error %a" Http.pp_http_failure e)
+          | Error (`XmlParseError msg, _) -> Logs.err (fun m -> m "XML Parse Error: %s" msg)
+          | Error (`AWSServiceError { _type = { namespace; name }; message }, metadata) ->
+              Logs.err (fun m ->
+                  m "AWS Service Error %s:%s - %s (RequestId: %s)" namespace name
+                    (Option.value ~default:"" message)
+                    (Option.value ~default:"" metadata.Response.request_id))
+          | Error (_, metadata) ->
+              Logs.err (fun m ->
+                  m "Unknown error (RequestId: %s)"
+                    (Option.value ~default:"" metadata.Response.request_id))))

--- a/smaws_lib/Response.ml
+++ b/smaws_lib/Response.ml
@@ -1,0 +1,4 @@
+type metadata = { request_id : string option }
+type 'a t = { response : 'a; metadata : metadata }
+
+let map ~f { response; metadata } = { response = f response; metadata }

--- a/smaws_lib/Smaws_Lib.ml
+++ b/smaws_lib/Smaws_Lib.ml
@@ -9,6 +9,7 @@ module Json = Json
 module Xml = Xml
 module UInt64 = UInt64
 module Uuid = Uuid
+module Response = Response
 module Protocols = Protocols
 module Service = Service
 module Sign = Sign

--- a/smaws_lib/protocols_impl/AwsJson.ml
+++ b/smaws_lib/protocols_impl/AwsJson.ml
@@ -157,14 +157,15 @@ let request_with_metadata (type http_t) ~(shape_name : string) ~(service : Servi
       | x when x >= 200 && x < 300 ->
           (deserialize_res output_deserializer) body_res
           |> Result.map (fun result -> { Response.response = result; metadata = { request_id } })
-          |> Result.map_error (fun e -> `JsonParseError e)
+          |> Result.map_error (fun e -> (`JsonParseError e, { Response.request_id }))
       | _ -> (
           let error_body = ensure_error_type ~headers:response_headers body_res in
+          let metadata = { Response.request_id } in
           match (deserialize_res error_deserializer) error_body with
-          | Ok error -> Error error
-          | Error error -> Error (`JsonParseError error))
+          | Ok error -> Error (error, metadata)
+          | Error error -> Error (`JsonParseError error, metadata))
     end
-  | Error error -> Error (`HttpError error)
+  | Error error -> Error (`HttpError error, { Response.request_id = None })
 
 let request (type http_t) ~(shape_name : string) ~(service : Service.descriptor)
     ~(context : http_t Context.t) ~(input : json_type)
@@ -173,6 +174,7 @@ let request (type http_t) ~(shape_name : string) ~(service : Service.descriptor)
   request_with_metadata ~shape_name ~service ~context ~input ~output_deserializer
     ~error_deserializer
   |> Result.map (fun { Response.response; _ } -> response)
+  |> Result.map_error (fun (error, _) -> error)
 
 let error_deserializer handler tree path =
   let _obj = Json.DeserializeHelpers.assoc_of_yojson tree path in

--- a/smaws_lib/protocols_impl/AwsJson.ml
+++ b/smaws_lib/protocols_impl/AwsJson.ml
@@ -107,7 +107,7 @@ let error_to_string = function
 
 let pp_error fmt e = Fmt.pf fmt "%s" (error_to_string e)
 
-let request (type http_t) ~(shape_name : string) ~(service : Service.descriptor)
+let request_with_metadata (type http_t) ~(shape_name : string) ~(service : Service.descriptor)
     ~(context : http_t Context.t) ~(input : json_type)
     ~(output_deserializer : json_type -> string list -> 'res)
     ~(error_deserializer : json_type -> string list -> 'error) =
@@ -131,6 +131,17 @@ let request (type http_t) ~(shape_name : string) ~(service : Service.descriptor)
   let http = Context.http context in
   match Http.request ~method_:`POST ~headers ~body:(`String body) ~uri http with
   | Ok (response, body) -> begin
+      let response_headers = Http.Response.headers response in
+      let request_id =
+        let find ~f headers =
+          List.find_map
+            (fun (k, v) -> if f (String.lowercase_ascii k) then Some v else None)
+            headers
+        in
+        match find ~f:(String.equal "x-amzn-requestid") response_headers with
+        | Some _ as v -> v
+        | None -> find ~f:(String.equal "x-amz-request-id") response_headers
+      in
       let body = body |> Http.Body.to_string in
 
       let body_res =
@@ -145,14 +156,23 @@ let request (type http_t) ~(shape_name : string) ~(service : Service.descriptor)
       match response |> Http.Response.status with
       | x when x >= 200 && x < 300 ->
           (deserialize_res output_deserializer) body_res
+          |> Result.map (fun result -> { Response.response = result; metadata = { request_id } })
           |> Result.map_error (fun e -> `JsonParseError e)
       | _ -> (
-          let error_body = ensure_error_type ~headers:(Http.Response.headers response) body_res in
+          let error_body = ensure_error_type ~headers:response_headers body_res in
           match (deserialize_res error_deserializer) error_body with
           | Ok error -> Error error
           | Error error -> Error (`JsonParseError error))
     end
   | Error error -> Error (`HttpError error)
+
+let request (type http_t) ~(shape_name : string) ~(service : Service.descriptor)
+    ~(context : http_t Context.t) ~(input : json_type)
+    ~(output_deserializer : json_type -> string list -> 'res)
+    ~(error_deserializer : json_type -> string list -> 'error) =
+  request_with_metadata ~shape_name ~service ~context ~input ~output_deserializer
+    ~error_deserializer
+  |> Result.map (fun { Response.response; _ } -> response)
 
 let error_deserializer handler tree path =
   let _obj = Json.DeserializeHelpers.assoc_of_yojson tree path in

--- a/smaws_lib/protocols_impl/AwsQuery.ml
+++ b/smaws_lib/protocols_impl/AwsQuery.ml
@@ -246,7 +246,8 @@ module Response = struct
             (result, request_id))
           ())
 
-  let parse_xml_error_response ~(body : string) : (Error.t, Xml.Parse.error) result =
+  let parse_xml_error_response ~(body : string) : (Error.t * string option, Xml.Parse.error) result
+      =
     let open Xml.Parse in
     run (fun () ->
         let xmlSource = source_with_encoding ~src:body ~encoding:None in
@@ -277,9 +278,15 @@ module Response = struct
                   Error.{ errorType; code; message = !r_message })
                 ()
             in
-            (* Skip trailing siblings (e.g. <RequestId>) before </ErrorResponse>. *)
+            (* Read trailing siblings (e.g. <RequestId>) before </ErrorResponse>. *)
+            let request_id =
+              match Xmlm.peek xmlSource with
+              | `El_start el when tag_equal "RequestId" None el ->
+                  Some (Read.element xmlSource "RequestId" ())
+              | _ -> None
+            in
             Read.skip_to_end xmlSource;
-            error)
+            (error, request_id))
           ())
 
   (* Re-parse an awsQuery error response body and run [structParser] positioned
@@ -327,13 +334,17 @@ let request_with_metadata (type http_t) ~(action : string) ~(xmlNamespace : stri
             ~resultParser:output_deserializer
           |> Result.map (fun (result, request_id) ->
               { Response_record.response = result; metadata = { request_id } })
-          |> Result.map_error (fun (Xml.Parse.XmlParseError msg) -> `XmlParseError msg)
+          |> Result.map_error (fun (Xml.Parse.XmlParseError msg) ->
+              (`XmlParseError msg, { Response_record.request_id = None }))
       | _ -> (
           match Response.parse_xml_error_response ~body with
-          | Ok error -> Error (error_deserializer error ~body)
-          | Error (Xml.Parse.XmlParseError msg) -> Error (`XmlParseError msg))
+          | Ok (error, request_id) ->
+              let metadata = { Response_record.request_id } in
+              Error (error_deserializer error ~body, metadata)
+          | Error (Xml.Parse.XmlParseError msg) ->
+              Error (`XmlParseError msg, { Response_record.request_id = None }))
     end
-  | Error http_failure -> Error (`HttpError http_failure)
+  | Error http_failure -> Error (`HttpError http_failure, { Response_record.request_id = None })
 
 let request (type http_t) ~(action : string) ~(xmlNamespace : string)
     ~(service : Service.descriptor) ~(context : http_t Context.t)
@@ -342,3 +353,4 @@ let request (type http_t) ~(action : string) ~(xmlNamespace : string)
   request_with_metadata ~action ~xmlNamespace ~service ~context ~fields ~output_deserializer
     ~error_deserializer
   |> Result.map (fun { Response_record.response; _ } -> response)
+  |> Result.map_error (fun (error, _) -> error)

--- a/smaws_lib/protocols_impl/AwsQuery.ml
+++ b/smaws_lib/protocols_impl/AwsQuery.ml
@@ -194,6 +194,8 @@ module Errors = struct
       AwsErrors.{ message = error.message; _type = { namespace = ""; name = error.code } }
 end
 
+module Response_record = Response
+
 module Response = struct
   let parse_xml_ok_response ~(action : string) ~(xmlNamespace : string) ~(body : string)
       ~resultParser =
@@ -220,8 +222,28 @@ module Response = struct
                   Read.sequence xmlSource (action ^ "Result") (fun i _ -> resultParser i) ()
               | _ -> resultParser xmlSource
             in
-            Read.skip_to_end xmlSource;
-            result)
+            let request_id =
+              match Xmlm.peek xmlSource with
+              | `El_start el when tag_equal "ResponseMetadata" (Some xmlNamespace) el ->
+                  let request_id =
+                    Read.sequence xmlSource "ResponseMetadata"
+                      (fun i _ ->
+                        match Xmlm.peek i with
+                        | `El_start el when tag_equal "RequestId" (Some xmlNamespace) el ->
+                            Some (Read.element i "RequestId" ())
+                        | _ ->
+                            (* skip any other metadata children *)
+                            Read.skip_to_end i;
+                            None)
+                      ()
+                  in
+                  Read.skip_to_end xmlSource;
+                  request_id
+              | _ ->
+                  Read.skip_to_end xmlSource;
+                  None
+            in
+            (result, request_id))
           ())
 
   let parse_xml_error_response ~(body : string) : (Error.t, Xml.Parse.error) result =
@@ -281,7 +303,7 @@ end
 
 let error_deserializer handler (error : Error.t) ~body:_ = handler error
 
-let request (type http_t) ~(action : string) ~(xmlNamespace : string)
+let request_with_metadata (type http_t) ~(action : string) ~(xmlNamespace : string)
     ~(service : Service.descriptor) ~(context : http_t Context.t)
     ~(fields : (string * string list) list) ~(output_deserializer : Xmlm.input -> 'out)
     ~(error_deserializer : Error.t -> body:string -> 'err) =
@@ -303,6 +325,8 @@ let request (type http_t) ~(action : string) ~(xmlNamespace : string)
       | x when x >= 200 && x < 300 ->
           Response.parse_xml_ok_response ~action ~xmlNamespace ~body
             ~resultParser:output_deserializer
+          |> Result.map (fun (result, request_id) ->
+              { Response_record.response = result; metadata = { request_id } })
           |> Result.map_error (fun (Xml.Parse.XmlParseError msg) -> `XmlParseError msg)
       | _ -> (
           match Response.parse_xml_error_response ~body with
@@ -310,3 +334,11 @@ let request (type http_t) ~(action : string) ~(xmlNamespace : string)
           | Error (Xml.Parse.XmlParseError msg) -> Error (`XmlParseError msg))
     end
   | Error http_failure -> Error (`HttpError http_failure)
+
+let request (type http_t) ~(action : string) ~(xmlNamespace : string)
+    ~(service : Service.descriptor) ~(context : http_t Context.t)
+    ~(fields : (string * string list) list) ~(output_deserializer : Xmlm.input -> 'out)
+    ~(error_deserializer : Error.t -> body:string -> 'err) =
+  request_with_metadata ~action ~xmlNamespace ~service ~context ~fields ~output_deserializer
+    ~error_deserializer
+  |> Result.map (fun { Response_record.response; _ } -> response)

--- a/smaws_lib_test/aws_json_error_metadata_test.ml
+++ b/smaws_lib_test/aws_json_error_metadata_test.ml
@@ -1,0 +1,36 @@
+(** Regression test: AWS JSON error responses carry the request id from [x-amzn-requestid] (or
+    [x-amz-request-id]) in the error tuple metadata. *)
+
+let config : Smaws_Lib.Config.t =
+  {
+    resolveAuth =
+      (fun () -> { access_key_id = "hello"; secret_access_key = "world"; session_token = None });
+    resolveRegion = (fun () -> "us-east-1");
+    endpoint = None;
+  }
+
+let run env =
+  let open Smaws_Lib in
+  let open Model_tests_protocols.Json in
+  Eio.Switch.run ~name:"smaws-json-error-metadata-test" @@ fun sw ->
+  let module Mock = (val Smaws_Test_Support_Lib.Http_mock.create_http_mock ()) in
+  let http_type = (module Mock : Http.Client with type t = Mock.t) in
+  let ctx = Context.make ~config ~http_type () in
+  Mock.mock_response ~status:400
+    ~headers:[ ("x-amzn-requestid", "req-json-1") ]
+    ~body:({|{"__type": "com.amazonaws.jsonprotocol#InvalidGreeting", "message": "boom"}|} : string)
+    ();
+  match GreetingWithErrors.request_with_metadata ctx () with
+  | Ok _ -> Alcotest.fail "expected an error response"
+  | Error (error, metadata) -> (
+      Alcotest.(check (option string))
+        "request_id from x-amzn-requestid header" (Some "req-json-1") metadata.Response.request_id;
+      (* The exact variant depends on the generated error model; just ensure
+         it is an AWS service error so the test remains focused on metadata. *)
+      match error with
+      | `AWSServiceError { _type = { name = "InvalidGreeting"; _ }; message } ->
+          Alcotest.(check (option string)) "error message" (Some "boom") message
+      | `InvalidGreeting _ -> Alcotest.(check bool) "specific error variant present" true true
+      | _ -> Alcotest.fail "unexpected error variant")
+
+let () = Eio_main.run run

--- a/smaws_lib_test/aws_query_response_test.ml
+++ b/smaws_lib_test/aws_query_response_test.ml
@@ -66,14 +66,15 @@ let error_response_recovers_message_and_skips_request_id () =
   (* Without the scanSequence + skip_to_end fix this raises Unparseable
      (on the <Message> after <Code>, and/or the trailing <RequestId>), and
      message was always None. *)
-  let error =
+  let error, request_id =
     Result.get_ok
       (AwsQuery.Response.parse_xml_error_response ~body:error_body_with_message_and_request_id)
   in
   let module E = AwsQuery.Error in
   Alcotest.(check bool) "errorType is Sender" true (error.E.errorType = E.Sender);
   Alcotest.(check string) "code" "SomeError" error.E.code;
-  Alcotest.(check (option string)) "message recovered" (Some "boom") error.E.message
+  Alcotest.(check (option string)) "message recovered" (Some "boom") error.E.message;
+  Alcotest.(check (option string)) "request_id recovered" (Some "req-2") request_id
 
 let parse_error_struct_recovers_members_and_skips_metadata () =
   (* A generated error-shape _of_xml uses Structure.scanSequence over <Error>'s

--- a/smaws_lib_test/aws_query_response_test.ml
+++ b/smaws_lib_test/aws_query_response_test.ml
@@ -52,12 +52,15 @@ module Xml = Smaws_Lib.Xml
 let ok_response_skips_response_metadata () =
   (* Without the skip_to_end fix this raises XmlUnexpectedConstruct on the
      <ResponseMetadata> sibling. *)
-  let result =
+  let result, request_id =
     AwsQuery.Response.parse_xml_ok_response ~action:"GetX" ~xmlNamespace:"https://example.com/"
       ~body:ok_body_with_response_metadata ~resultParser:(fun i ->
         Xml.Parse.Read.element i "Foo" ())
+    |> Result.get_ok
   in
-  Alcotest.(check string) "result parsed from <Result>" "bar" (Result.get_ok result)
+  Alcotest.(check string) "result parsed from <Result>" "bar" result;
+  Alcotest.(check (option string))
+    "request_id parsed from <ResponseMetadata>" (Some "req-1") request_id
 
 let error_response_recovers_message_and_skips_request_id () =
   (* Without the scanSequence + skip_to_end fix this raises Unparseable

--- a/smaws_lib_test/dune
+++ b/smaws_lib_test/dune
@@ -1,5 +1,18 @@
 (test
+ (name aws_json_error_metadata_test)
+ (modules aws_json_error_metadata_test)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq))
+ (libraries
+  model_tests_protocols
+  Smaws_Lib
+  eio_main
+  alcotest
+  Smaws_Test_Support_Lib))
+
+(test
  (name request_test_example)
+ (modules request_test_example)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq))
  (libraries
@@ -11,12 +24,15 @@
 
 (test
  (name aws_query_response_test)
+ (modules aws_query_response_test)
  (libraries Smaws_Lib alcotest))
 
 (test
  (name aws_query_serialize_test)
+ (modules aws_query_serialize_test)
  (libraries Smaws_Lib alcotest))
 
 (test
  (name uint64_test)
+ (modules uint64_test)
  (libraries Smaws_Lib alcotest))


### PR DESCRIPTION
Exposes AWS request IDs returned in responses by adding a `Smaws_Lib.Response` metadata wrapper and generating `request_with_metadata` operation bindings alongside the existing `request` ones.

Changes:
- Add `Smaws_Lib.Response` module (`response` + `request_id` metadata)
- Track `x-amzn-requestid` / `x-amz-request-id` headers in AwsJson
- Extract `<ResponseMetadata>/<RequestId>` in AwsQuery response parsing
- Generate both `request` and `request_with_metadata` for JSON and Query protocol operations
- Regenerate all affected SDKs and protocol conformance tests

Runtime + codegen build and tests pass.
